### PR TITLE
chore: set minimum working rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 repository = "https://github.com/woodruffw/zizmor"
 homepage = "https://github.com/woodruffw/zizmor"
 authors = ["William Woodruff <william@yossarian.net>"]
+rust-version = "1.80.1"
 
 [dependencies]
 annotate-snippets = "0.11.4"


### PR DESCRIPTION
Prevent older rust toolchains from compile-time errors on clean checkout.

Oldest version found with `cargo msrv find`

Refs: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field