### PR TITLE
template_injection: handle actions/github-script

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -192,7 +192,7 @@ impl<'a> WorkflowAudit<'a> for TemplateInjection<'a> {
                 };
 
                 for (expr, severity, confidence) in
-                    self.injectable_template_expressions(&script, normal)
+                    self.injectable_template_expressions(script, normal)
                 {
                     findings.push(
                         Self::finding()


### PR DESCRIPTION
There are infinitely many other actions that can have template expansion result in code injection, but this is a very common one.