### PR TITLE
fix: handle booleans for insecure-commands correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "github-actions-models"
-version = "0.28.3"
+version = "0.29.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 [workspace.dependencies]
 anyhow = "1.0.98"
 github-actions-expressions = { path = "crates/github-actions-expressions", version = "0.0.3" }
-github-actions-models = { path = "crates/github-actions-models", version = "0.28.3" }
+github-actions-models = { path = "crates/github-actions-models", version = "0.29.0" }
 itertools = "0.14.0"
 pest = "2.8.0"
 pest_derive = "2.8.0"

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-actions-models"
-version = "0.28.3"
+version = "0.29.0"
 description = "Unofficial, high-quality data models for GitHub Actions workflows, actions, and related components"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/github-actions-models"
 keywords = ["github", "ci"]

--- a/crates/zizmor/src/audit/insecure_commands.rs
+++ b/crates/zizmor/src/audit/insecure_commands.rs
@@ -2,8 +2,8 @@ use std::ops::Deref;
 
 use anyhow::Result;
 use github_actions_models::action;
+use github_actions_models::common::Env;
 use github_actions_models::common::expr::LoE;
-use github_actions_models::common::{Env, EnvValue};
 use github_actions_models::workflow::job::StepBody;
 
 use super::{AuditLoadError, Job, audit_meta};
@@ -56,10 +56,9 @@ impl InsecureCommands {
     }
 
     fn has_insecure_commands_enabled(&self, env: &Env) -> bool {
-        if let Some(EnvValue::String(value)) = env.get("ACTIONS_ALLOW_UNSECURE_COMMANDS") {
-            !value.is_empty()
-        } else {
-            false
+        match env.get("ACTIONS_ALLOW_UNSECURE_COMMANDS") {
+            Some(value) => value.csharp_trueish(),
+            None => false,
         }
     }
 

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -15,7 +15,7 @@ fn gha_hazmat() -> Result<()> {
             .offline(false)
             .output(OutputMode::Both)
             .args(["--no-online-audits"])
-            .input("woodruffw/gha-hazmat@42064a9533f401a493c3599e56f144918f8eacfd")
+            .input("woodruffw/gha-hazmat@33cd22cdd7823a5795768388aff977fe992b5aad")
             .run()?
     );
     Ok(())

--- a/crates/zizmor/tests/integration/snapshot.rs
+++ b/crates/zizmor/tests/integration/snapshot.rs
@@ -264,6 +264,13 @@ fn insecure_commands() -> Result<()> {
             .run()?
     );
 
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("insecure-commands/issue-839-repro.yml"))
+            .args(["--persona=auditor"])
+            .run()?
+    );
+
     Ok(())
 }
 

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -1,8 +1,8 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\"]).input(\"woodruffw/gha-hazmat@42064a9533f401a493c3599e56f144918f8eacfd\").run()?"
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\"]).input(\"woodruffw/gha-hazmat@33cd22cdd7823a5795768388aff977fe992b5aad\").run()?"
 ---
- INFO collect_inputs: zizmor: collected 20 inputs from woodruffw/gha-hazmat
+ INFO collect_inputs: zizmor: collected 22 inputs from woodruffw/gha-hazmat
  INFO zizmor: skipping impostor-commit: offline audits only requested
  INFO zizmor: skipping ref-confusion: offline audits only requested
  INFO zizmor: skipping known-vulnerable-actions: offline audits only requested
@@ -24,8 +24,10 @@ expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-onlin
  INFO audit: zizmor: 🌈 completed .github/workflows/secrets-inherit.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/self-hosted.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/template-injection.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/unpinned-images.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/unpinned.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/unredacted-secrets.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/unsound-contains.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/workflow-run.yml
  INFO audit: zizmor: 🌈 completed ref-confusion/action.yml
 error[artipacked]: credential persistence through GitHub Actions artifacts
@@ -394,11 +396,11 @@ warning[excessive-permissions]: overly broad permissions
 11 | |     runs-on: ubuntu-latest
 ...  |
 18 | |           # NOT OK
-19 | |           ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-   | |                                               -
-   | |_______________________________________________|
-   |                                                 this job
-   |                                                 default permissions used due to no permissions: block
+19 | |           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+   | |                                                -
+   | |________________________________________________|
+   |                                                  this job
+   |                                                  default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium
 
