### PR TITLE
docs: describe installation of Chimera Linux package

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -112,6 +112,18 @@ description: Installation instructions for zizmor.
     pacman -S zizmor
     ```
 
+=== "Chimera Linux"
+
+    [![Chimera Linux package](https://repology.org/badge/version-for-repo/chimera/zizmor.svg)](https://repology.org/project/zizmor/versions)
+
+    !!! note
+
+        This is a community-maintained package.
+
+    ```bash
+    apk add zizmor
+    ```
+
 === "Other ecosystems"
 
     !!! info


### PR DESCRIPTION
With https://github.com/chimera-linux/cports/pull/4255 merged, zizmor is now being built for Chimera Linux and Chimera Linux users will be able to install it from there, so I thought I'd update the docs.

How do the icons work? I've looked around and couldn't really find where they are sourced from.