### PR TITLE
chore(doc): remove event filters

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -570,9 +570,7 @@ two primary ways to use `zizmor` in GitHub Actions:
 
     on:
       push:
-        branches: ["main"]
       pull_request:
-        branches: ["**"]
 
     permissions: {}
 
@@ -644,9 +642,7 @@ two primary ways to use `zizmor` in GitHub Actions:
 
     on:
       push:
-        branches: ["main"]
       pull_request:
-        branches: ["**"]
 
     jobs:
       zizmor:


### PR DESCRIPTION
Removing these entirely means that we trigger on all `push` and `pull_request` events, which is typically what we want.