### PR TITLE
feat: extend template injection audit & use CodeQL models

### DIFF
--- a/.github/workflows/process-codeql-sink-models.js
+++ b/.github/workflows/process-codeql-sink-models.js
@@ -64,7 +64,7 @@ function processYamlFile(filePath, relevantKinds, onlyManualModels) {
                 continue
             }
 
-            // Ignore 'on: workflow_call' inputs; seems to be mostly for for 'generated' models
+            // Ignore 'on: workflow_call' inputs; seems to be mostly for 'generated' models
             if (action.includes('/.github/workflows/')) {
                 continue
             }

--- a/.github/workflows/process-codeql-sink-models.js
+++ b/.github/workflows/process-codeql-sink-models.js
@@ -1,0 +1,135 @@
+/*
+ * Processes the CodeQL models from https://github.com/github/codeql/blob/codeql-cli/v2.21.2/actions/ql/lib/ext
+ * and extracts the information needed by zizmor
+ */
+
+// @ts-check
+
+const path = require('node:path')
+const fs = require('node:fs')
+// yaml library is installed by GitHub workflow
+const yaml = require('../../codeql-models-working-dir/node_modules/yaml')
+
+/** @type Map<string, string[]> */
+const codeInjectionSinks = new Map()
+
+/**
+ * @param {fs.PathLike} filePath
+ * @param {Set<string>} relevantKinds which sink kinds are relevant
+ * @param {boolean} onlyManualModels whether to include only models with 'provenance == manual'
+ */
+function processYamlFile(filePath, relevantKinds, onlyManualModels) {
+    const content = yaml.parse(fs.readFileSync(filePath, { encoding: 'utf8' }))
+    const extensions = content['extensions']
+
+    if (extensions === undefined) {
+        throw new Error('Missing extensions: ' + content)
+    }
+
+    for (const extension of extensions) {
+        const addsTo = extension['addsTo']
+        if (addsTo === undefined) {
+            throw new Error('Missing addsTo: ' + content)
+        }
+
+        const extensible = addsTo['extensible']
+        if (extensible !== 'actionsSinkModel') {
+            continue
+        }
+
+        const pack = addsTo['pack']
+        // Fail if CodeQL starts using other packs, have to examine then what this means,
+        // e.g. whether it has lower accuracy or severity
+        if (pack !== 'codeql/actions-all') {
+            throw new Error('Unexpected pack: ' + pack)
+        }
+
+        const data = extension['data']
+        if (data === undefined) {
+            throw new Error('Missing data: ' + content)
+        }
+
+        for (const dataEntry of data) {
+            if (dataEntry.length !== 5) {
+                throw new Error('Contains malformed data entry: ' + dataEntry)
+            }
+
+            // See https://github.com/github/codeql/blob/codeql-cli/v2.21.2/actions/ql/lib/codeql/actions/dataflow/internal/ExternalFlowExtensions.qll#L22-L24
+            /** @type string[] */
+            const [action, version, input, kind, provenance] = dataEntry
+            if (!relevantKinds.has(kind)) {
+                continue
+            }
+            if (onlyManualModels && provenance !== 'manual') {
+                continue
+            }
+
+            // Ignore 'on: workflow_call' inputs seem to be mostly for for 'generated' models
+            if (action.includes('/.github/workflows/')) {
+                continue
+            }
+
+            // Currently all models use only '*' as affected version, so for simplicity only
+            // support that for now
+            if (version !== '*') {
+                throw new Error(
+                    'Non-wildcard versions are not supported yet: ' + version
+                )
+            }
+
+            const inputPrefix = 'input.'
+            if (!input.startsWith(inputPrefix)) {
+                throw new Error('Contains input with unexpected format: ' + input)
+            }
+            const inputName = input.substring(inputPrefix.length)
+
+            let inputs = codeInjectionSinks.get(action)
+            if (inputs === undefined) {
+                inputs = []
+                codeInjectionSinks.set(action, inputs)
+            }
+            inputs.push(inputName)
+        }
+    }
+}
+
+/**
+ * @param {string} codeQlDir
+ * @param {fs.PathLike} outputFile
+ */
+function processModels(codeQlDir, outputFile) {
+    const modelsDir = path.join(codeQlDir, 'actions/ql/lib/ext')
+    const files = fs.readdirSync(modelsDir, {
+        recursive: true,
+        withFileTypes: true,
+    })
+
+    const relevantKinds = new Set(['code-injection'])
+    // For now only include models manually curated by the CodeQL developers
+    const onlyManualModels = true
+
+    let processedCount = 0
+    for (const file of files) {
+        if (file.isFile()) {
+            const name = file.name
+            if (name.endsWith('.yml') || name.endsWith('.yaml')) {
+                processedCount++
+                const filePath = path.join(file.parentPath, name)
+                try {
+                    processYamlFile(filePath, relevantKinds, onlyManualModels)
+                } catch (e) {
+                    throw new Error('Failed processing file: ' + filePath, { cause: e })
+                }
+            }
+        }
+    }
+
+    console.info(`Processed ${processedCount} files`)
+
+    // Important: Data format must match the parsing logic in the Rust code
+    const zizmorModelData = [...codeInjectionSinks].sort().map(entry => `${entry[0]}|${entry[1].join(',')}\n`).join('')
+    fs.writeFileSync(outputFile, zizmorModelData)
+    console.info(`Wrote model data to file: ${outputFile}`)
+}
+
+processModels('codeql', '../code-injection-models.txt')

