### PR TITLE
feat(cli): add completion generation support for nushell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,6 +3614,7 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
+ "clap_complete_nushell",
  "etcetera",
  "flate2",
  "github-actions-expressions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ camino = "1.1.9"
 clap = "4.5.38"
 clap-verbosity-flag = { version = "3.0.2", default-features = false }
 clap_complete = "4.5.50"
+clap_complete_nushell = "4.5.5"
 etcetera = "0.10.0"
 flate2 = "1.1.1"
 http-cache-reqwest = "0.15.1"

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -30,6 +30,7 @@ camino = { workspace = true, features = ["serde1"] }
 clap = { workspace = true, features = ["derive", "env"] }
 clap-verbosity-flag = { workspace = true, features = ["tracing"] }
 clap_complete.workspace = true
+clap_complete_nushell.workspace = true
 etcetera.workspace = true
 flate2.workspace = true
 github-actions-expressions.workspace = true

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -156,7 +156,7 @@ enum Shell {
     /// Nushell
     Nushell,
     /// `PowerShell`
-    PowerShell,
+    Powershell,
     /// Z `SHell` (zsh)
     Zsh,
 }

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -10,6 +10,7 @@ use anyhow::{Context, Result, anyhow};
 use audit::{Audit, AuditLoadError};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{CommandFactory, Parser, ValueEnum};
+use clap_complete::Generator;
 use clap_verbosity_flag::InfoLevel;
 use config::Config;
 use finding::{Confidence, Persona, Severity};
@@ -126,7 +127,7 @@ struct App {
 
     /// Generate tab completion scripts for the specified shell.
     #[arg(long, value_enum, value_name = "SHELL", exclusive = true)]
-    completions: Option<clap_complete::Shell>,
+    completions: Option<Shell>,
 
     /// Enable naches mode.
     #[arg(long, hide = true, env = "ZIZMOR_NACHES")]
@@ -140,6 +141,48 @@ struct App {
     /// to audit the repository at a particular git reference state.
     #[arg(required = true)]
     inputs: Vec<String>,
+}
+
+/// Shell with auto-generated completion script available.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+#[allow(clippy::enum_variant_names)]
+enum Shell {
+    /// Bourne Again `SHell` (bash)
+    Bash,
+    /// Elvish shell
+    Elvish,
+    /// Friendly Interactive `SHell` (fish)
+    Fish,
+    /// Nushell
+    Nushell,
+    /// `PowerShell`
+    PowerShell,
+    /// Z `SHell` (zsh)
+    Zsh,
+}
+
+impl Generator for Shell {
+    fn file_name(&self, name: &str) -> String {
+        match self {
+            Shell::Bash => clap_complete::shells::Bash.file_name(name),
+            Shell::Elvish => clap_complete::shells::Elvish.file_name(name),
+            Shell::Fish => clap_complete::shells::Fish.file_name(name),
+            Shell::Nushell => clap_complete_nushell::Nushell.file_name(name),
+            Shell::PowerShell => clap_complete::shells::PowerShell.file_name(name),
+            Shell::Zsh => clap_complete::shells::Zsh.file_name(name),
+        }
+    }
+
+    fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
+        match self {
+            Shell::Bash => clap_complete::shells::Bash.generate(cmd, buf),
+            Shell::Elvish => clap_complete::shells::Elvish.generate(cmd, buf),
+            Shell::Fish => clap_complete::shells::Fish.generate(cmd, buf),
+            Shell::Nushell => clap_complete_nushell::Nushell.generate(cmd, buf),
+            Shell::PowerShell => clap_complete::shells::PowerShell.generate(cmd, buf),
+            Shell::Zsh => clap_complete::shells::Zsh.generate(cmd, buf),
+        }
+    }
 }
 
 #[derive(Debug, Default, Copy, Clone, ValueEnum)]

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -168,7 +168,7 @@ impl Generator for Shell {
             Shell::Elvish => clap_complete::shells::Elvish.file_name(name),
             Shell::Fish => clap_complete::shells::Fish.file_name(name),
             Shell::Nushell => clap_complete_nushell::Nushell.file_name(name),
-            Shell::PowerShell => clap_complete::shells::PowerShell.file_name(name),
+            Shell::Powershell => clap_complete::shells::PowerShell.file_name(name),
             Shell::Zsh => clap_complete::shells::Zsh.file_name(name),
         }
     }
@@ -179,7 +179,7 @@ impl Generator for Shell {
             Shell::Elvish => clap_complete::shells::Elvish.generate(cmd, buf),
             Shell::Fish => clap_complete::shells::Fish.generate(cmd, buf),
             Shell::Nushell => clap_complete_nushell::Nushell.generate(cmd, buf),
-            Shell::PowerShell => clap_complete::shells::PowerShell.generate(cmd, buf),
+            Shell::Powershell => clap_complete::shells::PowerShell.generate(cmd, buf),
             Shell::Zsh => clap_complete::shells::Zsh.generate(cmd, buf),
         }
     }

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -665,7 +665,7 @@ impl<'doc> Step<'doc> {
         // The steps's own `shell:` takes precedence, followed by the
         // job's default, followed by the entire workflow's default,
         // followed by the runner's default.
-        let shell = shell
+        shell
             .as_deref()
             .or_else(|| {
                 self.job()
@@ -679,9 +679,7 @@ impl<'doc> Step<'doc> {
                     .as_ref()
                     .and_then(|d| d.run.as_ref().and_then(|r| r.shell.as_deref()))
             })
-            .or_else(|| self.parent.runner_default_shell());
-
-        shell
+            .or_else(|| self.parent.runner_default_shell())
     }
 }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,10 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### New Features 🌈
+
+* `zizmor` now supports generating completions for Nushell (#838)
+
 ## v1.8.0
 
 ### Announcements 📣

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -45,7 +45,7 @@ Options:
       --strict-collection
           Fail instead of warning on syntax and schema errors in collected inputs
       --completions <SHELL>
-          Generate tab completion scripts for the specified shell [possible values: bash, elvish, fish, nushell, power-shell, zsh]
+          Generate tab completion scripts for the specified shell [possible values: bash, elvish, fish, nushell, powershell, zsh]
   -h, --help
           Print help (see more with '--help')
   -V, --version

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -45,7 +45,7 @@ Options:
       --strict-collection
           Fail instead of warning on syntax and schema errors in collected inputs
       --completions <SHELL>
-          Generate tab completion scripts for the specified shell [possible values: bash, elvish, fish, powershell, zsh]
+          Generate tab completion scripts for the specified shell [possible values: bash, elvish, fish, nushell, power-shell, zsh]
   -h, --help
           Print help (see more with '--help')
   -V, --version


### PR DESCRIPTION
I'm packaging zizmor for Chimera Linux right now (see https://github.com/chimera-linux/cports/pull/4255), and Chimera Linux is shipping nushell completions where available. As a nushell user, I'd love to see nushell completions for zizmor in addition to the ones already provided. While I was at it, I also added carapace, which is a multi-shell completion engine.

The way I'm doing it here is not great, because it requires replicating `clap_complete::Shell` and extending it to support the additional shells. An alternative that requires less code on the zizmor side is to use something like `clap_allgen`, but that is not intended to be used with a `Shell` enum, it's intended use is to generate all completions with one function call. Going for that would be a breaking change of the CLI interface, which I'd assume would need to wait for a v2, if it's wanted at all?

A completely different alternative I'd like to bring up is generating completions during build time using a `build.rs` file. This would allow cross compiling zizmor and still shipping completion packages without resorting to emulation or compiling twice. That requires bigger changes though, so didn't want to spend time on this without discussing it first.