@@ -407,8 +409,8 @@ error[insecure-commands]: execution of insecure workflow commands is enabled
   |
 5 | / env:
 6 | |   # NOT OK
-7 | |   ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-  | |______________________________________^ insecure commands enabled here
+7 | |   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+  | |_______________________________________^ insecure commands enabled here
   |
   = note: audit confidence → High
 
@@ -417,8 +419,8 @@ error[insecure-commands]: execution of insecure workflow commands is enabled
    |
 12 | /     env:
 13 | |       # NOT OK
-14 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-   | |__________________________________________^ insecure commands enabled here
+14 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+   | |___________________________________________^ insecure commands enabled here
    |
    = note: audit confidence → High
 
@@ -427,8 +429,8 @@ error[insecure-commands]: execution of insecure workflow commands is enabled
    |
 17 | /         env:
 18 | |           # NOT OK
-19 | |           ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-   | |_______________________________________________^ insecure commands enabled here
+19 | |           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+   | |________________________________________________^ insecure commands enabled here
    |
    = note: audit confidence → High
 
@@ -914,6 +916,38 @@ error[template-injection]: code injection via template expansion
     |
     = note: audit confidence → High
 
+error[unpinned-images]: unpinned image references
+  --> .github/workflows/unpinned-images.yml:23:7
+   |
+23 |       image: fake.example.com/example
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is unpinned
+   |
+   = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+  --> .github/workflows/unpinned-images.yml:31:9
+   |
+31 |         image: fake.example.com/redis
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is unpinned
+   |
+   = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+  --> .github/workflows/unpinned-images.yml:38:7
+   |
+38 |       image: fake.example.com/example:latest
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is pinned to latest
+   |
+   = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+  --> .github/workflows/unpinned-images.yml:46:9
+   |
+46 |         image: fake.example.com/redis:latest
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is pinned to latest
+   |
+   = note: audit confidence → High
+
 warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/unpinned.yml:16:3
    |
@@ -976,6 +1010,46 @@ warning[unredacted-secrets]: leaked secret values
    |
    = note: audit confidence → High
 
+error[unsound-contains]: unsound contains condition
+  --> .github/workflows/unsound-contains.yml:26:9
+   |
+26 |         if: ${{ contains('refs/heads/main refs/heads/develop', github.ref) }}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ contains(..) condition can be bypassed if attacker can control 'github.ref'
+   |
+   = note: audit confidence → High
+
+error[unsound-contains]: unsound contains condition
+  --> .github/workflows/unsound-contains.yml:30:9
+   |
+30 |         if: ${{ contains('main,develop', env.GITHUB_REF_NAME) }}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ contains(..) condition can be bypassed if attacker can control 'env.GITHUB_REF_NAME'
+   |
+   = note: audit confidence → High
+
+error[unsound-contains]: unsound contains condition
+  --> .github/workflows/unsound-contains.yml:34:9
+   |
+34 |         if: contains('main,prod', github.ref_name) || contains('longusername anotherlongusername', github.actor) == true
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ contains(..) condition can be bypassed if attacker can control 'github.ref_name'
+   |
+   = note: audit confidence → High
+
+error[unsound-contains]: unsound contains condition
+  --> .github/workflows/unsound-contains.yml:34:9
+   |
+34 |         if: contains('main,prod', github.ref_name) || contains('longusername anotherlongusername', github.actor) == true
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ contains(..) condition can be bypassed if attacker can control 'github.actor'
+   |
+   = note: audit confidence → High
+
+info[unsound-contains]: unsound contains condition
+  --> .github/workflows/unsound-contains.yml:38:9
+   |
+38 |         if: contains('runner1,runner2', runner.name)
+   |         -------------------------------------------- info: contains(..) condition can be bypassed if attacker can control 'runner.name'
+   |
+   = note: audit confidence → High
+
 warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/workflow-run.yml:23:3
    |
@@ -1002,4 +1076,4 @@ error[dangerous-triggers]: use of fundamentally insecure workflow trigger
    |
    = note: audit confidence → Medium
 
