### PR TITLE
docs: alpha sort audit doc contents by audit name

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -73,6 +73,133 @@ with `#!yaml persist-credentials: true`.
               persist-credentials: false
     ```
 
+
+## `bot-conditions`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow  | [bot-conditions.yml]   | v1.2.0      | ✅             | ✅                 | ❌  |
+
+[bot-conditions.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/bot-conditions.yml
+
+Detects potentially spoofable bot conditions.
+
+Many workflows allow trustworthy bots (such as [Dependabot](https://github.com/dependabot))
+to bypass checks or otherwise perform privileged actions. This is often done
+with a `github.actor` check, e.g.:
+
+```yaml
+if: github.actor == 'dependabot[bot]'
+```
+
+However, this condition is spoofable: `github.actor` refers to the *last* actor
+to perform an "action" on the triggering context, and not necessarily
+the actor actually causing the trigger. An attacker can take
+advantage of this discrepancy to create a PR where the `HEAD` commit
+has `github.actor == 'dependabot[bot]'` but the rest of the branch history
+contains attacker-controlled code, bypassing the actor check.
+
+Other resources:
+
+* [GitHub Actions exploitations: Dependabot]
+
+### Remediation
+
+In general, checking a trigger's authenticity via `github.actor` is
+insufficient. Instead, most users should use `github.event.pull_request.user.login`
+or similar, since that context refers to the actor that *created* the Pull Request
+rather than the last one to modify it.
+
+More generally,
+[GitHub's documentation recommends](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
+not using `pull_request_target` for auto-merge workflows.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="bot-conditions.yml" hl_lines="1 6"
+        on: pull_request_target
+
+        jobs:
+          automerge:
+            runs-on: ubuntu-latest
+            if: github.actor == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
+            steps:
+              - run: gh pr merge --auto --merge "$PR_URL"
+                env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="bot-conditions.yml" hl_lines="1 6"
+        on: pull_request
+
+        jobs:
+          automerge:
+            runs-on: ubuntu-latest
+            if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
+            steps:
+              - run: gh pr merge --auto --merge "$PR_URL"
+                env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ```
+
+
+## `cache-poisoning`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow  | [cache-poisoning.yml]   | v0.10.0       | ✅             | ✅               | ❌  |
+
+[cache-poisoning.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/cache-poisoning.yml
+
+Detects potential cache-poisoning scenarios in release workflows.
+
+Caching and restoring build state is a process eased by utilities provided
+by GitHub, in particular @actions/cache and its "save" and "restore"
+sub-actions. In addition, many of the setup-like actions provided
+by GitHub come with built-in caching functionality, like @actions/setup-node,
+@actions/setup-java and others.
+
+Furthermore, there are many examples of community-driven Actions with built-in
+caching functionality, like @ruby/setup-ruby, @astral-sh/setup-uv,
+@Swatinem/rust-cache. In general, most of them build on top of @actions/toolkit
+for the sake of easily integrate with GitHub cache server at Workflow runtime.
+
+This vulnerability happens when release workflows leverage build state cached
+from previous workflow executions, in general on top of the aforementioned
+actions or  similar ones. The publication of artifacts usually happens driven
+by trigger events like `release` or events with path filters like `push`
+(e.g. for tags).
+
+In such scenarios, an attacker with access to a valid `GITHUB_TOKEN` can use it
+to poison the repository's GitHub Actions caches. That compounds with the
+default behavior of @actions/toolkit during cache restorations, allowing an
+attacker to retrieve payloads from poisoned cache entries, hence achieving code
+execution at Workflow runtime, potentially compromising ready-to-publish
+artifacts.
+
+Other resources:
+
+* [The Monsters in Your Build Cache – GitHub Actions Cache Poisoning]
+* [Cacheract: The Monster in your Build Cache]
+
+### Remediation
+
+In general, you should avoid using previously cached CI state within workflows
+intended to publish build artifacts:
+
+* Remove cache-aware actions like @actions/cache from workflows that produce
+  releases, *or*
+* Disable cache-aware actions with an `#!yaml if:` condition based on the trigger at
+  the step level, *or*
+* Set an action-specific input to disable cache restoration when appropriate,
+  such as `lookup-only` in @Swatinem/rust-cache.
+
 ## `dangerous-triggers`
 
 | Type     | Examples                  | Introduced in | Works offline  | Enabled by default | Configurable |
@@ -256,6 +383,131 @@ by default, and then set specific job-level permissions as needed.
                 uses: pypa/gh-action-pypi-publish@release/v1
         ```
 
+## `forbidden-uses`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow, Action  | N/A            | v1.6.0        | ✅             | ❌                |  ✅ |
+
+An *opt-in* audit for denylisting/allowlisting specific `#!yaml uses:` clauses.
+This is not enabled by default; you must
+[configure it](#forbidden-uses-configuration) to use it.
+
+!!! warning
+
+    This audit comes with several limitations that are important to understand:
+
+    * This audit is *opt-in*. You must configure it to use it; it
+      **does nothing** by default.
+    * This audit (currently) operates on *repository* `#!yaml uses:` clauses,
+      e.g. `#!yaml uses: actions/checkout@v4`. It does not operate on Docker
+      `#!yaml uses:` clauses, e.g. `#!yaml uses: docker://ubuntu:24.04`. This limitation
+      may be lifted in the future.
+    * This audit operates on `#!yaml uses:` clauses *as they appear* in the workflow
+      and action files. In other words, in *cannot* detect
+      [impostor commits](#impostor-commit) or indirect usage of actions
+      via manual `git clone` and local path usage.
+    * This audit's configuration operates on patterns, just like
+      [unpinned-uses](#unpinned-uses). That means that you can't (yet)
+      define *exact* matches. For example, you can't forbid `actions/checkout@v4`,
+      you have to forbid `actions/checkout`, which forbids all versions.
+
+### Configuration { #forbidden-uses-configuration }
+
+#### `rules.forbidden-uses.config.<allow|deny>`
+
+_Type_: `list`
+
+The `forbidden-uses` audit operates on either an allowlist or denylist
+basis:
+
+* In allowlist mode, only the listed `#!yaml uses:` patterns are allowed. All
+  non-matching `#!yaml uses:` clauses result in a finding.
+
+    Intended use case: only allowing "known good" actions to be used,
+    and forbidding everything else.
+
+* In denylist mode, only the listed `#!yaml uses:` patterns are disallowed. All
+  matching `#!yaml uses:` clauses result in a finding.
+
+    Intended use case: permitting all `#!yaml uses:` by default, but explicitly
+    forbidding "known bad" actions.
+
+Regardless of the mode used, the patterns allowed are the same as those
+in [unpinned-uses](#unpinned-uses-configuration).
+
+!!! example
+
+    The following configuration would allow only actions owned by
+    the @actions organization, plus any actions defined in @github/codeql-action:
+
+    ```yaml title="zizmor.yml"
+    rules:
+      forbidden-uses:
+        config:
+          allow:
+            - actions/*
+            - github/codeql-action/*
+    ```
+
+!!! example
+
+    The following would allow all actions except for those in the
+    @actions organization or defined in @github/codeql-action:
+
+    ```yaml title="zizmor.yml"
+    rules:
+      forbidden-uses:
+        config:
+          deny:
+            - actions/*
+            - github/codeql-action/*
+    ```
+
+### Remediation
+
+Either remove the offending `#!yaml uses:` clause or, if intended, add it to
+your [configuration](#forbidden-uses-configuration).
+
+## `github-env`
+
+| Type     | Examples           | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|--------------------|---------------|----------------|--------------------| --------------|
+| Workflow, Action  | [github-env.yml]   | v0.6.0        | ✅             | ✅       | ❌  |
+
+[github-env.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/github-env.yml
+
+Detects dangerous writes to the `GITHUB_ENV` and `GITHUB_PATH` environment variables.
+
+When used in workflows with dangerous triggers (such as `pull_request_target` and `workflow_run`),
+`GITHUB_ENV` and `GITHUB_PATH` can be an arbitrary code execution risk:
+
+* If the attacker is able to set arbitrary variables or variable contents via
+  `GITHUB_ENV`, they may be able to set `LD_PRELOAD` or otherwise induce code
+  execution implicitly within subsequent steps.
+* If the attacker is able to add an arbitrary directory to the `$PATH` via
+  `GITHUB_PATH`, they may be able to execute arbitrary code by shadowing
+  ordinary system executables (such as `ssh`).
+
+Other resources:
+
+* [GitHub Actions exploitation: environment manipulation]
+* [GHSL-2024-177: Environment Variable injection in an Actions workflow of Litestar]
+* [Google & Apache Found Vulnerable to GitHub Environment Injection]
+* [Hacking with Environment Variables]
+
+### Remediation
+
+In general, you should avoid modifying `GITHUB_ENV` and `GITHUB_PATH` within
+sensitive workflows that are attacker-triggered, like `pull_request_target`.
+
+If you absolutely must use `GITHUB_ENV` or `GITHUB_PATH`, avoid passing
+attacker-controlled values into either. Stick with literal strings and
+values computed solely from trusted sources.
+
+If you need to pass state between steps, consider using `GITHUB_OUTPUT` instead.
+
+
 ## `hardcoded-container-credentials`
 
 | Type     | Examples                    | Introduced in | Works offline  | Enabled by default | Configurable |
@@ -366,6 +618,54 @@ the commit actually exists within it.
 The only remediation, once discovered, is to replace the impostor commit
 within an authentic commit (or an authentic tag/branch reference).
 
+## `insecure-commands`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow, Action  | [insecure-commands.yml] | v0.5.0        | ✅             | ✅       | ❌  |
+
+[insecure-commands.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/insecure-commands.yml
+
+Detects opt-in for executing insecure workflow commands.
+
+Workflow commands (like `::set-env` and `::add-path`)
+[were deprecated by GitHub] in 2020 due to their inherent weaknesses
+(e.g., allowing any command with the ability to emit to `stdout`
+to inject environment variables and therefore obtain code execution).
+
+However, users can explicitly re-enable them by setting the
+`ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable at the workflow,
+job, or step level.
+
+Other resources:
+
+* [Semgrep audit]
+
+### Remediation
+
+In general, users should use for [GitHub Actions environment files]
+(like `GITHUB_PATH` and `GITHUB_OUTPUT`) instead of using workflow commands.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="insecure-commands" hl_lines="3"
+        - name: Setup my-bin
+          run: |
+            echo "::add-path::$HOME/.local/my-bin"
+          env:
+            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="insecure-commands" hl_lines="3"
+        - name: Setup my-bin
+          run: |
+            echo "$HOME/.local/my-bin" >> "$GITHUB_PATH"
+        ```
+
 ## `known-vulnerable-actions`
 
 | Type             | Examples                       | Introduced in | Works offline  | Enabled by default | Configurable |
@@ -389,6 +689,123 @@ injection via [template injection].
 
 If the vulnerability is applicable to your use: upgrade to a fixed version of
 the action if one is available, or remove the action's usage entirely.
+
+## `obfuscation`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow, Action  | N/A   | v1.7.0        | ✅             | ✅                 | ❌  |
+
+Checks for obfuscated usages of GitHub Actions features.
+
+This audit primarily serves to "unstick" other audits, which may fail to detect
+functioning but obfuscated usages of GitHub Actions features.
+
+This audit detects a variety of obfuscated usages, including:
+
+* Obfuscated paths within `#!yaml uses:` clauses, including redundant `/`
+  separators and uses of `.` or `..` in path segments.
+* Obfuscated GitHub expressions, including no-op patterns like
+  `fromJSON(toJSON(...))` and calls to `format(...)` where all
+  arguments are literal values.
+
+### Remediation
+
+Address the source of obfuscation by simplifying the expression,
+`#!yaml uses:` clause, or other obfuscated feature.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="obfuscation.yml" hl_lines="8"
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout
+                uses: actions/checkout@v4
+                with:
+                  repository: ${{ format('{0}/{1}', 'octocat', 'hello-world') }}
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="obfuscation.yml" hl_lines="8"
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout
+                uses: actions/checkout@v4
+                with:
+                  repository: octocat/hello-world
+        ```
+
+
+## `overprovisioned-secrets`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow, Action  | [overprovisioned-secrets.yml]   | v1.3.0      | ✅     | ✅         | ❌  |
+
+[overprovisioned-secrets.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/overprovisioned-secrets.yml
+
+Detects excessive sharing of the `secrets` context.
+
+Typically, users access the `secrets` context via its individual members:
+
+```yaml
+env:
+  SECRET_ONE: ${{ secrets.SECRET_ONE }}
+  SECRET_TWO: ${{ secrets.SECRET_TWO }}
+```
+
+This allows the Actions runner to only expose the secrets actually used by
+the workflow to the job environment.
+
+However, if the user instead accesses the *entire* `secrets` context:
+
+```yaml
+env:
+  SECRETS: ${{ toJson(secrets) }}
+```
+
+...then the entire `secrets` context is exposed to the runner, even if
+only a single secret is actually needed.
+
+### Remediation
+
+In general, users should avoid loading the entire `secrets` context.
+Secrets should be accessed individually by name.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="overprovisioned.yml" hl_lines="7"
+        jobs:
+          deploy:
+            runs-on: ubuntu-latest
+            steps:
+              - run: ./deploy.sh
+                env:
+                  SECRETS: ${{ toJSON(secrets) }}
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="overprovisioned.yml" hl_lines="7-8"
+        jobs:
+          deploy:
+            runs-on: ubuntu-latest
+            steps:
+              - run: ./deploy.sh
+                env:
+                  SECRET_ONE: ${{ secrets.SECRET_ONE }}
+                  SECRET_TWO: ${{ secrets.SECRET_TWO }}
+        ```
+
 
 ## `ref-confusion`
 
@@ -415,6 +832,52 @@ pre-existing consumers of that action without having to modify those consumers.
 ### Remediation
 
 Switch to hash-pinned actions.
+
+## `secrets-inherit`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow  | [secrets-inherit.yml]   | v1.1.0      | ✅             | ✅                 | ❌  |
+
+[secrets-inherit.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/secrets-inherit.yml
+
+Detects excessive secret inheritance between calling workflows and reusable
+(called) workflows.
+
+[Reusable workflows] can be given secrets by their calling workflow either
+explicitly, or in a blanket fashion with `#!yaml secrets: inherit`. The latter
+should almost never be used, as it makes it violates the
+[Principle of Least Authority] and makes it impossible to determine which exact
+secrets a reusable workflow was executed with.
+
+### Remediation
+
+In general, `#!yaml secrets: inherit` should be replaced with a `#!yaml secrets:` block
+that explicitly forwards each secret actually needed by the reusable workflow.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="reusable.yml" hl_lines="4"
+        jobs:
+          pass-secrets-to-workflow:
+            uses: ./.github/workflows/called-workflow.yml
+            secrets: inherit
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="reusable.yml" hl_lines="4-6"
+        jobs:
+          pass-secrets-to-workflow:
+            uses: ./.github/workflows/called-workflow.yml
+            secrets:
+              forward-me: ${{ secrets.forward-me }}
+              me-too: ${{ secrets.me-too }}
+        ```
+
+
 
 ## `self-hosted-runner`
 
@@ -462,6 +925,38 @@ there are steps you can take to minimize their risk:
 [GitHub's docs]: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks
 
 [ephemeral ("just-in-time") runners]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-just-in-time-runners
+
+## `stale-action-refs`
+
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------|--------------|
+| Workflow, Action  | N/A            | v1.7.0        | ❌            | ✅                | ❌          |
+
+Checks for `#!yaml uses:` clauses which pin an action using a SHA reference,
+but where that reference does not point to a Git tag.
+
+When using an action commit which is not a Git tag / release version, that commit
+might contain bugs or vulnerabilities which have not been publicly documented
+because they might have been fixed before the subsequent release. Additionally,
+because changelogs are usually only published for releases, it is difficult to
+tell which changes of the subsequent release the pinned commit includes.
+
+!!! note
+
+    This is a `--pedantic` only audit because the detected situation is not
+    a vulnerability per se. But it might be worth investigating which commit
+    the SHA reference points to, and why not a SHA reference pointing to a
+    Git tag is used.
+
+    Some action repositories use a "rolling release branch" strategy where
+    all commits on a certain branch are considered releases. In such a case
+    findings of this audit can likely be ignored.
+
+### Remediation
+
+Change the `#!yaml uses:` clause to pin the action using a SHA reference
+which points to a Git tag.
+
 
 ## `template-injection`
 
@@ -543,44 +1038,95 @@ shell quoting/expansion rules.
             ISSUE_TITLE: ${{ github.event.issue.title }}
         ```
 
-## `use-trusted-publishing`
+## `unpinned-images`
 
-| Type     | Examples                     | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|------------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow  | [pypi-manual-credential.yml] | v0.1.0        | ✅             | ✅                 | ❌  |
+| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------|--------------|
+| Workflow, Action  | [unpinned-images.yml] | v1.7.0        | ✅            | ✅                | ❌          |
 
-[pypi-manual-credential.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/pypi-manual-credential.yml
+[unpinned-images.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/unpinned-images.yml
 
-Detects packaging workflows that could use [Trusted Publishing].
+Checks for `container.image` values where the image is not pinned by either a tag (other than `latest`) or SHA256.
 
-Some packaging ecosystems/indices (like [PyPI] and [RubyGems]) support
-"Trusted Publishing," which is an OIDC-based "tokenless" authentication
-mechanism for uploading to the index from within a CI/CD workflow.
+When image references are unpinned or are pinned to a mutable tag, the
+workflow is at risk because the image used will be unpredictable over time.
+Changes made to the OCI registry used to source the image may result in untrusted
+images gaining access to your workflow.
 
-This "tokenless" flow has significant security benefits over a traditional
-manually configured API token, and should be preferred wherever supported
-and possible.
+This can be a security risk:
 
-[Trusted Publishing]: https://repos.openssf.org/trusted-publishers-for-all-package-repositories.html
+1. Registries may not consistently enforce immutable image tags
+2. Completely unpinned images can be changed at any time by the OCI registry.
 
-[PyPI]: https://pypi.org
+By default, this audit applies the following policy:
 
-[RubyGems]: https://rubygems.org
+* Regular findings are created for all image references missing a tag
+
+    ```yaml
+    container:
+      image: foo/bar
+    ```
+
+    or using the `latest` tag:
+
+    ```yaml
+    container:
+      image: foo/bar:latest
+    ```
+
+* Pedantic findings are created for all image references using a tag (`!= latest`) rather than SHA256 hash.
+
+    ```yaml
+    container:
+      image: foo/bar:not-a-sha256
+    ```
 
 Other resources:
 
-* [Trusted Publishers for All Package Repositories]
-* [Publishing to PyPI with a Trusted Publisher]
-* [Trusted Publishing - RubyGems Guides]
-* [Trusted publishing: a new benchmark for packaging security]
+- [Aqua: The Challenges of Uniquely Identifying Your Images]
+- [GitHub: Safeguard your containers with new container signing capability in GitHub Actions]
+
+
 
 ### Remediation
 
-In general, enabling Trusted Publishing requires a one-time change to your
-package's configuration on its associated index (e.g. PyPI or RubyGems).
+Pin the `#!yaml container.image:` value to a specific SHA256 image registry hash.
 
-Once your Trusted Publisher is registered, see @pypa/gh-action-pypi-publish
-or @rubygems/release-gem for canonical examples of using it.
+Many popular registries will display the hash value in their web console or you
+can use the command line to determine the hash of an image you have previously pulled
+by running `#!bash docker inspect redis:7.4.3 --format='{{.RepoDigests}}'`.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="unpinned-images.yml" hl_lines="7-8"
+        name: unpinned-images
+        on: [push]
+
+        jobs:
+          unpinned-image:
+            runs-on: ubuntu-latest
+            container:
+              image: fake.example.com/example
+            steps:
+              - run: "echo unpinned container!"
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="unpinned-images.yml" hl_lines="7-8"
+        name: unpinned-images
+        on: [push]
+
+        jobs:
+          unpinned-image:
+            runs-on: ubuntu-latest
+            container:
+              image: fake.example.com/example@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+            steps:
+              - run: "echo pinned container!"
+        ```
 
 ## `unpinned-uses`
 
@@ -792,323 +1338,7 @@ For Docker actions (like `docker://ubuntu`): add an appropriate
         1. Or `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` for a SHA-pinned action.
 
 
-## `insecure-commands`
 
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow, Action  | [insecure-commands.yml] | v0.5.0        | ✅             | ✅       | ❌  |
-
-[insecure-commands.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/insecure-commands.yml
-
-Detects opt-in for executing insecure workflow commands.
-
-Workflow commands (like `::set-env` and `::add-path`)
-[were deprecated by GitHub] in 2020 due to their inherent weaknesses
-(e.g., allowing any command with the ability to emit to `stdout`
-to inject environment variables and therefore obtain code execution).
-
-However, users can explicitly re-enable them by setting the
-`ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable at the workflow,
-job, or step level.
-
-Other resources:
-
-* [Semgrep audit]
-
-### Remediation
-
-In general, users should use for [GitHub Actions environment files]
-(like `GITHUB_PATH` and `GITHUB_OUTPUT`) instead of using workflow commands.
-
-!!! example
-
-    === "Before :warning:"
-
-        ```yaml title="insecure-commands" hl_lines="3"
-        - name: Setup my-bin
-          run: |
-            echo "::add-path::$HOME/.local/my-bin"
-          env:
-            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-        ```
-
-    === "After :white_check_mark:"
-
-        ```yaml title="insecure-commands" hl_lines="3"
-        - name: Setup my-bin
-          run: |
-            echo "$HOME/.local/my-bin" >> "$GITHUB_PATH"
-        ```
-
-## `github-env`
-
-| Type     | Examples           | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|--------------------|---------------|----------------|--------------------| --------------|
-| Workflow, Action  | [github-env.yml]   | v0.6.0        | ✅             | ✅       | ❌  |
-
-[github-env.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/github-env.yml
-
-Detects dangerous writes to the `GITHUB_ENV` and `GITHUB_PATH` environment variables.
-
-When used in workflows with dangerous triggers (such as `pull_request_target` and `workflow_run`),
-`GITHUB_ENV` and `GITHUB_PATH` can be an arbitrary code execution risk:
-
-* If the attacker is able to set arbitrary variables or variable contents via
-  `GITHUB_ENV`, they may be able to set `LD_PRELOAD` or otherwise induce code
-  execution implicitly within subsequent steps.
-* If the attacker is able to add an arbitrary directory to the `$PATH` via
-  `GITHUB_PATH`, they may be able to execute arbitrary code by shadowing
-  ordinary system executables (such as `ssh`).
-
-Other resources:
-
-* [GitHub Actions exploitation: environment manipulation]
-* [GHSL-2024-177: Environment Variable injection in an Actions workflow of Litestar]
-* [Google & Apache Found Vulnerable to GitHub Environment Injection]
-* [Hacking with Environment Variables]
-
-### Remediation
-
-In general, you should avoid modifying `GITHUB_ENV` and `GITHUB_PATH` within
-sensitive workflows that are attacker-triggered, like `pull_request_target`.
-
-If you absolutely must use `GITHUB_ENV` or `GITHUB_PATH`, avoid passing
-attacker-controlled values into either. Stick with literal strings and
-values computed solely from trusted sources.
-
-If you need to pass state between steps, consider using `GITHUB_OUTPUT` instead.
-
-## `cache-poisoning`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow  | [cache-poisoning.yml]   | v0.10.0       | ✅             | ✅               | ❌  |
-
-[cache-poisoning.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/cache-poisoning.yml
-
-Detects potential cache-poisoning scenarios in release workflows.
-
-Caching and restoring build state is a process eased by utilities provided
-by GitHub, in particular @actions/cache and its "save" and "restore"
-sub-actions. In addition, many of the setup-like actions provided
-by GitHub come with built-in caching functionality, like @actions/setup-node,
-@actions/setup-java and others.
-
-Furthermore, there are many examples of community-driven Actions with built-in
-caching functionality, like @ruby/setup-ruby, @astral-sh/setup-uv,
-@Swatinem/rust-cache. In general, most of them build on top of @actions/toolkit
-for the sake of easily integrate with GitHub cache server at Workflow runtime.
-
-This vulnerability happens when release workflows leverage build state cached
-from previous workflow executions, in general on top of the aforementioned
-actions or  similar ones. The publication of artifacts usually happens driven
-by trigger events like `release` or events with path filters like `push`
-(e.g. for tags).
-
-In such scenarios, an attacker with access to a valid `GITHUB_TOKEN` can use it
-to poison the repository's GitHub Actions caches. That compounds with the
-default behavior of @actions/toolkit during cache restorations, allowing an
-attacker to retrieve payloads from poisoned cache entries, hence achieving code
-execution at Workflow runtime, potentially compromising ready-to-publish
-artifacts.
-
-Other resources:
-
-* [The Monsters in Your Build Cache – GitHub Actions Cache Poisoning]
-* [Cacheract: The Monster in your Build Cache]
-
-### Remediation
-
-In general, you should avoid using previously cached CI state within workflows
-intended to publish build artifacts:
-
-* Remove cache-aware actions like @actions/cache from workflows that produce
-  releases, *or*
-* Disable cache-aware actions with an `#!yaml if:` condition based on the trigger at
-  the step level, *or*
-* Set an action-specific input to disable cache restoration when appropriate,
-  such as `lookup-only` in @Swatinem/rust-cache.
-
-## `secrets-inherit`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow  | [secrets-inherit.yml]   | v1.1.0      | ✅             | ✅                 | ❌  |
-
-[secrets-inherit.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/secrets-inherit.yml
-
-Detects excessive secret inheritance between calling workflows and reusable
-(called) workflows.
-
-[Reusable workflows] can be given secrets by their calling workflow either
-explicitly, or in a blanket fashion with `#!yaml secrets: inherit`. The latter
-should almost never be used, as it makes it violates the
-[Principle of Least Authority] and makes it impossible to determine which exact
-secrets a reusable workflow was executed with.
-
-### Remediation
-
-In general, `#!yaml secrets: inherit` should be replaced with a `#!yaml secrets:` block
-that explicitly forwards each secret actually needed by the reusable workflow.
-
-!!! example
-
-    === "Before :warning:"
-
-        ```yaml title="reusable.yml" hl_lines="4"
-        jobs:
-          pass-secrets-to-workflow:
-            uses: ./.github/workflows/called-workflow.yml
-            secrets: inherit
-        ```
-
-    === "After :white_check_mark:"
-
-        ```yaml title="reusable.yml" hl_lines="4-6"
-        jobs:
-          pass-secrets-to-workflow:
-            uses: ./.github/workflows/called-workflow.yml
-            secrets:
-              forward-me: ${{ secrets.forward-me }}
-              me-too: ${{ secrets.me-too }}
-        ```
-
-## `bot-conditions`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow  | [bot-conditions.yml]   | v1.2.0      | ✅             | ✅                 | ❌  |
-
-[bot-conditions.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/bot-conditions.yml
-
-Detects potentially spoofable bot conditions.
-
-Many workflows allow trustworthy bots (such as [Dependabot](https://github.com/dependabot))
-to bypass checks or otherwise perform privileged actions. This is often done
-with a `github.actor` check, e.g.:
-
-```yaml
-if: github.actor == 'dependabot[bot]'
-```
-
-However, this condition is spoofable: `github.actor` refers to the *last* actor
-to perform an "action" on the triggering context, and not necessarily
-the actor actually causing the trigger. An attacker can take
-advantage of this discrepancy to create a PR where the `HEAD` commit
-has `github.actor == 'dependabot[bot]'` but the rest of the branch history
-contains attacker-controlled code, bypassing the actor check.
-
-Other resources:
-
-* [GitHub Actions exploitations: Dependabot]
-
-### Remediation
-
-In general, checking a trigger's authenticity via `github.actor` is
-insufficient. Instead, most users should use `github.event.pull_request.user.login`
-or similar, since that context refers to the actor that *created* the Pull Request
-rather than the last one to modify it.
-
-More generally,
-[GitHub's documentation recommends](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
-not using `pull_request_target` for auto-merge workflows.
-
-!!! example
-
-    === "Before :warning:"
-
-        ```yaml title="bot-conditions.yml" hl_lines="1 6"
-        on: pull_request_target
-
-        jobs:
-          automerge:
-            runs-on: ubuntu-latest
-            if: github.actor == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
-            steps:
-              - run: gh pr merge --auto --merge "$PR_URL"
-                env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ```
-
-    === "After :white_check_mark:"
-
-        ```yaml title="bot-conditions.yml" hl_lines="1 6"
-        on: pull_request
-
-        jobs:
-          automerge:
-            runs-on: ubuntu-latest
-            if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
-            steps:
-              - run: gh pr merge --auto --merge "$PR_URL"
-                env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ```
-
-## `overprovisioned-secrets`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow, Action  | [overprovisioned-secrets.yml]   | v1.3.0      | ✅     | ✅         | ❌  |
-
-[overprovisioned-secrets.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/overprovisioned-secrets.yml
-
-Detects excessive sharing of the `secrets` context.
-
-Typically, users access the `secrets` context via its individual members:
-
-```yaml
-env:
-  SECRET_ONE: ${{ secrets.SECRET_ONE }}
-  SECRET_TWO: ${{ secrets.SECRET_TWO }}
-```
-
-This allows the Actions runner to only expose the secrets actually used by
-the workflow to the job environment.
-
-However, if the user instead accesses the *entire* `secrets` context:
-
-```yaml
-env:
-  SECRETS: ${{ toJson(secrets) }}
-```
-
-...then the entire `secrets` context is exposed to the runner, even if
-only a single secret is actually needed.
-
-### Remediation
-
-In general, users should avoid loading the entire `secrets` context.
-Secrets should be accessed individually by name.
-
-!!! example
-
-    === "Before :warning:"
-
-        ```yaml title="overprovisioned.yml" hl_lines="7"
-        jobs:
-          deploy:
-            runs-on: ubuntu-latest
-            steps:
-              - run: ./deploy.sh
-                env:
-                  SECRETS: ${{ toJSON(secrets) }}
-        ```
-
-    === "After :white_check_mark:"
-
-        ```yaml title="overprovisioned.yml" hl_lines="7-8"
-        jobs:
-          deploy:
-            runs-on: ubuntu-latest
-            steps:
-              - run: ./deploy.sh
-                env:
-                  SECRET_ONE: ${{ secrets.SECRET_ONE }}
-                  SECRET_TWO: ${{ secrets.SECRET_TWO }}
-        ```
 
 ## `unredacted-secrets`
 
@@ -1179,174 +1409,6 @@ individual fields as separate secrets.
                   PASSWORD: ${{ secrets.MY_SECRET_PASSWORD }}
         ```
 
-## `forbidden-uses`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow, Action  | N/A            | v1.6.0        | ✅             | ❌                |  ✅ |
-
-An *opt-in* audit for denylisting/allowlisting specific `#!yaml uses:` clauses.
-This is not enabled by default; you must
-[configure it](#forbidden-uses-configuration) to use it.
-
-!!! warning
-
-    This audit comes with several limitations that are important to understand:
-
-    * This audit is *opt-in*. You must configure it to use it; it
-      **does nothing** by default.
-    * This audit (currently) operates on *repository* `#!yaml uses:` clauses,
-      e.g. `#!yaml uses: actions/checkout@v4`. It does not operate on Docker
-      `#!yaml uses:` clauses, e.g. `#!yaml uses: docker://ubuntu:24.04`. This limitation
-      may be lifted in the future.
-    * This audit operates on `#!yaml uses:` clauses *as they appear* in the workflow
-      and action files. In other words, in *cannot* detect
-      [impostor commits](#impostor-commit) or indirect usage of actions
-      via manual `git clone` and local path usage.
-    * This audit's configuration operates on patterns, just like
-      [unpinned-uses](#unpinned-uses). That means that you can't (yet)
-      define *exact* matches. For example, you can't forbid `actions/checkout@v4`,
-      you have to forbid `actions/checkout`, which forbids all versions.
-
-### Configuration { #forbidden-uses-configuration }
-
-#### `rules.forbidden-uses.config.<allow|deny>`
-
-_Type_: `list`
-
-The `forbidden-uses` audit operates on either an allowlist or denylist
-basis:
-
-* In allowlist mode, only the listed `#!yaml uses:` patterns are allowed. All
-  non-matching `#!yaml uses:` clauses result in a finding.
-
-    Intended use case: only allowing "known good" actions to be used,
-    and forbidding everything else.
-
-* In denylist mode, only the listed `#!yaml uses:` patterns are disallowed. All
-  matching `#!yaml uses:` clauses result in a finding.
-
-    Intended use case: permitting all `#!yaml uses:` by default, but explicitly
-    forbidding "known bad" actions.
-
-Regardless of the mode used, the patterns allowed are the same as those
-in [unpinned-uses](#unpinned-uses-configuration).
-
-!!! example
-
-    The following configuration would allow only actions owned by
-    the @actions organization, plus any actions defined in @github/codeql-action:
-
-    ```yaml title="zizmor.yml"
-    rules:
-      forbidden-uses:
-        config:
-          allow:
-            - actions/*
-            - github/codeql-action/*
-    ```
-
-!!! example
-
-    The following would allow all actions except for those in the
-    @actions organization or defined in @github/codeql-action:
-
-    ```yaml title="zizmor.yml"
-    rules:
-      forbidden-uses:
-        config:
-          deny:
-            - actions/*
-            - github/codeql-action/*
-    ```
-
-### Remediation
-
-Either remove the offending `#!yaml uses:` clause or, if intended, add it to
-your [configuration](#forbidden-uses-configuration).
-
-## `obfuscation`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------| ---------------|
-| Workflow, Action  | N/A   | v1.7.0        | ✅             | ✅                 | ❌  |
-
-Checks for obfuscated usages of GitHub Actions features.
-
-This audit primarily serves to "unstick" other audits, which may fail to detect
-functioning but obfuscated usages of GitHub Actions features.
-
-This audit detects a variety of obfuscated usages, including:
-
-* Obfuscated paths within `#!yaml uses:` clauses, including redundant `/`
-  separators and uses of `.` or `..` in path segments.
-* Obfuscated GitHub expressions, including no-op patterns like
-  `fromJSON(toJSON(...))` and calls to `format(...)` where all
-  arguments are literal values.
-
-### Remediation
-
-Address the source of obfuscation by simplifying the expression,
-`#!yaml uses:` clause, or other obfuscated feature.
-
-!!! example
-
-    === "Before :warning:"
-
-        ```yaml title="obfuscation.yml" hl_lines="8"
-        jobs:
-          build:
-            runs-on: ubuntu-latest
-            steps:
-              - name: Checkout
-                uses: actions/checkout@v4
-                with:
-                  repository: ${{ format('{0}/{1}', 'octocat', 'hello-world') }}
-        ```
-
-    === "After :white_check_mark:"
-
-        ```yaml title="obfuscation.yml" hl_lines="8"
-        jobs:
-          build:
-            runs-on: ubuntu-latest
-            steps:
-              - name: Checkout
-                uses: actions/checkout@v4
-                with:
-                  repository: octocat/hello-world
-        ```
-
-## `stale-action-refs`
-
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------|--------------|
-| Workflow, Action  | N/A            | v1.7.0        | ❌            | ✅                | ❌          |
-
-Checks for `#!yaml uses:` clauses which pin an action using a SHA reference,
-but where that reference does not point to a Git tag.
-
-When using an action commit which is not a Git tag / release version, that commit
-might contain bugs or vulnerabilities which have not been publicly documented
-because they might have been fixed before the subsequent release. Additionally,
-because changelogs are usually only published for releases, it is difficult to
-tell which changes of the subsequent release the pinned commit includes.
-
-!!! note
-
-    This is a `--pedantic` only audit because the detected situation is not
-    a vulnerability per se. But it might be worth investigating which commit
-    the SHA reference points to, and why not a SHA reference pointing to a
-    Git tag is used.
-
-    Some action repositories use a "rolling release branch" strategy where
-    all commits on a certain branch are considered releases. In such a case
-    findings of this audit can likely be ignored.
-
-### Remediation
-
-Change the `#!yaml uses:` clause to pin the action using a SHA reference
-which points to a Git tag.
 
 ## `unsound-contains`
 
@@ -1425,95 +1487,46 @@ Other resources:
                 if: contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref)
         ```
 
-## `unpinned-images`
 
-| Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |
-|----------|-------------------------|---------------|----------------|--------------------|--------------|
-| Workflow, Action  | [unpinned-images.yml] | v1.7.0        | ✅            | ✅                | ❌          |
+## `use-trusted-publishing`
 
-[unpinned-images.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/unpinned-images.yml
+| Type     | Examples                     | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|------------------------------|---------------|----------------|--------------------| ---------------|
+| Workflow  | [pypi-manual-credential.yml] | v0.1.0        | ✅             | ✅                 | ❌  |
 
-Checks for `container.image` values where the image is not pinned by either a tag (other than `latest`) or SHA256.
+[pypi-manual-credential.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/pypi-manual-credential.yml
 
-When image references are unpinned or are pinned to a mutable tag, the
-workflow is at risk because the image used will be unpredictable over time.
-Changes made to the OCI registry used to source the image may result in untrusted
-images gaining access to your workflow.
+Detects packaging workflows that could use [Trusted Publishing].
 
-This can be a security risk:
+Some packaging ecosystems/indices (like [PyPI] and [RubyGems]) support
+"Trusted Publishing," which is an OIDC-based "tokenless" authentication
+mechanism for uploading to the index from within a CI/CD workflow.
 
-1. Registries may not consistently enforce immutable image tags
-2. Completely unpinned images can be changed at any time by the OCI registry.
+This "tokenless" flow has significant security benefits over a traditional
+manually configured API token, and should be preferred wherever supported
+and possible.
 
-By default, this audit applies the following policy:
+[Trusted Publishing]: https://repos.openssf.org/trusted-publishers-for-all-package-repositories.html
 
-* Regular findings are created for all image references missing a tag
+[PyPI]: https://pypi.org
 
-    ```yaml
-    container:
-      image: foo/bar
-    ```
-
-    or using the `latest` tag:
-
-    ```yaml
-    container:
-      image: foo/bar:latest
-    ```
-
-* Pedantic findings are created for all image references using a tag (`!= latest`) rather than SHA256 hash.
-
-    ```yaml
-    container:
-      image: foo/bar:not-a-sha256
-    ```
+[RubyGems]: https://rubygems.org
 
 Other resources:
 
-- [Aqua: The Challenges of Uniquely Identifying Your Images]
-- [GitHub: Safeguard your containers with new container signing capability in GitHub Actions]
-
-
+* [Trusted Publishers for All Package Repositories]
+* [Publishing to PyPI with a Trusted Publisher]
+* [Trusted Publishing - RubyGems Guides]
+* [Trusted publishing: a new benchmark for packaging security]
 
 ### Remediation
 
-Pin the `#!yaml container.image:` value to a specific SHA256 image registry hash.
+In general, enabling Trusted Publishing requires a one-time change to your
+package's configuration on its associated index (e.g. PyPI or RubyGems).
 
-Many popular registries will display the hash value in their web console or you
-can use the command line to determine the hash of an image you have previously pulled
-by running `#!bash docker inspect redis:7.4.3 --format='{{.RepoDigests}}'`.
+Once your Trusted Publisher is registered, see @pypa/gh-action-pypi-publish
+or @rubygems/release-gem for canonical examples of using it.
 
-!!! example
-
-    === "Before :warning:"
-
-        ```yaml title="unpinned-images.yml" hl_lines="7-8"
-        name: unpinned-images
-        on: [push]
-
-        jobs:
-          unpinned-image:
-            runs-on: ubuntu-latest
-            container:
-              image: fake.example.com/example
-            steps:
-              - run: "echo unpinned container!"
-        ```
-
-    === "After :white_check_mark:"
-
-        ```yaml title="unpinned-images.yml" hl_lines="7-8"
-        name: unpinned-images
-        on: [push]
-
-        jobs:
-          unpinned-image:
-            runs-on: ubuntu-latest
-            container:
-              image: fake.example.com/example@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-            steps:
-              - run: "echo pinned container!"
-        ```
 
 [ArtiPACKED: Hacking Giants Through a Race Condition in GitHub Actions Artifacts]: https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
 [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests]: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

--- a/docs/development.md
+++ b/docs/development.md
@@ -295,8 +295,9 @@ The general procedure for adding a new audit can be described as:
   proper `Workflow`, `Job` or `Step` instance
 - Register `MyNewAudit` in the known audits at `src/main.rs`
 - Add proper integration tests covering some scenarios at `tests/acceptance.rs`
-- Add proper docs for this new audit at `docs/audits`. Please add related public
-  information about the underlying vulnerability
+- Add proper docs for this new audit at `docs/audits`. Take care to add your new
+  heading in alpha order relative to the other audit headings. Please include
+  relevant public information about the underlying vulnerability
 - Open your Pull Request!
 
 #### Adding locations to an audit


### PR DESCRIPTION
The right navigation of https://woodruffw.github.io/zizmor/audits/ uses these headings and as a user or contributor that is consulting that nav to explore the various audits, reading the list in its unsorted current form is confusing.