### PR TITLE
chore(ci): experiment with pinact

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,6 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 16 * * *"
   workflow_dispatch:
-  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -16,7 +16,7 @@ jobs:
     uses: zizmorcore/.github/.github/workflows/pinact-reusable.yml@98563e15293546f024fc295f62071c80c05b1a49
     with:
       dry-run: true
-      extra-inputs: |
+      extra-inputs: >-
         docs/usage.md
         docs/audits.md
     secrets:

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,23 @@
+name: Update use pins with pinact
+
+on:
+  schedule:
+    - cron: "0 16 * * *"
+  workflow_dispatch:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  call-pinact:
+    permissions:
+      contents: write # for branch creation
+      pull-requests: write # for pull request creation
+    uses: zizmorcore/.github/.github/workflows/pinact-reusable.yml@98563e15293546f024fc295f62071c80c05b1a49
+    with:
+      dry-run: true
+      extra-inputs: |
+        docs/usage.md
+        docs/audits.md
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write # for branch creation
       pull-requests: write # for pull request creation
-    uses: zizmorcore/.github/.github/workflows/pinact-reusable.yml@98563e15293546f024fc295f62071c80c05b1a49
+    uses: zizmorcore/.github/.github/workflows/pinact-reusable.yml@1f08e4c16ea12a8372b10d32c9e83814e28585a4
     with:
       dry-run: true
       extra-inputs: >-

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -343,7 +343,7 @@ by default, and then set specific job-level permissions as needed.
                   path: dist/
 
               - name: publish
-                uses: pypa/gh-action-pypi-publish@release/v1
+                uses: pypa/gh-action-pypi-publish@v1.12.4
         ```
 
     === "After :white_check_mark:"
@@ -380,7 +380,7 @@ by default, and then set specific job-level permissions as needed.
                   path: dist/
 
               - name: publish
-                uses: pypa/gh-action-pypi-publish@release/v1
+                uses: pypa/gh-action-pypi-publish@v1.12.4
         ```
 
 ## `forbidden-uses`


### PR DESCRIPTION
The idea here is to replace our use of Dependabot with `pinact`, since the latter allows us to update arbitrary files (including our documentation).