-99 findings (13 suppressed): 0 unknown, 5 informational, 0 low, 37 medium, 44 high
+110 findings (15 suppressed): 0 unknown, 6 informational, 0 low, 37 medium, 52 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__insecure_commands-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__insecure_commands-2.snap
@@ -1,13 +1,13 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"insecure-commands.yml\")).run()?"
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:10:5
    |
 10 | /     env:
-11 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-   | |__________________________________________^ insecure commands enabled here
+11 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+   | |___________________________________________^ insecure commands enabled here
    |
    = note: audit confidence → High
 

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__insecure_commands-3.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__insecure_commands-3.snap
@@ -1,13 +1,13 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"insecure-commands/action.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:18:7
    |
 18 | /       env:
-19 | |         ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-   | |____________________________________________^ insecure commands enabled here
+19 | |         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+   | |_____________________________________________^ insecure commands enabled here
    |
    = note: audit confidence → High
 
@@ -15,8 +15,8 @@ error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:25:7
    |
 25 | /       env:
-26 | |         ACTIONS_ALLOW_UNSECURE_COMMANDS: anything
-   | |_________________________________________________^ insecure commands enabled here
+26 | |         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+   | |_____________________________________________^ insecure commands enabled here
    |
    = note: audit confidence → High
 

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__insecure_commands-4.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__insecure_commands-4.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
-expression: "zizmor().input(input_under_test(\"insecure-commands.yml\")).args([\"--persona=auditor\"]).run()?"
+expression: "zizmor().input(input_under_test(\"insecure-commands/issue-839-repro.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:10:5
    |
 10 | /     env:
-11 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-   | |___________________________________________^ insecure commands enabled here
+11 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+   | |_____________________________________________^ insecure commands enabled here
    |
    = note: audit confidence → High
 

--- a/crates/zizmor/tests/integration/test-data/insecure-commands.yml
+++ b/crates/zizmor/tests/integration/test-data/insecure-commands.yml
@@ -8,7 +8,7 @@ jobs:
   some-dangerous-job:
     runs-on: ubuntu-latest
     env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - run: echo "don't do this"
 
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
+          - ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     steps:
       - run: echo "don't do this"

--- a/crates/zizmor/tests/integration/test-data/insecure-commands/action.yml
+++ b/crates/zizmor/tests/integration/test-data/insecure-commands/action.yml
@@ -16,14 +16,14 @@ runs:
         echo "hello!"
       shell: bash
       env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     - name: true-positive-2
       run: |
         echo "hello!"
       shell: bash
       env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: anything
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     - name: true-positive-3
       run: |

--- a/crates/zizmor/tests/integration/test-data/insecure-commands/issue-839-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/insecure-commands/issue-839-repro.yml
@@ -1,0 +1,45 @@
+on: pull_request
+
+name: issue-839-repro
+
+permissions: {}
+
+jobs:
+  some-dangerous-job:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+    steps:
+      - run: echo "don't do this"
+
+  env-via-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - ACTIONS_ALLOW_UNSECURE_COMMANDS: "   true"
+
+    steps:
+      - run: echo "don't do this"
+        env: ${{ matrix.env }}
+
+  this-is-ok-1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "this is ok"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: false
+
+  this-is-ok-2:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "this is ok"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "false"
+
+  this-is-ok-3:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "this is ok"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: yes # does not evaluate to true

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ of `zizmor`.
 
 * `zizmor` now supports generating completions for Nushell (#838)
 
+### Bug Fixes 🐛
+
+* The [insecure-commands] now correctly detects different truthy
+  values in `ACTIONS_ALLOW_UNSECURE_COMMANDS` (#840)
+
 ## v1.8.0
 
 ### Announcements 📣
@@ -805,3 +810,4 @@ This is one of `zizmor`'s bigger recent releases! Key enhancements include:
 [stale-action-refs]: ./audits.md#stale-action-refs
 [unsound-contains]: ./audits.md#unsound-contains
 [unpinned-images]: ./audits.md#unpinned-images
+[insecure-commands]: ./audits.md#insecure-commands


### PR DESCRIPTION
TL;DR: We previously (incorrectly) treated any nonempty string as a "true" value for `insecure-commands`, when in reality the GitHub Actions runner uses C#'s `Boolean.TryParse` for this.

We fix our handling by reproducing `Boolean.TryParse`'s behavior.

Fixes #839.