--- a/.github/workflows/process-codeql-sink-models.js
+++ b/.github/workflows/process-codeql-sink-models.js
@@ -1,5 +1,5 @@
 /*
- * Processes the CodeQL models from https://github.com/github/codeql/blob/codeql-cli/v2.21.2/actions/ql/lib/ext
+ * Processes the CodeQL models from https://github.com/github/codeql/tree/main/actions/ql/lib/ext
  * and extracts the information needed by zizmor
  */
 
@@ -64,7 +64,7 @@ function processYamlFile(filePath, relevantKinds, onlyManualModels) {
                 continue
             }
 
-            // Ignore 'on: workflow_call' inputs seem to be mostly for for 'generated' models
+            // Ignore 'on: workflow_call' inputs; seems to be mostly for for 'generated' models
             if (action.includes('/.github/workflows/')) {
                 continue
             }

--- a/.github/workflows/update-code-injection-models.yml
+++ b/.github/workflows/update-code-injection-models.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: 22
 
+      # Use custom working dir for downloading npm packages and cloning the CodeQL repo
       - name: Create working dir
         run: |
           mkdir codeql-models-working-dir

--- a/.github/workflows/update-code-injection-models.yml
+++ b/.github/workflows/update-code-injection-models.yml
@@ -1,0 +1,72 @@
+name: 'Update code injection models'
+
+on:
+  # Run weekly (at arbitrary time)
+  schedule:
+    - cron: '31 7 * * 5'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update-models:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Update models
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Create working dir
+        run: |
+          mkdir codeql-models-working-dir
+
+      - name: Install dependencies
+        run: |
+          npm install yaml@2.7.1 --no-save
+        working-directory: codeql-models-working-dir
+
+      - name: Check out CodeQL
+        id: checkout_codeql
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: github/codeql
+          path: codeql-models-working-dir/codeql
+          sparse-checkout: |
+            actions/ql/lib/ext
+
+      - name: Update model file
+        run: node ../.github/workflows/process-codeql-sink-models.js
+        working-directory: codeql-models-working-dir
+
+      # If there are no changes, this action will not create a pull request
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          add-paths: |
+            code-injection-models.txt
+          branch: bot/code-injection-models-update
+          commit-message: |
+            Update code injection models
+
+            https://github.com/github/codeql/commit/${{ steps.checkout_codeql.outputs.commit }}
+          title: Update code injection models
+          # Note: Unfortunately this action cannot trigger the regular workflows for the PR automatically, see
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # Therefore suggest below to close and then reopen the PR
+          body: |
+            Automatically generated pull request to update the code injection models based on https://github.com/github/codeql/commit/${{ steps.checkout_codeql.outputs.commit }}.
+
+            In case of conflicts, manually run the workflow from the [Actions tab](https://github.com/woodruffw/zizmor/actions/workflows/update-code-injection-models.yml), the changes will then be force-pushed onto this pull request branch.
+            Do not manually update the pull request branch; those changes might get overwritten.
+
+            > [!IMPORTANT]\
+            > GitHub workflows have not been executed for this pull request yet. Before merging, close and then directly reopen this pull request to trigger the workflows.

--- a/code-injection-models.txt
+++ b/code-injection-models.txt
@@ -1,0 +1,15 @@
+8398a7/action-slack|custom_payload
+actions/github-script|script
+appleboy/ssh-action|script
+azure/cli|inlineScript
+azure/powershell|inlineScript
+devorbitus/yq-action-output|cmd
+docker/build-push-action|context
+gautamkrishnar/blog-post-workflow|item_exec
+imjohnbo/issue-bot|body,linked-comments-previous-issue-text,linked-comments-new-issue-text
+lucasbento/auto-close-issues|issue-close-message
+mikefarah/yq|cmd
+roots/issue-closer-action|issue-close-message,pr-close-message
+sergeysova/jq-action|cmd
+skitionek/notify-microsoft-teams|overwrite
+tibdex/backport|body_template,head_template,labels_template,title_template

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -979,6 +979,9 @@ used with attacker-controllable expression contexts, such as
 `github.event.issue.title` (which the attacker can fully control by supplying
 a new issue title).
 
+The list of action inputs which are vulnerable to injection attacks is
+based on [GitHub's CodeQL models](https://github.com/github/codeql/blob/main/actions/ql/lib/ext).
+
 Other resources:
 
 * [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -41,6 +41,9 @@ of `zizmor`.
   which was to terminate the audit if any collected input could
   not be parsed (#734)
 
+* The [template-injection] audit has been extended to detect more
+  vulnerable action inputs (#TODO)
+
 ### Bug Fixes 🐛
 
 * The SARIF output format now uses `zizmor/{id}` for rule IDs instead

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -42,7 +42,7 @@ of `zizmor`.
   not be parsed (#734)
 
 * The [template-injection] audit has been extended to detect more
-  vulnerable action inputs (#TODO)
+  vulnerable action inputs (#743)
 
 ### Bug Fixes 🐛
 

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -332,6 +332,12 @@ fn template_injection() -> Result<()> {
             .run()?
     );
 
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("template-injection/pwsh-script.yml"))
+            .run()?
+    );
+
     Ok(())
 }
 

--- a/tests/integration/snapshots/integration__snapshot__template_injection-10.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-10.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"template-injection/pwsh-script.yml\")).run()?"
+---
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:12:7
+   |
+12 |        - uses: Amadevus/pwsh-script@97a8b211a5922816aa8a69ced41fa32f23477186 # v2.0.3
+   |  ________^
+13 | |        with:
+14 | |          script: |
+   | | _________^
+15 | ||           Write-ActionDebug "Running for pull request ${{ github.event.pull_request.title }}"
+   | ||                                                                                              ^
+   | ||______________________________________________________________________________________________|
+   |  |______________________________________________________________________________________________this step
+   |                                                                                                 github.event.pull_request.title may expand into attacker-controllable code
+   |
+   = note: audit confidence → High
+
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/integration/test-data/template-injection/pwsh-script.yml
+++ b/tests/integration/test-data/template-injection/pwsh-script.yml
@@ -1,0 +1,15 @@
+name: pwsh-script
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  some-job:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: Amadevus/pwsh-script@97a8b211a5922816aa8a69ced41fa32f23477186 # v2.0.3
+      with:
+        script: |
+          Write-ActionDebug "Running for pull request ${{ github.event.pull_request.title }}"


### PR DESCRIPTION
Resolves #417

This is a proof-of-concept for refactoring the `template-injection` audit to make it easier to add new injection sinks in the future, and to use CodeQL's models.

A new GitHub workflow is added which runs on schedule and on demand which pull the https://github.com/github/codeql repository, processes their injection sink models and generates a file in custom zizmor-specific format, and creates a pull request for updating the file.
That file is loaded by zizmor's `template-injection` audit at compile time.

Here is an example run from my fork:
- https://github.com/Marcono1234/zizmor/actions/runs/14815681649/job/41595747538
- Generated pull request: https://github.com/Marcono1234/zizmor/pull/2

The idea for that workflow is based on https://github.com/gradle/actions/blob/main/.github/workflows/update-checksums-file.yml (which is a similar use case for processing external resources and including them in the build).