### PR TITLE
feat: Step::location_with_name

### DIFF
--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -104,7 +104,9 @@ impl WorkflowAudit for RefConfusion {
                                     .severity(Severity::Medium)
                                     .confidence(Confidence::High)
                                     .add_location(
-                                        step.location().annotated(REF_CONFUSION_ANNOTATION),
+                                        step.location()
+                                            .with_keys(&["uses".into()])
+                                            .annotated(REF_CONFUSION_ANNOTATION),
                                     )
                                     .build(workflow)?,
                             );

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -217,7 +217,7 @@ impl WorkflowAudit for TemplateInjection {
                         Self::finding()
                             .severity(severity)
                             .confidence(confidence)
-                            .add_location(step.location().annotated("this step"))
+                            .add_location(step.location_with_name())
                             .add_location(script_loc.clone().annotated(format!(
                                 "{expr} may expand into attacker-controllable code"
                             )))

--- a/src/models.rs
+++ b/src/models.rs
@@ -145,8 +145,19 @@ impl<'w> Step<'w> {
         }
     }
 
+    /// Returns a symbolic location for this [`Step`].
     pub(crate) fn location(&self) -> SymbolicLocation<'w> {
         self.parent.with_step(self)
+    }
+
+    /// Like [`Step::location`], except with the step's `name`
+    /// key as the final path component if present.
+    pub(crate) fn location_with_name(&self) -> SymbolicLocation<'w> {
+        match self.inner.name {
+            Some(_) => self.location().with_keys(&["name".into()]),
+            None => self.location(),
+        }
+        .annotated("this step")
     }
 }
 


### PR DESCRIPTION
Results in slightly nicer step span renders,
where possible. This could be used in a few other
places, but hasn't been yet.

Previous:

![1730045384](https://github.com/user-attachments/assets/c46a978c-355c-410b-b7f9-1ef02fdf7e6a)

New:

![1730045407](https://github.com/user-attachments/assets/6207ca0c-fa1b-47f2-b744-15c2e4dcbbb8)
