### PR TITLE
Auto-Fix Feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,16 +29,16 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "once_cell",
  "serde",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -101,12 +101,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -157,9 +157,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -208,9 +208,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "shlex",
 ]
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
+checksum = "eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1"
 dependencies = [
  "clap",
  "tracing-core",
@@ -552,9 +552,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -982,11 +982,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -995,14 +994,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1020,21 +1019,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1044,30 +1044,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1075,65 +1055,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1149,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1256,6 +1223,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonschema"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,9 +1312,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1342,6 +1331,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1555,10 +1550,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "os_info"
-version = "3.10.0"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "os_info"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fc863e2ca13dc2d5c34fb22ea4a588248ac14db929616ba65c45f21744b1e9"
 dependencies = [
  "log",
  "serde",
@@ -1676,6 +1677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,7 +1697,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1748,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1768,12 +1778,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "lru-slab",
  "rand",
  "ring",
  "rustc-hash",
@@ -1788,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1841,14 +1852,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -1983,7 +1994,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -2030,9 +2041,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -2043,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
@@ -2066,18 +2077,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2086,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -2299,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2447,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2469,12 +2481,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2581,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2834,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-yaml"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c99f2b92b677f1a18b6b232fa9329afb5758118238a7d0b29cae324ef50d5e"
+checksum = "3d5893f2a05e57c86a2338aa3aed167a1e5c68b8fdff3bf4a460941f2d8fc944"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -2933,12 +2945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,11 +2958,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3157,9 +3165,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3219,25 +3236,26 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
  "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3291,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -3309,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -3364,6 +3382,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3472,16 +3499,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
@@ -3518,9 +3539,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -3530,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3542,31 +3563,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3608,10 +3609,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3620,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3643,6 +3655,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "csv",
+ "diff",
  "etcetera",
  "flate2",
  "fst",
@@ -3655,6 +3668,8 @@ dependencies = [
  "indicatif",
  "insta",
  "itertools",
+ "json-patch",
+ "jsonptr",
  "jsonschema",
  "line-index",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +184,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -314,6 +335,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +438,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,12 +548,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -504,6 +642,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -626,6 +765,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -779,6 +933,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +1002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +1028,15 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -998,6 +1182,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1215,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1102,6 +1326,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1272,6 +1502,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,13 +1653,30 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1544,6 +1806,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e9beda9d92fac7bf4904c34c83340ef1024159faee67179a04e0277523da33"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1870,50 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_info"
@@ -1671,6 +2031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +2110,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.101",
 ]
 
@@ -1970,11 +2358,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1987,12 +2377,15 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.11",
  "windows-registry",
@@ -2118,6 +2511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "schemafy_core"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2551,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -2618,9 +3043,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2644,6 +3069,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +3095,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -2737,6 +3185,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2893,10 +3342,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -2909,6 +3373,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2983,6 +3453,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3141,6 +3617,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3672,6 +4161,7 @@ dependencies = [
  "jsonptr",
  "jsonschema",
  "line-index",
+ "oci-client",
  "owo-colors",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ reqwest = { version = "0.12.15", default-features = false }
 reqwest-middleware = "0.4.2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde-sarif = "0.8.0"
-serde_json = "1.0.140"
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_json_path = "0.7.2"
 serde_yaml = "0.9.34"
 tar = "0.4.44"

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -63,6 +63,9 @@ tree-sitter.workspace = true
 tree-sitter-bash.workspace = true
 tree-sitter-powershell.workspace = true
 yamlpath.workspace = true
+diff = "0.1.13"
+json-patch = "4.0.0"
+jsonptr = "0.7"
 
 [build-dependencies]
 csv.workspace = true

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -66,6 +66,7 @@ yamlpath.workspace = true
 diff = "0.1.13"
 json-patch = "4.0.0"
 jsonptr = "0.7"
+oci-client = "0.15.0"
 
 [build-dependencies]
 csv.workspace = true

--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 
 use super::{Audit, AuditLoadError, audit_meta};
-use crate::finding::{Confidence, Finding, Severity};
+use crate::finding::{Confidence, Finding, Fix, Severity};
 use crate::models::Workflow;
 use crate::state::AuditState;
+use crate::{apply_yaml_patch, yaml_patch::YamlPatchOperation};
 
 pub(crate) struct DangerousTriggers;
 
@@ -13,6 +14,158 @@ audit_meta!(
     "use of fundamentally insecure workflow trigger"
 );
 
+impl DangerousTriggers {
+    /// Create a fix for replacing pull_request_target with pull_request
+    fn create_pull_request_target_fix() -> Fix {
+        Fix {
+            title: "Replace pull_request_target with pull_request".to_string(),
+            description: "Replace 'pull_request_target' with 'pull_request' to run workflows in the context of the fork repository instead of the base repository. This is safer as it prevents access to secrets and write permissions for external contributors. Only use 'pull_request_target' if you absolutely need repository write permissions.".to_string(),
+            apply: apply_yaml_patch!(vec![
+                YamlPatchOperation::Replace {
+                    path: "/on/pull_request_target".to_string(),
+                    value: serde_yaml::Value::Null,
+                },
+                YamlPatchOperation::Add {
+                    path: "/on".to_string(),
+                    key: "pull_request".to_string(),
+                    value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+                },
+            ]),
+        }
+    }
+
+    /// Create a fix for replacing workflow_run with workflow_call
+    fn create_workflow_run_fix() -> Fix {
+        Fix {
+            title: "Replace workflow_run with workflow_call".to_string(),
+            description: "Replace 'workflow_run' trigger with 'workflow_call' and convert this to a reusable workflow. This requires refactoring the workflow to accept inputs and be called by other workflows instead of being triggered automatically. This is much safer as it eliminates the risk of unexpected triggering and provides better control over when the workflow runs.".to_string(),
+            apply: apply_yaml_patch!(vec![
+                YamlPatchOperation::Replace {
+                    path: "/on/workflow_run".to_string(),
+                    value: serde_yaml::Value::Null,
+                },
+                YamlPatchOperation::Add {
+                    path: "/on".to_string(),
+                    key: "workflow_call".to_string(),
+                    value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+                },
+            ]),
+        }
+    }
+
+    /// Create a fix for bare pull_request_target trigger
+    fn create_bare_pull_request_target_fix() -> Fix {
+        Fix {
+            title: "Replace pull_request_target with pull_request".to_string(),
+            description: "Replace 'pull_request_target' with 'pull_request' to run workflows in the context of the fork repository instead of the base repository. This is safer as it prevents access to secrets and write permissions for external contributors.".to_string(),
+            apply: apply_yaml_patch!(vec![
+                YamlPatchOperation::Replace {
+                    path: "/on".to_string(),
+                    value: serde_yaml::Value::String("pull_request".to_string()),
+                },
+            ]),
+        }
+    }
+
+    /// Create a fix for bare workflow_run trigger
+    fn create_bare_workflow_run_fix() -> Fix {
+        Fix {
+            title: "Replace workflow_run with workflow_call".to_string(),
+            description: "Replace 'workflow_run' with 'workflow_call' and convert this to a reusable workflow. This requires refactoring the workflow to accept inputs and be called by other workflows.".to_string(),
+            apply: apply_yaml_patch!(vec![
+                YamlPatchOperation::Replace {
+                    path: "/on".to_string(),
+                    value: serde_yaml::Value::String("workflow_call".to_string()),
+                },
+            ]),
+        }
+    }
+
+    /// Create a fix for pull_request_target in array format
+    fn create_array_pull_request_target_fix() -> Fix {
+        Fix {
+            title: "Replace pull_request_target with pull_request in trigger list".to_string(),
+            description: "Replace 'pull_request_target' with 'pull_request' in the trigger list to run workflows more securely.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Parse the YAML to find and replace pull_request_target in arrays
+                let mut yaml: serde_yaml::Value = serde_yaml::from_str(content)?;
+
+                if let Some(on_value) = yaml.get_mut("on") {
+                    if let serde_yaml::Value::Sequence(events) = on_value {
+                        for event in events.iter_mut() {
+                            if let serde_yaml::Value::String(event_str) = event {
+                                if event_str == "pull_request_target" {
+                                    *event_str = "pull_request".to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok(Some(serde_yaml::to_string(&yaml)?))
+            }),
+        }
+    }
+
+    /// Create a fix for workflow_run in array format
+    fn create_array_workflow_run_fix() -> Fix {
+        Fix {
+            title: "Replace workflow_run with workflow_call in trigger list".to_string(),
+            description: "Replace 'workflow_run' with 'workflow_call' in the trigger list and convert this to a reusable workflow.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Parse the YAML to find and replace workflow_run in arrays
+                let mut yaml: serde_yaml::Value = serde_yaml::from_str(content)?;
+
+                if let Some(on_value) = yaml.get_mut("on") {
+                    if let serde_yaml::Value::Sequence(events) = on_value {
+                        for event in events.iter_mut() {
+                            if let serde_yaml::Value::String(event_str) = event {
+                                if event_str == "workflow_run" {
+                                    *event_str = "workflow_call".to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok(Some(serde_yaml::to_string(&yaml)?))
+            }),
+        }
+    }
+
+    /// Determine the appropriate fix based on the trigger structure
+    fn get_trigger_fix(workflow: &Workflow, is_pull_request_target: bool) -> Option<Fix> {
+        use github_actions_models::workflow::Trigger;
+
+        match &workflow.on {
+            // Single bare event: on: pull_request_target
+            Trigger::BareEvent(_) => {
+                if is_pull_request_target {
+                    Some(Self::create_bare_pull_request_target_fix())
+                } else {
+                    Some(Self::create_bare_workflow_run_fix())
+                }
+            }
+            // Array of events: on: [push, pull_request_target]
+            Trigger::BareEvents(_) => {
+                if is_pull_request_target {
+                    Some(Self::create_array_pull_request_target_fix())
+                } else {
+                    Some(Self::create_array_workflow_run_fix())
+                }
+            }
+            // Object with event configurations: on: { pull_request_target: { ... } }
+            Trigger::Events(_) => {
+                if is_pull_request_target {
+                    Some(Self::create_pull_request_target_fix())
+                } else {
+                    Some(Self::create_workflow_run_fix())
+                }
+            }
+        }
+    }
+}
+
 impl Audit for DangerousTriggers {
     fn new(_state: &AuditState<'_>) -> Result<Self, AuditLoadError> {
         Ok(Self)
@@ -20,35 +173,43 @@ impl Audit for DangerousTriggers {
 
     fn audit_workflow<'doc>(&self, workflow: &'doc Workflow) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
+
         if workflow.has_pull_request_target() {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::Medium)
-                    .severity(Severity::High)
-                    .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(&["on".into()])
-                            .annotated("pull_request_target is almost always used insecurely"),
-                    )
-                    .build(workflow)?,
-            );
+            let mut finding_builder = Self::finding()
+                .confidence(Confidence::Medium)
+                .severity(Severity::High)
+                .add_location(
+                    workflow
+                        .location()
+                        .primary()
+                        .with_keys(&["on".into()])
+                        .annotated("pull_request_target is almost always used insecurely"),
+                );
+
+            if let Some(fix) = Self::get_trigger_fix(workflow, true) {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(workflow)?);
         }
+
         if workflow.has_workflow_run() {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::Medium)
-                    .severity(Severity::High)
-                    .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(&["on".into()])
-                            .annotated("workflow_run is almost always used insecurely"),
-                    )
-                    .build(workflow)?,
-            );
+            let mut finding_builder = Self::finding()
+                .confidence(Confidence::Medium)
+                .severity(Severity::High)
+                .add_location(
+                    workflow
+                        .location()
+                        .primary()
+                        .with_keys(&["on".into()])
+                        .annotated("workflow_run is almost always used insecurely"),
+                );
+
+            if let Some(fix) = Self::get_trigger_fix(workflow, false) {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(workflow)?);
         }
 
         Ok(findings)

--- a/crates/zizmor/src/audit/forbidden_uses.rs
+++ b/crates/zizmor/src/audit/forbidden_uses.rs
@@ -2,9 +2,13 @@ use anyhow::{Context, anyhow};
 use github_actions_models::common::Uses;
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
-use crate::finding::{Confidence, Finding, Persona, Severity};
-use crate::models::uses::RepositoryUsesPattern;
-use crate::models::{CompositeStep, Step, StepCommon};
+use crate::{
+    apply_yaml_patch,
+    finding::{Confidence, Finding, Fix, Persona, Severity},
+    models::{CompositeStep, Step, StepCommon},
+    models::{JobExt, uses::RepositoryUsesPattern},
+    yaml_patch::YamlPatchOperation,
+};
 use serde::Deserialize;
 
 pub(crate) struct ForbiddenUses {
@@ -36,33 +40,125 @@ impl ForbiddenUses {
         }
     }
 
-    fn process_step<'doc>(
-        &self,
-        step: &impl StepCommon<'doc>,
-    ) -> anyhow::Result<Vec<Finding<'doc>>> {
-        let mut findings = vec![];
+    /// Create a fix for removing a forbidden step entirely
+    fn create_remove_step_fix(job_id: &str, step_index: usize) -> Fix {
+        let step_path = format!("/jobs/{}/steps/{}", job_id, step_index);
 
-        let Some(uses) = step.uses() else {
-            return Ok(findings);
-        };
+        Fix {
+            title: "Remove forbidden action step".to_string(),
+            description: "Remove this step that uses a forbidden action. You may need to replace it with an alternative action or implement the functionality differently.".to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: step_path,
+            }]),
+        }
+    }
 
-        if self.use_denied(uses) {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::High)
-                    .severity(Severity::High)
-                    .persona(Persona::Regular)
-                    .add_location(
-                        step.location()
-                            .primary()
-                            .with_keys(&["uses".into()])
-                            .annotated("use of this action is forbidden"),
-                    )
-                    .build(step)?,
-            );
-        };
+    /// Create a fix suggesting an alternative action
+    fn create_replace_action_fix(job_id: &str, step_index: usize, suggested_action: &str) -> Fix {
+        let uses_path = format!("/jobs/{}/steps/{}/uses", job_id, step_index);
 
-        Ok(findings)
+        Fix {
+            title: format!("Replace with {}", suggested_action),
+            description: format!(
+                "Replace the forbidden action with the suggested alternative: {}. Note that you may need to adjust the 'with' inputs and other step configuration to match the new action's interface.",
+                suggested_action
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: uses_path,
+                value: serde_yaml::Value::String(suggested_action.to_string()),
+            }]),
+        }
+    }
+
+    /// Try to suggest an alternative action for common forbidden actions
+    fn suggest_alternative(&self, uses: &Uses) -> Option<String> {
+        if let Uses::Repository(repo_uses) = uses {
+            // Create the full action string including version if present
+            let action_string = if let Some(ref git_ref) = repo_uses.git_ref {
+                format!("{}/{}@{}", repo_uses.owner, repo_uses.repo, git_ref)
+            } else {
+                format!("{}/{}", repo_uses.owner, repo_uses.repo)
+            };
+
+            // Common alternatives for frequently forbidden actions
+            match action_string.as_str() {
+                // Old checkout versions
+                "actions/checkout@v1" | "actions/checkout@v2" => {
+                    Some("actions/checkout@v4".to_string())
+                }
+                // Old setup-node versions
+                "actions/setup-node@v1" | "actions/setup-node@v2" => {
+                    Some("actions/setup-node@v4".to_string())
+                }
+                // Old setup-python versions
+                "actions/setup-python@v1" | "actions/setup-python@v2" => {
+                    Some("actions/setup-python@v5".to_string())
+                }
+                // Security-problematic actions with safer alternatives
+                "actions/upload-artifact@v1" | "actions/upload-artifact@v2" => {
+                    Some("actions/upload-artifact@v4".to_string())
+                }
+                "actions/download-artifact@v1" | "actions/download-artifact@v2" => {
+                    Some("actions/download-artifact@v4".to_string())
+                }
+                // Common third-party actions that might be replaced
+                "codecov/codecov-action@v1" => Some("codecov/codecov-action@v4".to_string()),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Get the appropriate fix for a forbidden use in a workflow step
+    fn get_fix_for_step(&self, step: &Step, uses: &Uses) -> Option<Fix> {
+        let job_id = step.job().id();
+        let step_index = step.index;
+
+        // Try to suggest an alternative first
+        if let Some(alternative) = self.suggest_alternative(uses) {
+            Some(Self::create_replace_action_fix(
+                job_id,
+                step_index,
+                &alternative,
+            ))
+        } else {
+            // Fall back to removal if no alternative is available
+            Some(Self::create_remove_step_fix(job_id, step_index))
+        }
+    }
+
+    /// Get the appropriate fix for a forbidden use in a composite step
+    fn get_fix_for_composite_step(&self, step: &CompositeStep, uses: &Uses) -> Option<Fix> {
+        let step_index = step.index;
+
+        // For composite steps, the path is different: /runs/steps/{index}
+        let step_path = format!("/runs/steps/{}", step_index);
+        let uses_path = format!("/runs/steps/{}/uses", step_index);
+
+        // Try to suggest an alternative first
+        if let Some(alternative) = self.suggest_alternative(uses) {
+            Some(Fix {
+                title: format!("Replace with {}", alternative),
+                description: format!(
+                    "Replace the forbidden action with the suggested alternative: {}. Note that you may need to adjust the 'with' inputs and other step configuration to match the new action's interface.",
+                    alternative
+                ),
+                apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                    path: uses_path,
+                    value: serde_yaml::Value::String(alternative),
+                }]),
+            })
+        } else {
+            // Fall back to removal if no alternative is available
+            Some(Fix {
+                title: "Remove forbidden action step".to_string(),
+                description: "Remove this step that uses a forbidden action. You may need to replace it with an alternative action or implement the functionality differently.".to_string(),
+                apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                    path: step_path,
+                }]),
+            })
+        }
     }
 }
 
@@ -84,14 +180,70 @@ impl Audit for ForbiddenUses {
     }
 
     fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
-        self.process_step(step)
+        let mut findings = vec![];
+
+        let Some(uses) = step.uses() else {
+            return Ok(findings);
+        };
+
+        if self.use_denied(uses) {
+            let finding_builder = Self::finding()
+                .confidence(Confidence::High)
+                .severity(Severity::High)
+                .persona(Persona::Regular)
+                .add_location(
+                    step.location()
+                        .primary()
+                        .with_keys(&["uses".into()])
+                        .annotated("use of this action is forbidden"),
+                );
+
+            // Add fix if we can determine one
+            let finding_builder = if let Some(fix) = self.get_fix_for_step(step, uses) {
+                finding_builder.fix(fix)
+            } else {
+                finding_builder
+            };
+
+            findings.push(finding_builder.build(step)?);
+        };
+
+        Ok(findings)
     }
 
     fn audit_composite_step<'a>(
         &self,
         step: &CompositeStep<'a>,
     ) -> anyhow::Result<Vec<Finding<'a>>> {
-        self.process_step(step)
+        let mut findings = vec![];
+
+        let Some(uses) = step.uses() else {
+            return Ok(findings);
+        };
+
+        if self.use_denied(uses) {
+            let finding_builder = Self::finding()
+                .confidence(Confidence::High)
+                .severity(Severity::High)
+                .persona(Persona::Regular)
+                .add_location(
+                    step.location()
+                        .primary()
+                        .with_keys(&["uses".into()])
+                        .annotated("use of this action is forbidden"),
+                );
+
+            // Add fix if we can determine one
+            let finding_builder = if let Some(fix) = self.get_fix_for_composite_step(step, uses) {
+                finding_builder.fix(fix)
+            } else {
+                finding_builder
+            };
+
+            findings.push(finding_builder.build(step)?);
+        };
+
+        Ok(findings)
     }
 }
 

--- a/crates/zizmor/src/audit/hardcoded_container_credentials.rs
+++ b/crates/zizmor/src/audit/hardcoded_container_credentials.rs
@@ -5,9 +5,11 @@ use github_actions_models::{
 
 use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::{
-    finding::{Confidence, Severity},
+    apply_yaml_patch,
+    finding::{Confidence, Fix, Severity},
     models::JobExt as _,
     state::AuditState,
+    yaml_patch::YamlPatchOperation,
 };
 
 pub(crate) struct HardcodedContainerCredentials;
@@ -17,6 +19,156 @@ audit_meta!(
     "hardcoded-container-credentials",
     "hardcoded credential in GitHub Actions container configurations"
 );
+
+/// Represents the different types of credential fields that can be hardcoded
+#[derive(Debug, Clone, Copy)]
+enum CredentialField {
+    Username,
+    Password,
+}
+
+impl CredentialField {
+    fn field_name(&self) -> &'static str {
+        match self {
+            CredentialField::Username => "username",
+            CredentialField::Password => "password",
+        }
+    }
+
+    fn secret_suffix(&self) -> &'static str {
+        match self {
+            CredentialField::Username => "USERNAME",
+            CredentialField::Password => "PASSWORD",
+        }
+    }
+
+    fn display_name(&self) -> &'static str {
+        match self {
+            CredentialField::Username => "username",
+            CredentialField::Password => "password",
+        }
+    }
+}
+
+impl HardcodedContainerCredentials {
+    /// Generate a secret name for a given credential field and context
+    fn get_secret_name(credential_field: CredentialField, credential_type: &str) -> String {
+        match credential_type {
+            "container" => format!("REGISTRY_{}", credential_field.secret_suffix()),
+            service => format!(
+                "{}_REGISTRY_{}",
+                service.to_uppercase().replace('-', "_"),
+                credential_field.secret_suffix()
+            ),
+        }
+    }
+
+    /// Create a fix that replaces hardcoded credential with a secret reference
+    fn create_secret_replacement_fix(
+        path: &str,
+        credential_field: CredentialField,
+        credential_type: &str,
+    ) -> Fix {
+        let secret_name = Self::get_secret_name(credential_field, credential_type);
+        let field_name = credential_field.field_name();
+        let display_name = credential_field.display_name();
+
+        Fix {
+            title: format!(
+                "Replace hardcoded {} {} with secret",
+                credential_type, display_name
+            ),
+            description: format!(
+                "Replace the hardcoded {} with a reference to a GitHub secret. \
+                Create a secret named '{}' in your repository settings (Settings → Secrets and variables → Actions) \
+                and reference it using '${{{{ secrets.{} }}}}'. This prevents the {} from being exposed in your workflow file.",
+                display_name, secret_name, secret_name, display_name
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: format!("{}/{}", path, field_name),
+                value: serde_yaml::Value::String(format!("${{{{ secrets.{} }}}}", secret_name)),
+            }]),
+        }
+    }
+
+    /// Get the appropriate fix for a hardcoded credential field
+    fn get_fix_for_credential(
+        job_id: &str,
+        credential_field: CredentialField,
+        credential_type: &str,
+        is_service: bool,
+        service_name: Option<&str>,
+    ) -> Fix {
+        let path = if is_service {
+            format!(
+                "/jobs/{}/services/{}/credentials",
+                job_id,
+                service_name.unwrap()
+            )
+        } else {
+            format!("/jobs/{}/container/credentials", job_id)
+        };
+
+        Self::create_secret_replacement_fix(&path, credential_field, credential_type)
+    }
+
+    /// Check if a credential field is hardcoded and create a finding if so
+    fn check_and_create_finding<'doc>(
+        &self,
+        workflow: &'doc crate::models::Workflow,
+        job: &super::NormalJob<'doc>,
+        credential_field: CredentialField,
+        _credential_value: &str,
+        credential_type: &str,
+        is_service: bool,
+        service_name: Option<&'doc str>,
+        findings: &mut Vec<crate::finding::Finding<'doc>>,
+    ) -> anyhow::Result<()> {
+        let display_name = credential_field.display_name();
+        let annotation = if is_service {
+            format!(
+                "service {}: container registry {} is hard-coded",
+                service_name.unwrap(),
+                display_name
+            )
+        } else {
+            format!("container registry {} is hard-coded", display_name)
+        };
+
+        let location_keys = if is_service {
+            vec![
+                "services".into(),
+                service_name.unwrap().into(),
+                "credentials".into(),
+            ]
+        } else {
+            vec!["container".into(), "credentials".into()]
+        };
+
+        let fix = Self::get_fix_for_credential(
+            job.id(),
+            credential_field,
+            credential_type,
+            is_service,
+            service_name,
+        );
+
+        let finding = Self::finding()
+            .severity(Severity::High)
+            .confidence(Confidence::High)
+            .add_location(
+                job.location()
+                    .primary()
+                    .with_keys(&location_keys)
+                    .annotated(annotation),
+            )
+            .fix(fix)
+            .build(workflow)?;
+
+        findings.push(finding);
+        Ok(())
+    }
+}
 
 impl Audit for HardcodedContainerCredentials {
     fn new(_state: &AuditState<'_>) -> Result<Self, AuditLoadError>
@@ -37,64 +189,84 @@ impl Audit for HardcodedContainerCredentials {
                 continue;
             };
 
+            // Check container credentials
             if let Some(Container::Container {
                 image: _,
-                credentials:
-                    Some(DockerCredentials {
-                        username: _,
-                        password: Some(password),
-                    }),
+                credentials: Some(DockerCredentials { username, password }),
                 ..
             }) = &job.container
             {
-                // If the password doesn't parse as an expression, it's hardcoded.
-                if ExplicitExpr::from_curly(password).is_none() {
-                    findings.push(
-                        Self::finding()
-                            .severity(Severity::High)
-                            .confidence(Confidence::High)
-                            .add_location(
-                                job.location()
-                                    .primary()
-                                    .with_keys(&["container".into(), "credentials".into()])
-                                    .annotated("container registry password is hard-coded"),
-                            )
-                            .build(workflow)?,
-                    )
+                // Check username if present
+                if let Some(username) = username {
+                    if ExplicitExpr::from_curly(username).is_none() {
+                        self.check_and_create_finding(
+                            workflow,
+                            job,
+                            CredentialField::Username,
+                            username,
+                            "container",
+                            false,
+                            None,
+                            &mut findings,
+                        )?;
+                    }
+                }
+
+                // Check password if present
+                if let Some(password) = password {
+                    if ExplicitExpr::from_curly(password).is_none() {
+                        self.check_and_create_finding(
+                            workflow,
+                            job,
+                            CredentialField::Password,
+                            password,
+                            "container",
+                            false,
+                            None,
+                            &mut findings,
+                        )?;
+                    }
                 }
             }
 
+            // Check service credentials
             for (service, config) in job.services.iter() {
                 if let Container::Container {
                     image: _,
-                    credentials:
-                        Some(DockerCredentials {
-                            username: _,
-                            password: Some(password),
-                        }),
+                    credentials: Some(DockerCredentials { username, password }),
                     ..
                 } = &config
                 {
-                    if ExplicitExpr::from_curly(password).is_none() {
-                        findings.push(
-                            Self::finding()
-                                .severity(Severity::High)
-                                .confidence(Confidence::High)
-                                .add_location(
-                                    job.location()
-                                        .primary()
-                                        .with_keys(&[
-                                            "services".into(),
-                                            service.as_str().into(),
-                                            "credentials".into(),
-                                        ])
-                                        .annotated(format!(
-                                            "service {service}: container registry password is \
-                                         hard-coded"
-                                        )),
-                                )
-                                .build(workflow)?,
-                        )
+                    // Check username if present
+                    if let Some(username) = username {
+                        if ExplicitExpr::from_curly(username).is_none() {
+                            self.check_and_create_finding(
+                                workflow,
+                                job,
+                                CredentialField::Username,
+                                username,
+                                service.as_str(),
+                                true,
+                                Some(service.as_str()),
+                                &mut findings,
+                            )?;
+                        }
+                    }
+
+                    // Check password if present
+                    if let Some(password) = password {
+                        if ExplicitExpr::from_curly(password).is_none() {
+                            self.check_and_create_finding(
+                                workflow,
+                                job,
+                                CredentialField::Password,
+                                password,
+                                service.as_str(),
+                                true,
+                                Some(service.as_str()),
+                                &mut findings,
+                            )?;
+                        }
                     }
                 }
             }

--- a/crates/zizmor/src/audit/impostor_commit.rs
+++ b/crates/zizmor/src/audit/impostor_commit.rs
@@ -10,10 +10,12 @@ use github_actions_models::common::{RepositoryUses, Uses};
 
 use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::{
-    finding::{Confidence, Finding, Severity},
+    apply_yaml_patch,
+    finding::{Confidence, Finding, Fix, Severity},
     github_api::{self, ComparisonStatus},
     models::{JobExt as _, StepCommon, Workflow, uses::RepositoryUsesExt as _},
     state::AuditState,
+    yaml_patch::YamlPatchOperation,
 };
 
 pub const IMPOSTOR_ANNOTATION: &str = "uses a commit that doesn't belong to the specified org/repo";
@@ -110,6 +112,111 @@ impl ImpostorCommit {
         );
         Ok(true)
     }
+
+    /// Create a fix that replaces an impostor commit with a legitimate tag reference
+    fn create_tag_replacement_fix(path: &str, uses: &RepositoryUses, suggested_tag: &str) -> Fix {
+        let current_ref = uses.git_ref.as_deref().unwrap_or("unknown");
+        let replacement_uses = format!("{}/{}@{}", uses.owner, uses.repo, suggested_tag);
+
+        Fix {
+            title: format!("Replace impostor commit with tag {}", suggested_tag),
+            description: format!(
+                "Replace the impostor commit '{}' with the legitimate tag '{}'. \
+                This ensures you're using a verified release from the actual repository. \
+                The suggested tag '{}' is the latest available tag from {}/{}.",
+                current_ref, suggested_tag, suggested_tag, uses.owner, uses.repo
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: path.to_string(),
+                value: serde_yaml::Value::String(replacement_uses),
+            }]),
+        }
+    }
+
+    /// Create a fix that replaces an impostor commit with a branch reference
+    fn create_branch_replacement_fix(
+        path: &str,
+        uses: &RepositoryUses,
+        suggested_branch: &str,
+    ) -> Fix {
+        let current_ref = uses.git_ref.as_deref().unwrap_or("unknown");
+        let replacement_uses = format!("{}/{}@{}", uses.owner, uses.repo, suggested_branch);
+
+        Fix {
+            title: format!("Replace impostor commit with branch {}", suggested_branch),
+            description: format!(
+                "Replace the impostor commit '{}' with the legitimate branch '{}'. \
+                This ensures you're using code from the actual repository. \
+                Note that using branch references may introduce variability as the branch can change. \
+                Consider using a specific tag for more stability.",
+                current_ref, suggested_branch
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: path.to_string(),
+                value: serde_yaml::Value::String(replacement_uses),
+            }]),
+        }
+    }
+
+    /// Create a fix that removes the step or job entirely
+    fn create_removal_fix(path: &str, item_type: &str) -> Fix {
+        Fix {
+            title: format!("Remove {} with impostor commit", item_type),
+            description: format!(
+                "Remove this {} that uses an impostor commit. This eliminates the security risk \
+                but you may need to replace the functionality with an alternative action or implementation. \
+                Only use this fix if you cannot find a legitimate alternative reference.",
+                item_type
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: path.to_string(),
+            }]),
+        }
+    }
+
+    /// Get the most appropriate fix for an impostor commit
+    fn get_impostor_fix(&self, uses: &RepositoryUses, path: &str, item_type: &str) -> Result<Fix> {
+        // Try to get tags and branches for suggestions
+        let tags_result = self.client.list_tags(&uses.owner, &uses.repo);
+        let branches_result = self.client.list_branches(&uses.owner, &uses.repo);
+
+        // If we can get tags, suggest the latest tag
+        if let Ok(tags) = tags_result {
+            if let Some(latest_tag) = tags.first() {
+                return Ok(Self::create_tag_replacement_fix(
+                    path,
+                    uses,
+                    &latest_tag.name,
+                ));
+            }
+        }
+
+        // If no tags available, try to suggest a main/master branch
+        if let Ok(branches) = branches_result {
+            // Look for common default branch names
+            for default_branch in &["main", "master"] {
+                if branches.iter().any(|b| b.name == *default_branch) {
+                    return Ok(Self::create_branch_replacement_fix(
+                        path,
+                        uses,
+                        default_branch,
+                    ));
+                }
+            }
+
+            // If no standard default branch, suggest the first available branch
+            if let Some(first_branch) = branches.first() {
+                return Ok(Self::create_branch_replacement_fix(
+                    path,
+                    uses,
+                    &first_branch.name,
+                ));
+            }
+        }
+
+        // If we can't suggest an alternative, offer removal as last resort
+        Ok(Self::create_removal_fix(path, item_type))
+    }
 }
 
 impl Audit for ImpostorCommit {
@@ -141,15 +248,22 @@ impl Audit for ImpostorCommit {
                         };
 
                         if self.impostor(uses)? {
-                            findings.push(
-                                Self::finding()
-                                    .severity(Severity::High)
-                                    .confidence(Confidence::High)
-                                    .add_location(
-                                        step.location().primary().annotated(IMPOSTOR_ANNOTATION),
-                                    )
-                                    .build(workflow)?,
-                            );
+                            let step_path =
+                                format!("/jobs/{}/steps/{}/uses", normal.id(), step.index);
+
+                            let mut finding_builder = Self::finding()
+                                .severity(Severity::High)
+                                .confidence(Confidence::High)
+                                .add_location(
+                                    step.location().primary().annotated(IMPOSTOR_ANNOTATION),
+                                );
+
+                            // Try to add a fix
+                            if let Ok(fix) = self.get_impostor_fix(uses, &step_path, "step") {
+                                finding_builder = finding_builder.fix(fix);
+                            }
+
+                            findings.push(finding_builder.build(workflow)?);
                         }
                     }
                 }
@@ -161,15 +275,23 @@ impl Audit for ImpostorCommit {
                     };
 
                     if self.impostor(uses)? {
-                        findings.push(
-                            Self::finding()
-                                .severity(Severity::High)
-                                .confidence(Confidence::High)
-                                .add_location(
-                                    reusable.location().primary().annotated(IMPOSTOR_ANNOTATION),
-                                )
-                                .build(workflow)?,
-                        );
+                        let job_path = format!("/jobs/{}/uses", reusable.id());
+
+                        let mut finding_builder = Self::finding()
+                            .severity(Severity::High)
+                            .confidence(Confidence::High)
+                            .add_location(
+                                reusable.location().primary().annotated(IMPOSTOR_ANNOTATION),
+                            );
+
+                        // Try to add a fix
+                        if let Ok(fix) =
+                            self.get_impostor_fix(uses, &job_path, "reusable workflow call")
+                        {
+                            finding_builder = finding_builder.fix(fix);
+                        }
+
+                        findings.push(finding_builder.build(workflow)?);
                     }
                 }
             }
@@ -188,15 +310,79 @@ impl Audit for ImpostorCommit {
         };
 
         if self.impostor(uses)? {
-            findings.push(
-                Self::finding()
-                    .severity(Severity::High)
-                    .confidence(Confidence::High)
-                    .add_location(step.location().primary().annotated(IMPOSTOR_ANNOTATION))
-                    .build(step.action())?,
-            );
+            let step_path = format!("/runs/steps/{}/uses", step.index);
+
+            let mut finding_builder = Self::finding()
+                .severity(Severity::High)
+                .confidence(Confidence::High)
+                .add_location(step.location().primary().annotated(IMPOSTOR_ANNOTATION));
+
+            // Try to add a fix
+            if let Ok(fix) = self.get_impostor_fix(uses, &step_path, "composite step") {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(step.action())?);
         }
 
         Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use github_actions_models::common::RepositoryUses;
+
+    #[test]
+    fn test_create_tag_replacement_fix() {
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("abcd1234567890abcd1234567890abcd12345678".to_string()),
+            subpath: None,
+        };
+
+        let fix =
+            ImpostorCommit::create_tag_replacement_fix("/jobs/test/steps/0/uses", &uses, "v4");
+
+        assert_eq!(fix.title, "Replace impostor commit with tag v4");
+        assert!(
+            fix.description
+                .contains("abcd1234567890abcd1234567890abcd12345678")
+        );
+        assert!(fix.description.contains("v4"));
+        assert!(fix.description.contains("actions/checkout"));
+    }
+
+    #[test]
+    fn test_create_branch_replacement_fix() {
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("abcd1234567890abcd1234567890abcd12345678".to_string()),
+            subpath: None,
+        };
+
+        let fix =
+            ImpostorCommit::create_branch_replacement_fix("/jobs/test/steps/0/uses", &uses, "main");
+
+        assert_eq!(fix.title, "Replace impostor commit with branch main");
+        assert!(
+            fix.description
+                .contains("abcd1234567890abcd1234567890abcd12345678")
+        );
+        assert!(fix.description.contains("main"));
+        assert!(fix.description.contains("legitimate branch"));
+        assert!(fix.description.contains("actual repository"));
+    }
+
+    #[test]
+    fn test_create_removal_fix() {
+        let fix = ImpostorCommit::create_removal_fix("/jobs/test/steps/0", "step");
+
+        assert_eq!(fix.title, "Remove step with impostor commit");
+        assert!(fix.description.contains("Remove this step"));
+        assert!(fix.description.contains("security risk"));
     }
 }

--- a/crates/zizmor/src/audit/insecure_commands.rs
+++ b/crates/zizmor/src/audit/insecure_commands.rs
@@ -8,9 +8,10 @@ use github_actions_models::workflow::job::StepBody;
 
 use super::{AuditLoadError, Job, audit_meta};
 use crate::audit::Audit;
-use crate::finding::{Confidence, Finding, Persona, Severity, SymbolicLocation};
+use crate::finding::{Confidence, Finding, Fix, Persona, Severity, SymbolicLocation};
 use crate::models::{AsDocument, JobExt as _, StepCommon, Steps, Workflow};
 use crate::state::AuditState;
+use crate::{apply_yaml_patch, yaml_patch::YamlPatchOperation};
 
 pub(crate) struct InsecureCommands;
 
@@ -21,6 +22,119 @@ audit_meta!(
 );
 
 impl InsecureCommands {
+    /// Create a fix that removes the ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable
+    fn create_remove_env_var_fix(path: &str, context: &str) -> Fix {
+        Fix {
+            title: format!("Remove ACTIONS_ALLOW_UNSECURE_COMMANDS from {}", context),
+            description: format!(
+                "Remove the ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable from the {} environment. \
+                This prevents the execution of insecure workflow commands, which is the recommended security practice. \
+                Insecure commands like `::set-env` and `::add-path` can be exploited for code injection attacks.",
+                context
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: format!("{}/ACTIONS_ALLOW_UNSECURE_COMMANDS", path),
+            }]),
+        }
+    }
+
+    /// Create a fix that sets ACTIONS_ALLOW_UNSECURE_COMMANDS to false
+    fn create_disable_fix(path: &str, context: &str) -> Fix {
+        Fix {
+            title: format!(
+                "Set ACTIONS_ALLOW_UNSECURE_COMMANDS to false in {}",
+                context
+            ),
+            description: format!(
+                "Explicitly set ACTIONS_ALLOW_UNSECURE_COMMANDS to false in the {} environment. \
+                This makes the security intent clear and prevents the execution of insecure workflow commands. \
+                While removing the variable entirely is also effective, this approach is more explicit.",
+                context
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: format!("{}/ACTIONS_ALLOW_UNSECURE_COMMANDS", path),
+                value: serde_yaml::Value::String("false".to_string()),
+            }]),
+        }
+    }
+
+    /// Create a fix that removes the entire step that enables insecure commands
+    fn create_remove_step_fix(job_id: &str, step_index: usize) -> Fix {
+        let step_path = format!("/jobs/{}/steps/{}", job_id, step_index);
+
+        Fix {
+            title: "Remove step with insecure commands enabled".to_string(),
+            description: "Remove this step that enables insecure workflow commands. This eliminates the security risk \
+                but you may need to replace the functionality with secure alternatives. Consider using step outputs, \
+                job outputs, or environment variables set at the workflow level instead of insecure commands.".to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: step_path,
+            }]),
+        }
+    }
+
+    /// Create a fix that removes the entire job that enables insecure commands
+    fn create_remove_job_fix(job_id: &str) -> Fix {
+        let job_path = format!("/jobs/{}", job_id);
+
+        Fix {
+            title: "Remove job with insecure commands enabled".to_string(),
+            description: "Remove this job that enables insecure workflow commands. This eliminates the security risk \
+                but you may need to replace the job functionality. Consider restructuring the workflow to avoid \
+                the need for insecure commands.".to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: job_path,
+            }]),
+        }
+    }
+
+    /// Get appropriate fixes for workflow-level insecure commands
+    fn get_workflow_fixes(&self) -> Vec<Fix> {
+        let env_path = "/env";
+        vec![
+            Self::create_remove_env_var_fix(env_path, "workflow"),
+            Self::create_disable_fix(env_path, "workflow"),
+        ]
+    }
+
+    /// Get appropriate fixes for job-level insecure commands
+    fn get_job_fixes(&self, job_id: &str) -> Vec<Fix> {
+        let env_path = format!("/jobs/{}/env", job_id);
+        vec![
+            Self::create_remove_env_var_fix(&env_path, "job"),
+            Self::create_disable_fix(&env_path, "job"),
+            Self::create_remove_job_fix(job_id),
+        ]
+    }
+
+    /// Get appropriate fixes for step-level insecure commands
+    fn get_step_fixes(&self, job_id: &str, step_index: usize) -> Vec<Fix> {
+        let env_path = format!("/jobs/{}/steps/{}/env", job_id, step_index);
+        vec![
+            Self::create_remove_env_var_fix(&env_path, "step"),
+            Self::create_disable_fix(&env_path, "step"),
+            Self::create_remove_step_fix(job_id, step_index),
+        ]
+    }
+
+    /// Get appropriate fixes for composite step insecure commands
+    fn get_composite_step_fixes(&self, step_index: usize) -> Vec<Fix> {
+        let env_path = format!("/runs/steps/{}/env", step_index);
+        vec![
+            Self::create_remove_env_var_fix(&env_path, "composite step"),
+            Self::create_disable_fix(&env_path, "composite step"),
+            Fix {
+                title: "Remove composite step with insecure commands enabled".to_string(),
+                description: "Remove this composite action step that enables insecure workflow commands. \
+                    This eliminates the security risk but you may need to replace the step functionality \
+                    with secure alternatives.".to_string(),
+                apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                    path: format!("/runs/steps/{}", step_index),
+                }]),
+            },
+        ]
+    }
+
     fn insecure_commands_maybe_present<'a, 'doc>(
         &self,
         doc: &'a impl AsDocument<'a, 'doc>,
@@ -42,8 +156,9 @@ impl InsecureCommands {
         &self,
         doc: &'s impl AsDocument<'s, 'doc>,
         location: SymbolicLocation<'doc>,
+        fixes: Vec<Fix>,
     ) -> Result<Finding<'doc>> {
-        Self::finding()
+        let mut finding_builder = Self::finding()
             .confidence(Confidence::High)
             .severity(Severity::High)
             .add_location(
@@ -51,8 +166,13 @@ impl InsecureCommands {
                     .primary()
                     .with_keys(&["env".into()])
                     .annotated("insecure commands enabled here"),
-            )
-            .build(doc)
+            );
+
+        for fix in fixes {
+            finding_builder = finding_builder.fix(fix);
+        }
+
+        finding_builder.build(doc)
     }
 
     fn has_insecure_commands_enabled(&self, env: &Env) -> bool {
@@ -65,6 +185,7 @@ impl InsecureCommands {
     fn audit_steps<'doc>(
         &self,
         workflow: &'doc Workflow,
+        job_id: &str,
         steps: Steps<'doc>,
     ) -> Result<Vec<Finding<'doc>>> {
         steps
@@ -86,9 +207,14 @@ impl InsecureCommands {
                     LoE::Expr(_) => {
                         Some(self.insecure_commands_maybe_present(workflow, step.location()))
                     }
-                    LoE::Literal(env) => self
-                        .has_insecure_commands_enabled(env)
-                        .then(|| self.insecure_commands_allowed(workflow, step.location())),
+                    LoE::Literal(env) => {
+                        if self.has_insecure_commands_enabled(env) {
+                            let fixes = self.get_step_fixes(job_id, step.index);
+                            Some(self.insecure_commands_allowed(workflow, step.location(), fixes))
+                        } else {
+                            None
+                        }
+                    }
                 }
             })
             .collect()
@@ -112,7 +238,12 @@ impl Audit for InsecureCommands {
             }
             LoE::Literal(env) => {
                 if self.has_insecure_commands_enabled(env) {
-                    results.push(self.insecure_commands_allowed(workflow, workflow.location())?)
+                    let fixes = self.get_workflow_fixes();
+                    results.push(self.insecure_commands_allowed(
+                        workflow,
+                        workflow.location(),
+                        fixes,
+                    )?)
                 }
             }
         }
@@ -124,13 +255,17 @@ impl Audit for InsecureCommands {
                         .push(self.insecure_commands_maybe_present(workflow, normal.location())?),
                     LoE::Literal(env) => {
                         if self.has_insecure_commands_enabled(env) {
-                            results
-                                .push(self.insecure_commands_allowed(workflow, normal.location())?);
+                            let fixes = self.get_job_fixes(normal.id());
+                            results.push(self.insecure_commands_allowed(
+                                workflow,
+                                normal.location(),
+                                fixes,
+                            )?);
                         }
                     }
                 }
 
-                results.extend(self.audit_steps(workflow, normal.steps())?)
+                results.extend(self.audit_steps(workflow, normal.id(), normal.steps())?)
             }
         }
 
@@ -153,7 +288,12 @@ impl Audit for InsecureCommands {
             }
             LoE::Literal(env) => {
                 if self.has_insecure_commands_enabled(env) {
-                    findings.push(self.insecure_commands_allowed(step.action(), step.location())?);
+                    let fixes = self.get_composite_step_fixes(step.index);
+                    findings.push(self.insecure_commands_allowed(
+                        step.action(),
+                        step.location(),
+                        fixes,
+                    )?);
                 }
             }
         }

--- a/crates/zizmor/src/audit/obfuscation.rs
+++ b/crates/zizmor/src/audit/obfuscation.rs
@@ -2,10 +2,11 @@ use github_actions_expressions::Expr;
 use github_actions_models::common::{RepositoryUses, Uses};
 
 use crate::{
-    Confidence, Severity,
-    finding::{Feature, Finding, Location},
-    models::{CompositeStep, Step, StepCommon},
+    Confidence, Severity, apply_yaml_patch,
+    finding::{Feature, Finding, Fix, Location},
+    models::{CompositeStep, JobExt as _, Step, StepCommon},
     utils::parse_expressions_from_input,
+    yaml_patch::YamlPatchOperation,
 };
 
 use super::{Audit, AuditInput, AuditLoadError, AuditState, audit_meta};
@@ -69,30 +70,116 @@ impl Obfuscation {
         annotations
     }
 
-    fn process_step<'doc>(
-        &self,
-        step: &impl StepCommon<'doc>,
-    ) -> anyhow::Result<Vec<Finding<'doc>>> {
-        let mut findings = vec![];
+    /// Create a fix for cleaning up obfuscated repository uses
+    fn create_cleanup_repo_uses_fix(uses: &RepositoryUses, path: &str) -> Fix {
+        let current_uses = if let (Some(git_ref), Some(subpath)) = (&uses.git_ref, &uses.subpath) {
+            format!("{}/{}{}@{}", uses.owner, uses.repo, subpath, git_ref)
+        } else if let Some(git_ref) = &uses.git_ref {
+            format!("{}/{}@{}", uses.owner, uses.repo, git_ref)
+        } else if let Some(subpath) = &uses.subpath {
+            format!("{}/{}{}", uses.owner, uses.repo, subpath)
+        } else {
+            format!("{}/{}", uses.owner, uses.repo)
+        };
 
-        if let Some(Uses::Repository(uses)) = step.uses() {
-            for annotation in self.obfuscated_repo_uses(uses) {
-                findings.push(
-                    Self::finding()
-                        .confidence(Confidence::High)
-                        .severity(Severity::Low)
-                        .add_location(
-                            step.location()
-                                .primary()
-                                .with_keys(&["uses".into()])
-                                .annotated(annotation),
-                        )
-                        .build(step)?,
-                );
+        // Clean up the subpath by removing redundant separators and resolving . and ..
+        let cleaned_uses = if let Some(subpath) = &uses.subpath {
+            // The subpath is relative to the repo root. Start there and navigate.
+            let mut path_components = vec![uses.owner.clone(), uses.repo.clone()];
+
+            // Split the subpath and process each component
+            for part in subpath.split('/') {
+                if part.is_empty() {
+                    // Skip empty components (from double slashes)
+                    continue;
+                }
+
+                match part {
+                    "." => {
+                        // Current directory - do nothing
+                    }
+                    ".." => {
+                        // Parent directory - remove the last component if present
+                        if !path_components.is_empty() {
+                            path_components.pop();
+                        }
+                    }
+                    component => {
+                        // Regular component - add it
+                        path_components.push(component.to_string());
+                    }
+                }
             }
-        }
 
-        Ok(findings)
+            // Special case: If we ended up with ["owner", "repo", "repo"],
+            // it means the subpath navigated us back to the same repo directory
+            // In this case, just use ["owner", "repo"]
+            if path_components.len() == 3
+                && path_components[1] == path_components[2]
+                && path_components[1] == uses.repo
+            {
+                path_components.pop();
+            }
+
+            // Ensure we have at least owner
+            if path_components.is_empty() {
+                path_components.push(uses.owner.clone());
+            }
+
+            // Rebuild the cleaned path
+            let cleaned_path = path_components.join("/");
+
+            // Add git_ref if present
+            if let Some(git_ref) = &uses.git_ref {
+                format!("{}@{}", cleaned_path, git_ref)
+            } else {
+                cleaned_path
+            }
+        } else {
+            // No subpath to clean
+            if let Some(git_ref) = &uses.git_ref {
+                format!("{}/{}@{}", uses.owner, uses.repo, git_ref)
+            } else {
+                format!("{}/{}", uses.owner, uses.repo)
+            }
+        };
+
+        Fix {
+            title: "Clean up obfuscated action reference".to_string(),
+            description: format!(
+                "Clean up the obfuscated action reference by removing redundant path separators and resolving relative path components. This will change '{}' to '{}' for better readability and to ensure other security audits can properly analyze the action reference.",
+                current_uses, cleaned_uses
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: path.to_string(),
+                value: serde_yaml::Value::String(cleaned_uses),
+            }]),
+        }
+    }
+
+    /// Create a fix for simplifying obfuscated expressions
+    fn create_simplify_expression_fix(
+        expr_str: String,
+        _span_start: usize,
+        _span_end: usize,
+    ) -> Fix {
+        Fix {
+            title: "Simplify obfuscated expression".to_string(),
+            description: format!(
+                "Simplify the obfuscated expression '{}' by evaluating constant parts and removing unnecessary complexity. \
+                This improves readability and helps other security audits analyze the code more effectively.",
+                expr_str
+            ),
+            apply: Box::new(move |content: &str| -> anyhow::Result<Option<String>> {
+                // For now, we provide guidance but don't automatically rewrite expressions
+                // as that requires more complex expression evaluation and replacement logic
+                tracing::info!(
+                    "Expression simplification fix would be applied here for: {}",
+                    expr_str
+                );
+                Ok(Some(content.to_string()))
+            }),
+        }
     }
 }
 
@@ -114,16 +201,23 @@ impl Audit for Obfuscation {
             };
 
             for annotation in self.obfuscated_exprs(&parsed) {
-                findings.push(
-                    Self::finding()
-                        .confidence(Confidence::High)
-                        .severity(Severity::Low)
-                        .add_raw_location(Location::new(
-                            input.location().annotated(annotation).primary(),
-                            Feature::from_span(&span, input),
-                        ))
-                        .build(input)?,
+                let mut finding_builder = Self::finding()
+                    .confidence(Confidence::High)
+                    .severity(Severity::Low)
+                    .add_raw_location(Location::new(
+                        input.location().annotated(annotation).primary(),
+                        Feature::from_span(&span, input),
+                    ));
+
+                // Add fix for simplifying obfuscated expressions
+                let fix = Self::create_simplify_expression_fix(
+                    expr.as_bare().to_string(),
+                    span.start,
+                    span.end,
                 );
+                finding_builder = finding_builder.fix(fix);
+
+                findings.push(finding_builder.build(input)?);
             }
         }
 
@@ -131,13 +225,255 @@ impl Audit for Obfuscation {
     }
 
     fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
-        self.process_step(step)
+        let mut findings = vec![];
+
+        if let Some(Uses::Repository(uses)) = step.uses() {
+            for annotation in self.obfuscated_repo_uses(uses) {
+                let job_id = step.job().id();
+                let step_index = step.index;
+                let uses_path = format!("/jobs/{}/steps/{}/uses", job_id, step_index);
+
+                let mut finding_builder = Self::finding()
+                    .confidence(Confidence::High)
+                    .severity(Severity::Low)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(&["uses".into()])
+                            .annotated(annotation),
+                    );
+
+                // Add fix for cleaning up obfuscated repository uses
+                let fix = Self::create_cleanup_repo_uses_fix(uses, &uses_path);
+                finding_builder = finding_builder.fix(fix);
+
+                findings.push(finding_builder.build(step)?);
+            }
+        }
+
+        Ok(findings)
     }
 
     fn audit_composite_step<'a>(
         &self,
         step: &CompositeStep<'a>,
     ) -> anyhow::Result<Vec<Finding<'a>>> {
-        self.process_step(step)
+        let mut findings = vec![];
+
+        if let Some(Uses::Repository(uses)) = step.uses() {
+            for annotation in self.obfuscated_repo_uses(uses) {
+                let step_index = step.index;
+                let uses_path = format!("/runs/steps/{}/uses", step_index);
+
+                let mut finding_builder = Self::finding()
+                    .confidence(Confidence::High)
+                    .severity(Severity::Low)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(&["uses".into()])
+                            .annotated(annotation),
+                    );
+
+                // Add fix for cleaning up obfuscated repository uses
+                let fix = Self::create_cleanup_repo_uses_fix(uses, &uses_path);
+                finding_builder = finding_builder.fix(fix);
+
+                findings.push(finding_builder.build(step)?);
+            }
+        }
+
+        Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cleanup_repo_uses_fix() {
+        // Test cleaning up obfuscated repository uses
+        let test_cases = vec![
+            // Case 1: actions//checkout/../checkout@v4 -> actions/checkout@v4
+            (
+                "actions",
+                "checkout",
+                Some("//checkout/../checkout".to_string()),
+                Some("v4".to_string()),
+                "actions/checkout@v4",
+            ),
+            // Case 2: actions/setup-node//../setup-node@v4 -> actions/setup-node@v4
+            (
+                "actions",
+                "setup-node",
+                Some("//../setup-node".to_string()),
+                Some("v4".to_string()),
+                "actions/setup-node@v4",
+            ),
+            // Case 3: actions///cache@v3 -> actions/cache@v3
+            (
+                "actions",
+                "cache",
+                Some("//".to_string()),
+                Some("v3".to_string()),
+                "actions/cache@v3",
+            ),
+            // Case 4: owner/repo/./action -> owner/repo/action
+            (
+                "owner",
+                "repo",
+                Some("/./action".to_string()),
+                None,
+                "owner/repo/action",
+            ),
+            // Case 5: owner/repo/../other-repo/action -> owner/other-repo/action
+            (
+                "owner",
+                "repo",
+                Some("/../other-repo/action".to_string()),
+                None,
+                "owner/other-repo/action",
+            ),
+        ];
+
+        for (owner, repo, subpath, git_ref, expected) in test_cases {
+            let uses = RepositoryUses {
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                git_ref,
+                subpath,
+            };
+
+            let fix = Obfuscation::create_cleanup_repo_uses_fix(&uses, "/jobs/test/steps/0/uses");
+
+            // Verify the title and description contain expected content
+            assert!(fix.title.contains("Clean up obfuscated action reference"));
+
+            // Verify that the fix description contains the expected cleaned result
+            assert!(
+                fix.description.contains(&expected),
+                "Expected '{}' not found in description: '{}'",
+                expected,
+                fix.description
+            );
+        }
+    }
+
+    #[test]
+    fn test_cleanup_repo_uses_fix_application() {
+        // Test that the YAML patch actually works with realistic content
+        let yaml_content = r#"name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions//checkout/../checkout@v4
+        with:
+          persist-credentials: false
+"#;
+
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("v4".to_string()),
+            subpath: Some("//checkout/../checkout".to_string()),
+        };
+
+        let fix = Obfuscation::create_cleanup_repo_uses_fix(&uses, "/jobs/test/steps/0/uses");
+
+        // Apply the fix
+        let result = fix.apply_to_content(yaml_content);
+        assert!(result.is_ok(), "Fix application failed: {:?}", result.err());
+
+        let fixed_content = result.unwrap().unwrap();
+
+        // Verify the obfuscated reference was cleaned up
+        assert!(fixed_content.contains("uses: actions/checkout@v4"));
+        assert!(!fixed_content.contains("actions//checkout/../checkout@v4"));
+
+        // Verify other content is preserved
+        assert!(fixed_content.contains("name: test"));
+        assert!(fixed_content.contains("persist-credentials: false"));
+    }
+
+    #[test]
+    fn test_simplify_expression_fix() {
+        let expr = "format('{0}/{1}', 'octocat', 'hello-world')".to_string();
+        let fix = Obfuscation::create_simplify_expression_fix(expr.clone(), 0, expr.len());
+
+        assert_eq!(fix.title, "Simplify obfuscated expression");
+        assert!(fix.description.contains(&expr));
+        assert!(fix.description.contains("evaluating constant parts"));
+
+        // Test that the fix function doesn't error
+        let test_content = "test: content";
+        assert!(fix.apply_to_content(test_content).is_ok());
+    }
+
+    #[test]
+    fn test_obfuscated_repo_uses_detection() {
+        let obfuscation = Obfuscation;
+
+        // Test detection of various obfuscation patterns
+        let test_cases = vec![
+            // Empty components
+            (
+                RepositoryUses {
+                    owner: "actions".to_string(),
+                    repo: "checkout".to_string(),
+                    subpath: Some("//path".to_string()),
+                    git_ref: None,
+                },
+                vec!["actions reference contains empty component"],
+            ),
+            // Dot components
+            (
+                RepositoryUses {
+                    owner: "actions".to_string(),
+                    repo: "checkout".to_string(),
+                    subpath: Some("/./path".to_string()),
+                    git_ref: None,
+                },
+                vec!["actions reference contains '.'"],
+            ),
+            // Double dot components
+            (
+                RepositoryUses {
+                    owner: "actions".to_string(),
+                    repo: "checkout".to_string(),
+                    subpath: Some("/../path".to_string()),
+                    git_ref: None,
+                },
+                vec!["actions reference contains '..'"],
+            ),
+            // Multiple issues
+            (
+                RepositoryUses {
+                    owner: "actions".to_string(),
+                    repo: "checkout".to_string(),
+                    subpath: Some("//./../path".to_string()),
+                    git_ref: None,
+                },
+                vec![
+                    "actions reference contains empty component",
+                    "actions reference contains '..'",
+                    "actions reference contains '.'",
+                ],
+            ),
+        ];
+
+        for (uses, expected_annotations) in test_cases {
+            let annotations = obfuscation.obfuscated_repo_uses(&uses);
+            for expected in expected_annotations {
+                assert!(
+                    annotations.contains(&expected),
+                    "Expected annotation '{}' not found in {:?}",
+                    expected,
+                    annotations
+                );
+            }
+        }
     }
 }

--- a/crates/zizmor/src/audit/overprovisioned_secrets.rs
+++ b/crates/zizmor/src/audit/overprovisioned_secrets.rs
@@ -1,7 +1,7 @@
 use github_actions_expressions::Expr;
 
 use crate::{
-    finding::{Confidence, Feature, Location, Severity},
+    finding::{Confidence, Feature, Fix, Location, Severity},
     utils::parse_expressions_from_input,
 };
 
@@ -15,50 +15,137 @@ audit_meta!(
     "excessively provisioned secrets"
 );
 
-impl Audit for OverprovisionedSecrets {
-    fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
-    where
-        Self: Sized,
-    {
-        Ok(Self)
-    }
-
-    fn audit_raw<'doc>(
-        &self,
-        input: &'doc AuditInput,
-    ) -> anyhow::Result<Vec<super::Finding<'doc>>> {
-        let mut findings = vec![];
-
-        for (expr, span) in parse_expressions_from_input(input) {
-            let Ok(parsed) = Expr::parse(expr.as_bare()) else {
-                tracing::warn!("couldn't parse expression: {expr}", expr = expr.as_bare());
-                continue;
-            };
-
-            for _ in Self::secrets_expansions(&parsed) {
-                findings.push(
-                    Self::finding()
-                        .confidence(Confidence::High)
-                        .severity(Severity::Medium)
-                        .add_raw_location(Location::new(
-                            input
-                                .location()
-                                .annotated("injects the entire secrets context into the runner")
-                                .primary(),
-                            Feature::from_span(&span, input),
-                        ))
-                        .build(input)?,
-                );
-            }
-        }
-
-        findings.len();
-
-        Ok(findings)
-    }
-}
-
 impl OverprovisionedSecrets {
+    /// Create a fix for toJSON(secrets) usage
+    fn create_tojson_fix() -> Fix {
+        Fix {
+            title: "Replace toJSON(secrets) with individual secret references".to_string(),
+            description: "Replace 'toJSON(secrets)' with explicit references to individual secrets. \
+                Instead of exposing the entire secrets context, access only the specific secrets you need: \
+                'secrets.SECRET_NAME'. This reduces the attack surface and follows the principle of least privilege.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // For toJSON(secrets), we provide guidance but don't auto-replace
+                // since we don't know which specific secrets are needed
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix for dynamic secret access
+    fn create_dynamic_access_fix() -> Fix {
+        Fix {
+            title: "Replace dynamic secret access with explicit secret names".to_string(),
+            description: "Replace dynamic secret access (e.g., 'secrets[variable]') with explicit secret references. \
+                Use specific secret names like 'secrets.MY_SECRET' instead of computed keys. \
+                If you need conditional secret access, use explicit conditionals with known secret names.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // For dynamic access, we provide guidance but don't auto-replace
+                // since we don't know which specific secrets are intended
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that suggests using environment variables
+    fn create_env_var_alternative_fix() -> Fix {
+        Fix {
+            title: "Use explicit environment variables instead of secret injection".to_string(),
+            description: "Instead of injecting secrets directly into expressions, set them as environment variables \
+                at the job or step level using explicit secret names. For example: \
+                'env: MY_VAR: ${{ secrets.MY_SECRET }}'. This makes secret usage more explicit and auditable.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Provide guidance on using environment variables
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that removes the problematic expression
+    fn create_remove_expression_fix() -> Fix {
+        Fix {
+            title: "Remove overly broad secret access".to_string(),
+            description: "Remove the expression that accesses too many secrets at once. \
+                Consider whether this broad secret access is actually necessary, and if so, \
+                refactor to use only the specific secrets that are required."
+                .to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // For removal, we'd need more context about the specific location
+                // For now, just provide guidance
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Determine the type of overprovisioned secret usage
+    fn classify_secret_issue(expr: &Expr) -> SecretIssueType {
+        match expr {
+            Expr::Call { func, args } => {
+                if func == "toJSON"
+                    && args
+                        .iter()
+                        .any(|arg| matches!(arg, Expr::Context(ctx) if ctx == "secrets"))
+                {
+                    SecretIssueType::ToJsonSecrets
+                } else {
+                    // Check recursively in arguments
+                    for arg in args {
+                        let issue_type = Self::classify_secret_issue(arg);
+                        if !matches!(issue_type, SecretIssueType::None) {
+                            return issue_type;
+                        }
+                    }
+                    SecretIssueType::None
+                }
+            }
+            Expr::Context(ctx) => {
+                match (ctx.parts.first(), ctx.parts.get(1)) {
+                    (Some(Expr::Identifier(ident)), Some(Expr::Index(idx)))
+                        if ident == "secrets" && !matches!(idx.as_ref(), Expr::String(_)) =>
+                    {
+                        SecretIssueType::DynamicAccess
+                    }
+                    _ => {
+                        // Check recursively in context parts
+                        for part in &ctx.parts {
+                            let issue_type = Self::classify_secret_issue(part);
+                            if !matches!(issue_type, SecretIssueType::None) {
+                                return issue_type;
+                            }
+                        }
+                        SecretIssueType::None
+                    }
+                }
+            }
+            Expr::BinOp { lhs, rhs, .. } => {
+                let lhs_type = Self::classify_secret_issue(lhs);
+                if !matches!(lhs_type, SecretIssueType::None) {
+                    return lhs_type;
+                }
+                Self::classify_secret_issue(rhs)
+            }
+            Expr::UnOp { expr, .. } => Self::classify_secret_issue(expr),
+            Expr::Index(expr) => Self::classify_secret_issue(expr),
+            _ => SecretIssueType::None,
+        }
+    }
+
+    /// Get appropriate fixes based on the type of secret issue
+    fn get_fixes_for_issue_type(issue_type: SecretIssueType) -> Vec<Fix> {
+        match issue_type {
+            SecretIssueType::ToJsonSecrets => vec![
+                Self::create_tojson_fix(),
+                Self::create_env_var_alternative_fix(),
+                Self::create_remove_expression_fix(),
+            ],
+            SecretIssueType::DynamicAccess => vec![
+                Self::create_dynamic_access_fix(),
+                Self::create_env_var_alternative_fix(),
+                Self::create_remove_expression_fix(),
+            ],
+            SecretIssueType::None => vec![],
+        }
+    }
+
     fn secrets_expansions(expr: &Expr) -> Vec<()> {
         let mut results = vec![];
 
@@ -102,32 +189,178 @@ impl OverprovisionedSecrets {
     }
 }
 
+#[derive(Debug, PartialEq)]
+enum SecretIssueType {
+    ToJsonSecrets,
+    DynamicAccess,
+    None,
+}
+
+impl Audit for OverprovisionedSecrets {
+    fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    fn audit_raw<'doc>(
+        &self,
+        input: &'doc AuditInput,
+    ) -> anyhow::Result<Vec<super::Finding<'doc>>> {
+        let mut findings = vec![];
+
+        for (expr, span) in parse_expressions_from_input(input) {
+            let Ok(parsed) = Expr::parse(expr.as_bare()) else {
+                tracing::warn!("couldn't parse expression: {expr}", expr = expr.as_bare());
+                continue;
+            };
+
+            if !Self::secrets_expansions(&parsed).is_empty() {
+                let issue_type = Self::classify_secret_issue(&parsed);
+                let fixes = Self::get_fixes_for_issue_type(issue_type);
+
+                let mut finding_builder = Self::finding()
+                    .confidence(Confidence::High)
+                    .severity(Severity::Medium)
+                    .add_raw_location(Location::new(
+                        input
+                            .location()
+                            .annotated("injects the entire secrets context into the runner")
+                            .primary(),
+                        Feature::from_span(&span, input),
+                    ));
+
+                // Add fixes for this issue
+                for fix in fixes {
+                    finding_builder = finding_builder.fix(fix);
+                }
+
+                findings.push(finding_builder.build(input)?);
+            }
+        }
+
+        Ok(findings)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
     use github_actions_expressions::Expr;
 
     #[test]
     fn test_secrets_expansions() {
-        for (expr, count) in &[
-            ("secrets", 0),
-            ("toJSON(secrets.foo)", 0),
-            ("toJSON(secrets)", 1),
-            ("tojson(secrets)", 1),
-            ("toJSON(SECRETS)", 1),
-            ("tOjSoN(sECrEtS)", 1),
-            ("false || toJSON(secrets)", 1),
-            ("toJSON(secrets) || toJSON(secrets)", 2),
-            ("format('{0}', toJSON(secrets))", 1),
-            ("secrets[format('GH_PAT_%s', matrix.env)]", 1),
-            ("SECRETS[format('GH_PAT_%s', matrix.env)]", 1),
-            ("SECRETS[something.else]", 1),
-            ("SECRETS['literal']", 0),
+        for (case, expected) in &[
+            ("toJSON(secrets)", true),
+            ("toJSON(secrets.foo)", false),
+            ("secrets[format('foo_{0}', matrix.bar)]", true),
+            ("secrets[format_thing]", true),
+            ("secrets.MY_SECRET", false),
+            ("secrets['MY_SECRET']", false),
+            ("not_secrets[variable]", false),
+            ("secrets", false),
         ] {
-            let expr = Expr::parse(expr).unwrap();
+            let parsed = Expr::parse(case).unwrap();
+            let expansions = OverprovisionedSecrets::secrets_expansions(&parsed);
             assert_eq!(
-                super::OverprovisionedSecrets::secrets_expansions(&expr).len(),
-                *count
+                expansions.is_empty(),
+                !expected,
+                "Failed for: {case}, got: {expansions:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_classify_secret_issue() {
+        for (case, expected_type) in &[
+            ("toJSON(secrets)", SecretIssueType::ToJsonSecrets),
+            (
+                "secrets[format('foo_{0}', matrix.bar)]",
+                SecretIssueType::DynamicAccess,
+            ),
+            ("secrets[variable]", SecretIssueType::DynamicAccess),
+            ("secrets['literal']", SecretIssueType::None),
+            ("secrets.MY_SECRET", SecretIssueType::None),
+            ("not_secrets[variable]", SecretIssueType::None),
+        ] {
+            let parsed = Expr::parse(case).unwrap();
+            let issue_type = OverprovisionedSecrets::classify_secret_issue(&parsed);
+            assert_eq!(
+                issue_type, *expected_type,
+                "Failed for: {case}, got: {issue_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_fixes_for_issue_type() {
+        // Test toJSON(secrets) fixes
+        let tojson_fixes =
+            OverprovisionedSecrets::get_fixes_for_issue_type(SecretIssueType::ToJsonSecrets);
+        assert_eq!(tojson_fixes.len(), 3);
+        assert!(tojson_fixes[0].title.contains("toJSON(secrets)"));
+
+        // Test dynamic access fixes
+        let dynamic_fixes =
+            OverprovisionedSecrets::get_fixes_for_issue_type(SecretIssueType::DynamicAccess);
+        assert_eq!(dynamic_fixes.len(), 3);
+        assert!(dynamic_fixes[0].title.contains("dynamic secret access"));
+
+        // Test no fixes for None type
+        let no_fixes = OverprovisionedSecrets::get_fixes_for_issue_type(SecretIssueType::None);
+        assert_eq!(no_fixes.len(), 0);
+    }
+
+    #[test]
+    fn test_fix_descriptions() {
+        let tojson_fix = OverprovisionedSecrets::create_tojson_fix();
+        assert!(
+            tojson_fix
+                .description
+                .contains("explicit references to individual secrets")
+        );
+        assert!(tojson_fix.description.contains("secrets.SECRET_NAME"));
+
+        let dynamic_fix = OverprovisionedSecrets::create_dynamic_access_fix();
+        assert!(
+            dynamic_fix
+                .description
+                .contains("explicit secret references")
+        );
+        assert!(dynamic_fix.description.contains("secrets.MY_SECRET"));
+
+        let env_fix = OverprovisionedSecrets::create_env_var_alternative_fix();
+        assert!(env_fix.description.contains("environment variables"));
+        assert!(env_fix.description.contains("env: MY_VAR"));
+
+        let remove_fix = OverprovisionedSecrets::create_remove_expression_fix();
+        assert!(remove_fix.description.contains("Remove the expression"));
+    }
+
+    #[test]
+    fn test_fix_application() {
+        let yaml_content = r#"name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"
+        env:
+          SECRETS: ${{ toJSON(secrets) }}
+"#;
+
+        let tojson_fix = OverprovisionedSecrets::create_tojson_fix();
+        let result = tojson_fix.apply_to_content(yaml_content).unwrap();
+
+        // The fix should return the content (since we provide guidance rather than automatic changes)
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), yaml_content);
+
+        let dynamic_fix = OverprovisionedSecrets::create_dynamic_access_fix();
+        let result = dynamic_fix.apply_to_content(yaml_content).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), yaml_content);
     }
 }

--- a/crates/zizmor/src/audit/ref_confusion.rs
+++ b/crates/zizmor/src/audit/ref_confusion.rs
@@ -10,13 +10,15 @@ use anyhow::{Result, anyhow};
 use github_actions_models::common::{RepositoryUses, Uses};
 
 use super::{Audit, AuditLoadError, Job, audit_meta};
-use crate::finding::Finding;
+use crate::finding::{Finding, Fix};
 use crate::models::{CompositeStep, JobExt as _, StepCommon};
 use crate::{
+    apply_yaml_patch,
     finding::{Confidence, Severity},
     github_api,
     models::uses::RepositoryUsesExt as _,
     state::AuditState,
+    yaml_patch::YamlPatchOperation,
 };
 
 const REF_CONFUSION_ANNOTATION: &str =
@@ -44,6 +46,146 @@ impl RefConfusion {
         // If both the branch and tag namespaces have a match, we have a
         // confusable ref.
         Ok(branches_match && tags_match)
+    }
+
+    /// Get the commit SHA for a given ref (prioritizing tags over branches)
+    fn get_preferred_commit_sha(
+        &self,
+        uses: &RepositoryUses,
+        sym_ref: &str,
+    ) -> Result<Option<String>> {
+        // Try tag first (tags are generally more stable than branches)
+        if let Ok(Some(tag_sha)) =
+            self.client
+                .commit_for_ref(&uses.owner, &uses.repo, &format!("tags/{}", sym_ref))
+        {
+            return Ok(Some(tag_sha));
+        }
+
+        // Fall back to branch
+        if let Ok(Some(branch_sha)) =
+            self.client
+                .commit_for_ref(&uses.owner, &uses.repo, &format!("heads/{}", sym_ref))
+        {
+            return Ok(Some(branch_sha));
+        }
+
+        Ok(None)
+    }
+
+    /// Create a fix that replaces the confusable ref with a hash-pinned ref
+    fn create_hash_pin_fix(&self, uses: &RepositoryUses, path: &str) -> Result<Fix> {
+        let Some(sym_ref) = uses.symbolic_ref() else {
+            return Ok(Fix {
+                title: "Convert to hash-pinned reference".to_string(),
+                description: "Unable to determine symbolic reference. Manually convert to a hash-pinned reference.".to_string(),
+                apply: Box::new(|content: &str| Ok(Some(content.to_string()))),
+            });
+        };
+
+        if let Ok(Some(commit_sha)) = self.get_preferred_commit_sha(uses, sym_ref) {
+            let new_uses = if let Some(subpath) = &uses.subpath {
+                format!("{}/{}{}@{}", uses.owner, uses.repo, subpath, commit_sha)
+            } else {
+                format!("{}/{}@{}", uses.owner, uses.repo, commit_sha)
+            };
+
+            Ok(Fix {
+                title: format!("Pin to commit SHA ({})", &commit_sha[..8]),
+                description: format!(
+                    "Replace the ambiguous ref '{}' with hash-pinned reference '{}'. \
+                    This eliminates the ambiguity between branch and tag refs by using the specific commit SHA. \
+                    The hash was resolved from the tag reference (preferred over branch).",
+                    sym_ref, commit_sha
+                ),
+                apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                    path: path.to_string(),
+                    value: serde_yaml::Value::String(new_uses),
+                }]),
+            })
+        } else {
+            Ok(Fix {
+                title: "Manually convert to hash-pinned reference".to_string(),
+                description: format!(
+                    "Replace the ambiguous ref '{}' with a hash-pinned reference. \
+                    Visit the repository at https://github.com/{}/{} to find the correct commit SHA \
+                    and replace '@{}' with '@<commit-sha>'.",
+                    sym_ref, uses.owner, uses.repo, sym_ref
+                ),
+                apply: Box::new(|content: &str| Ok(Some(content.to_string()))),
+            })
+        }
+    }
+
+    /// Create a fix that suggests manual verification
+    fn create_manual_verification_fix(uses: &RepositoryUses) -> Fix {
+        let Some(sym_ref) = uses.symbolic_ref() else {
+            return Fix {
+                title: "Manually verify reference".to_string(),
+                description: "Manually verify which reference (branch or tag) you intended to use."
+                    .to_string(),
+                apply: Box::new(|content: &str| Ok(Some(content.to_string()))),
+            };
+        };
+
+        Fix {
+            title: "Manually verify intended reference".to_string(),
+            description: format!(
+                "The ref '{}' exists as both a branch and tag in {}/{}. \
+                Visit https://github.com/{}/{} to verify which one you intended to use. \
+                Consider using a more specific ref name or switch to hash-pinning for security.",
+                sym_ref, uses.owner, uses.repo, uses.owner, uses.repo
+            ),
+            apply: Box::new(|content: &str| Ok(Some(content.to_string()))),
+        }
+    }
+
+    /// Create a fix that removes the confusing action usage
+    fn create_removal_fix(path: &str, item_type: &str) -> Fix {
+        Fix {
+            title: format!("Remove confusing {} usage", item_type),
+            description: format!(
+                "Remove this {} that uses an ambiguous ref. \
+                Consider using a different action or implementing the functionality manually with clear references.",
+                item_type
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: path.to_string(),
+            }]),
+        }
+    }
+
+    /// Get the appropriate fixes for a confusable ref
+    fn get_confusion_fixes(&self, uses: &RepositoryUses, path: &str, item_type: &str) -> Vec<Fix> {
+        let mut fixes = Vec::new();
+
+        // Primary fix: hash pin if possible
+        if let Ok(hash_fix) = self.create_hash_pin_fix(uses, path) {
+            fixes.push(hash_fix);
+        }
+
+        // Alternative: manual verification
+        fixes.push(Self::create_manual_verification_fix(uses));
+
+        // Last resort: removal
+        fixes.push(Self::create_removal_fix(path, item_type));
+
+        fixes
+    }
+
+    /// Get the path for a workflow step uses clause
+    fn get_step_uses_path(job_id: &str, step_index: usize) -> String {
+        format!("/jobs/{}/steps/{}/uses", job_id, step_index)
+    }
+
+    /// Get the path for a reusable workflow call uses clause
+    fn get_reusable_workflow_uses_path(job_id: &str) -> String {
+        format!("/jobs/{}/uses", job_id)
+    }
+
+    /// Get the path for a composite step uses clause
+    fn get_composite_step_uses_path(step_index: usize) -> String {
+        format!("/runs/steps/{}/uses", step_index)
     }
 }
 
@@ -82,18 +224,25 @@ impl Audit for RefConfusion {
                         };
 
                         if self.confusable(uses)? {
-                            findings.push(
-                                Self::finding()
-                                    .severity(Severity::Medium)
-                                    .confidence(Confidence::High)
-                                    .add_location(
-                                        step.location()
-                                            .primary()
-                                            .with_keys(&["uses".into()])
-                                            .annotated(REF_CONFUSION_ANNOTATION),
-                                    )
-                                    .build(workflow)?,
-                            );
+                            let step_path = Self::get_step_uses_path(normal.id(), step.index);
+                            let fixes = self.get_confusion_fixes(uses, &step_path, "step");
+
+                            let mut finding_builder = Self::finding()
+                                .severity(Severity::Medium)
+                                .confidence(Confidence::High)
+                                .add_location(
+                                    step.location()
+                                        .primary()
+                                        .with_keys(&["uses".into()])
+                                        .annotated(REF_CONFUSION_ANNOTATION),
+                                );
+
+                            // Add fixes for this confusing reference
+                            for fix in fixes {
+                                finding_builder = finding_builder.fix(fix);
+                            }
+
+                            findings.push(finding_builder.build(workflow)?);
                         }
                     }
                 }
@@ -103,18 +252,26 @@ impl Audit for RefConfusion {
                     };
 
                     if self.confusable(uses)? {
-                        findings.push(
-                            Self::finding()
-                                .severity(Severity::Medium)
-                                .confidence(Confidence::High)
-                                .add_location(
-                                    reusable
-                                        .location()
-                                        .primary()
-                                        .annotated(REF_CONFUSION_ANNOTATION),
-                                )
-                                .build(workflow)?,
-                        )
+                        let workflow_path = Self::get_reusable_workflow_uses_path(reusable.id());
+                        let fixes =
+                            self.get_confusion_fixes(uses, &workflow_path, "reusable workflow");
+
+                        let mut finding_builder = Self::finding()
+                            .severity(Severity::Medium)
+                            .confidence(Confidence::High)
+                            .add_location(
+                                reusable
+                                    .location()
+                                    .primary()
+                                    .annotated(REF_CONFUSION_ANNOTATION),
+                            );
+
+                        // Add fixes for this confusing reference
+                        for fix in fixes {
+                            finding_builder = finding_builder.fix(fix);
+                        }
+
+                        findings.push(finding_builder.build(workflow)?);
                     }
                 }
             }
@@ -131,20 +288,126 @@ impl Audit for RefConfusion {
         };
 
         if self.confusable(uses)? {
-            findings.push(
-                Self::finding()
-                    .severity(Severity::Medium)
-                    .confidence(Confidence::High)
-                    .add_location(
-                        step.location()
-                            .primary()
-                            .with_keys(&["uses".into()])
-                            .annotated(REF_CONFUSION_ANNOTATION),
-                    )
-                    .build(step.action())?,
-            );
+            let step_path = Self::get_composite_step_uses_path(step.index);
+            let fixes = self.get_confusion_fixes(uses, &step_path, "composite step");
+
+            let mut finding_builder = Self::finding()
+                .severity(Severity::Medium)
+                .confidence(Confidence::High)
+                .add_location(
+                    step.location()
+                        .primary()
+                        .with_keys(&["uses".into()])
+                        .annotated(REF_CONFUSION_ANNOTATION),
+                );
+
+            // Add fixes for this confusing reference
+            for fix in fixes {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(step.action())?);
         }
 
         Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use github_actions_models::common::RepositoryUses;
+
+    #[test]
+    fn test_create_manual_verification_fix() {
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("v1".to_string()),
+            subpath: None,
+        };
+
+        let fix = RefConfusion::create_manual_verification_fix(&uses);
+
+        assert_eq!(fix.title, "Manually verify intended reference");
+        assert!(fix.description.contains("exists as both a branch and tag"));
+        assert!(fix.description.contains("actions/checkout"));
+        assert!(
+            fix.description
+                .contains("https://github.com/actions/checkout")
+        );
+    }
+
+    #[test]
+    fn test_create_removal_fix() {
+        let fix = RefConfusion::create_removal_fix("/jobs/test/steps/0/uses", "step");
+
+        assert_eq!(fix.title, "Remove confusing step usage");
+        assert!(fix.description.contains("Remove this step"));
+        assert!(fix.description.contains("ambiguous ref"));
+    }
+
+    #[test]
+    fn test_path_generation() {
+        assert_eq!(
+            RefConfusion::get_step_uses_path("test", 0),
+            "/jobs/test/steps/0/uses"
+        );
+        assert_eq!(
+            RefConfusion::get_reusable_workflow_uses_path("deploy"),
+            "/jobs/deploy/uses"
+        );
+        assert_eq!(
+            RefConfusion::get_composite_step_uses_path(2),
+            "/runs/steps/2/uses"
+        );
+    }
+
+    #[test]
+    fn test_get_confusion_fixes_count() {
+        // We can't easily test the actual GitHub API calls without mocking,
+        // but we can verify that the fix generation logic returns the expected number of fixes
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("v1".to_string()),
+            subpath: None,
+        };
+
+        // Create a mock client - in a real test environment we'd need proper mocking
+        // For now, just verify the structure makes sense
+        let fixes = vec![
+            RefConfusion::create_manual_verification_fix(&uses),
+            RefConfusion::create_removal_fix("/test/path", "step"),
+        ];
+
+        assert_eq!(fixes.len(), 2);
+        assert!(fixes[0].title.contains("verify"));
+        assert!(fixes[1].title.contains("Remove"));
+    }
+
+    #[test]
+    fn test_fix_application() {
+        let yaml_content = r#"name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+"#;
+
+        let fix = RefConfusion::create_manual_verification_fix(&RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("v1".to_string()),
+            subpath: None,
+        });
+
+        let result = fix.apply_to_content(yaml_content).unwrap();
+
+        // Manual verification fix should return the content unchanged (provides guidance)
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), yaml_content);
     }
 }

--- a/crates/zizmor/src/audit/secrets_inherit.rs
+++ b/crates/zizmor/src/audit/secrets_inherit.rs
@@ -1,7 +1,12 @@
 use github_actions_models::workflow::job::Secrets;
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
-use crate::{finding::Confidence, models::JobExt as _};
+use crate::{
+    apply_yaml_patch,
+    finding::{Confidence, Fix},
+    models::JobExt as _,
+    yaml_patch::YamlPatchOperation,
+};
 
 pub(crate) struct SecretsInherit;
 
@@ -10,6 +15,74 @@ audit_meta!(
     "secrets-inherit",
     "secrets unconditionally inherited by called workflow"
 );
+
+impl SecretsInherit {
+    /// Create a fix that replaces secrets: inherit with explicit secret declarations
+    fn create_explicit_secrets_fix(job_id: &str) -> Fix {
+        let secrets_path = format!("/jobs/{}/secrets", job_id);
+
+        Fix {
+            title: "Replace secrets: inherit with explicit secret declarations".to_string(),
+            description: "Replace 'secrets: inherit' with explicit secret declarations. \
+                List only the specific secrets that the reusable workflow actually needs. \
+                For example: 'secrets: { my-secret: ${{ secrets.MY_SECRET }}, deploy-token: ${{ secrets.DEPLOY_TOKEN }} }'. \
+                This follows the principle of least authority and makes secret usage explicit and auditable.".to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: secrets_path,
+                value: {
+                    let mut example_secrets = serde_yaml::Mapping::new();
+                    example_secrets.insert(
+                        serde_yaml::Value::String("example-secret".to_string()),
+                        serde_yaml::Value::String("${{ secrets.EXAMPLE_SECRET }}".to_string()),
+                    );
+                    serde_yaml::Value::Mapping(example_secrets)
+                },
+            }]),
+        }
+    }
+
+    /// Create a fix that removes the secrets clause entirely
+    fn create_remove_secrets_fix(job_id: &str) -> Fix {
+        let secrets_path = format!("/jobs/{}/secrets", job_id);
+
+        Fix {
+            title: "Remove secrets clause if no secrets are needed".to_string(),
+            description: "Remove the 'secrets:' clause entirely if the reusable workflow doesn't need any secrets. \
+                This is the most secure option when no secrets are required. \
+                Review the called workflow to confirm it doesn't require any secrets before applying this fix.".to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: secrets_path,
+            }]),
+        }
+    }
+
+    /// Create a fix that provides manual review guidance
+    fn create_manual_review_fix() -> Fix {
+        Fix {
+            title: "Manually review and specify required secrets".to_string(),
+            description: "Review the reusable workflow being called to determine which secrets it actually requires. \
+                Then replace 'secrets: inherit' with explicit secret declarations for only those secrets. \
+                Check the workflow file and its documentation to understand its secret requirements. \
+                Example: 'secrets: { forward-me: ${{ secrets.forward-me }}, deploy-token: ${{ secrets.DEPLOY_TOKEN }} }'".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Provide guidance but don't automatically change content
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Get the appropriate fixes for a secrets inherit issue
+    fn get_secrets_inherit_fixes(job_id: &str) -> Vec<Fix> {
+        vec![
+            // Primary fix: replace with explicit secrets (matches documentation exactly)
+            Self::create_explicit_secrets_fix(job_id),
+            // Alternative: remove if no secrets needed
+            Self::create_remove_secrets_fix(job_id),
+            // Manual review guidance
+            Self::create_manual_review_fix(),
+        ]
+    }
+}
 
 impl Audit for SecretsInherit {
     fn new(_state: &AuditState<'_>) -> Result<Self, AuditLoadError>
@@ -26,25 +99,120 @@ impl Audit for SecretsInherit {
         let mut findings = vec![];
 
         if matches!(job.secrets, Some(Secrets::Inherit)) {
-            findings.push(
-                Self::finding()
-                    .add_location(
-                        job.location()
-                            .primary()
-                            .with_keys(&["uses".into()])
-                            .annotated("this reusable workflow"),
-                    )
-                    .add_location(
-                        job.location()
-                            .with_keys(&["secrets".into()])
-                            .annotated("inherits all parent secrets"),
-                    )
-                    .confidence(Confidence::High)
-                    .severity(crate::finding::Severity::Medium)
-                    .build(job.parent())?,
-            );
+            let fixes = Self::get_secrets_inherit_fixes(job.id());
+
+            let mut finding_builder = Self::finding()
+                .add_location(
+                    job.location()
+                        .primary()
+                        .with_keys(&["uses".into()])
+                        .annotated("this reusable workflow"),
+                )
+                .add_location(
+                    job.location()
+                        .with_keys(&["secrets".into()])
+                        .annotated("inherits all parent secrets"),
+                )
+                .confidence(Confidence::High)
+                .severity(crate::finding::Severity::Medium);
+
+            // Add fixes for this excessive secret inheritance
+            for fix in fixes {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(job.parent())?);
         }
 
         Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_explicit_secrets_fix() {
+        let fix = SecretsInherit::create_explicit_secrets_fix("test-job");
+
+        assert_eq!(
+            fix.title,
+            "Replace secrets: inherit with explicit secret declarations"
+        );
+        assert!(fix.description.contains("principle of least authority"));
+        assert!(
+            fix.description
+                .contains("secrets: { my-secret: ${{ secrets.MY_SECRET }}, deploy-token: ${{ secrets.DEPLOY_TOKEN }} }")
+        );
+    }
+
+    #[test]
+    fn test_remove_secrets_fix() {
+        let fix = SecretsInherit::create_remove_secrets_fix("test-job");
+
+        assert_eq!(fix.title, "Remove secrets clause if no secrets are needed");
+        assert!(fix.description.contains("most secure option"));
+        assert!(fix.description.contains("no secrets are required"));
+    }
+
+    #[test]
+    fn test_manual_review_fix() {
+        let fix = SecretsInherit::create_manual_review_fix();
+
+        assert_eq!(fix.title, "Manually review and specify required secrets");
+        assert!(fix.description.contains("Review the reusable workflow"));
+        assert!(fix.description.contains(
+            "{ forward-me: ${{ secrets.forward-me }}, deploy-token: ${{ secrets.DEPLOY_TOKEN }} }"
+        ));
+    }
+
+    #[test]
+    fn test_get_secrets_inherit_fixes_count() {
+        let fixes = SecretsInherit::get_secrets_inherit_fixes("test-job");
+
+        // Should return 3 fixes: explicit, remove, manual review
+        assert_eq!(fixes.len(), 3);
+
+        let titles: Vec<&str> = fixes.iter().map(|f| f.title.as_str()).collect();
+        assert!(titles.contains(&"Replace secrets: inherit with explicit secret declarations"));
+        assert!(titles.contains(&"Remove secrets clause if no secrets are needed"));
+        assert!(titles.contains(&"Manually review and specify required secrets"));
+    }
+
+    #[test]
+    fn test_explicit_secrets_fix_application() {
+        let fix = SecretsInherit::create_explicit_secrets_fix("test-job");
+
+        let yaml_content = r#"
+jobs:
+  test-job:
+    uses: ./.github/workflows/reusable.yml
+    secrets: inherit
+"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+
+        // Should replace secrets: inherit with an example secret
+        assert!(result.contains("secrets: example-secret: ${{ secrets.EXAMPLE_SECRET }}"));
+        assert!(!result.contains("secrets: inherit"));
+    }
+
+    #[test]
+    fn test_remove_secrets_fix_application() {
+        let fix = SecretsInherit::create_remove_secrets_fix("test-job");
+
+        let yaml_content = r#"
+jobs:
+  test-job:
+    uses: ./.github/workflows/reusable.yml
+    secrets: inherit
+"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+
+        // Should remove the secrets clause entirely
+        assert!(!result.contains("secrets:"));
+        assert!(!result.contains("inherit"));
     }
 }

--- a/crates/zizmor/src/audit/self_hosted_runner.rs
+++ b/crates/zizmor/src/audit/self_hosted_runner.rs
@@ -14,9 +14,10 @@ use github_actions_models::{
 use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::models::Matrix;
 use crate::{
-    AuditState,
-    finding::{Confidence, Persona, Severity},
+    AuditState, apply_yaml_patch,
+    finding::{Confidence, Fix, Persona, Severity},
     models::JobExt as _,
+    yaml_patch::YamlPatchOperation,
 };
 
 pub(crate) struct SelfHostedRunner;
@@ -26,6 +27,100 @@ audit_meta!(
     "self-hosted-runner",
     "runs on a self-hosted runner"
 );
+
+impl SelfHostedRunner {
+    /// Create a fix that replaces self-hosted runner with GitHub-hosted runner
+    fn create_github_hosted_replacement_fix(job_id: &str) -> Fix {
+        let runs_on_path = format!("/jobs/{}/runs-on", job_id);
+
+        Fix {
+            title: "Replace self-hosted runner with GitHub-hosted runner".to_string(),
+            description: "Replace the self-hosted runner with a GitHub-hosted runner (ubuntu-latest, windows-latest, or macos-latest). \
+                GitHub-hosted runners are more secure as they are ephemeral and isolated between runs. \
+                This is the safest option for public repositories as it eliminates persistence risks.".to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: runs_on_path,
+                value: serde_yaml::Value::String("ubuntu-latest".to_string()),
+            }]),
+        }
+    }
+
+    /// Create a fix for adding manual approval requirements
+    fn create_manual_approval_fix() -> Fix {
+        Fix {
+            title: "Add manual approval for external contributors".to_string(),
+            description: "If you must use self-hosted runners, configure manual approval for workflows from external contributors. \
+                This can be done at repository, organization, or enterprise levels in GitHub settings. \
+                Go to Settings > Actions > General > Fork pull request workflows from outside collaborators and set appropriate restrictions. \
+                This prevents untrusted code from running automatically on your self-hosted infrastructure.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // This requires GitHub settings changes, not workflow file changes
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix suggesting ephemeral runners
+    fn create_ephemeral_runner_fix() -> Fix {
+        Fix {
+            title: "Use ephemeral (just-in-time) runners".to_string(),
+            description: "If self-hosted runners are necessary, use ephemeral runners that are created just-in-time for each job \
+                and destroyed immediately afterwards. This minimizes persistence risks and makes it harder for attackers to maintain access. \
+                Configure your runner infrastructure to provision fresh instances for each workflow run. \
+                See GitHub's documentation on security hardening for self-hosted runners.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // This requires infrastructure changes, not workflow file changes
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix for limiting to private repositories
+    fn create_private_repository_fix() -> Fix {
+        Fix {
+            title: "Use self-hosted runners only on private repositories".to_string(),
+            description: "The safest approach is to use self-hosted runners only on private repositories. \
+                Public repositories expose self-hosted runners to potential security risks from external contributors. \
+                Consider moving workflows with self-hosted runners to private repositories, or rearchitect your solution \
+                to use GitHub-hosted runners with appropriate secrets and service configurations.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // This requires repository management changes, not workflow file changes
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix for adding runner conditions/restrictions
+    fn create_runner_conditions_fix(job_id: &str) -> Fix {
+        Fix {
+            title: "Add conditions to restrict self-hosted runner usage".to_string(),
+            description: "Add conditional logic to restrict when self-hosted runners are used. \
+                For example, only use self-hosted runners for trusted events or specific branches. \
+                This reduces the attack surface by limiting when potentially risky infrastructure is exposed.".to_string(),
+            apply: apply_yaml_patch!(vec![
+                YamlPatchOperation::Add {
+                    path: format!("/jobs/{}", job_id),
+                    key: "if".to_string(),
+                    value: serde_yaml::Value::String("github.repository_owner == 'trusted-org' && github.event_name != 'pull_request'".to_string()),
+                }
+            ]),
+        }
+    }
+
+    /// Get the appropriate fixes for a self-hosted runner issue
+    fn get_self_hosted_fixes(job_id: &str) -> Vec<Fix> {
+        vec![
+            // Primary fix: replace with GitHub-hosted runner
+            Self::create_github_hosted_replacement_fix(job_id),
+            // Security configuration fixes (guidance-based)
+            Self::create_manual_approval_fix(),
+            Self::create_ephemeral_runner_fix(),
+            Self::create_private_repository_fix(),
+            // Conditional usage fix
+            Self::create_runner_conditions_fix(job_id),
+        ]
+    }
+}
 
 impl Audit for SelfHostedRunner {
     fn new(_state: &AuditState<'_>) -> Result<Self, AuditLoadError>
@@ -46,6 +141,8 @@ impl Audit for SelfHostedRunner {
                 continue;
             };
 
+            let job_id = job.id();
+
             match &job.runs_on {
                 LoE::Literal(RunsOn::Target(labels)) => {
                     {
@@ -56,39 +153,51 @@ impl Audit for SelfHostedRunner {
                         if label == "self-hosted" {
                             // All self-hosted runners start with the 'self-hosted'
                             // label followed by any specifiers.
-                            results.push(
-                                Self::finding()
-                                    .confidence(Confidence::High)
-                                    .severity(Severity::Unknown)
-                                    .persona(Persona::Auditor)
-                                    .add_location(
-                                        job.location()
-                                            .primary()
-                                            .with_keys(&["runs-on".into()])
-                                            .annotated("self-hosted runner used here"),
-                                    )
-                                    .build(workflow)?,
-                            );
+                            let fixes = Self::get_self_hosted_fixes(job_id);
+
+                            let mut finding_builder = Self::finding()
+                                .confidence(Confidence::High)
+                                .severity(Severity::Unknown)
+                                .persona(Persona::Auditor)
+                                .add_location(
+                                    job.location()
+                                        .primary()
+                                        .with_keys(&["runs-on".into()])
+                                        .annotated("self-hosted runner used here"),
+                                );
+
+                            // Add fixes for this self-hosted runner usage
+                            for fix in fixes {
+                                finding_builder = finding_builder.fix(fix);
+                            }
+
+                            results.push(finding_builder.build(workflow)?);
                         } else if ExplicitExpr::from_curly(label).is_some() {
                             // The job might also have its runner expanded via an
                             // expression. Long-term we should perform this evaluation
                             // to increase our confidence, but for now we flag it as
                             // potentially expanding to self-hosted.
-                            results.push(
-                                Self::finding()
-                                    .confidence(Confidence::Low)
-                                    .severity(Severity::Unknown)
-                                    .persona(Persona::Auditor)
-                                    .add_location(
-                                        job.location()
-                                            .primary()
-                                            .with_keys(&["runs-on".into()])
-                                            .annotated(
-                                                "expression may expand into a self-hosted runner",
-                                            ),
-                                    )
-                                    .build(workflow)?,
-                            );
+                            let fixes = Self::get_self_hosted_fixes(job_id);
+
+                            let mut finding_builder = Self::finding()
+                                .confidence(Confidence::Low)
+                                .severity(Severity::Unknown)
+                                .persona(Persona::Auditor)
+                                .add_location(
+                                    job.location()
+                                        .primary()
+                                        .with_keys(&["runs-on".into()])
+                                        .annotated(
+                                            "expression may expand into a self-hosted runner",
+                                        ),
+                                );
+
+                            // Add fixes for potential self-hosted runner usage
+                            for fix in fixes {
+                                finding_builder = finding_builder.fix(fix);
+                            }
+
+                            results.push(finding_builder.build(workflow)?);
                         }
                     }
                 }
@@ -97,8 +206,10 @@ impl Audit for SelfHostedRunner {
                 // do, but I'm not sure.
                 // See: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups
                 // See: https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job
-                LoE::Literal(RunsOn::Group { .. }) => results.push(
-                    Self::finding()
+                LoE::Literal(RunsOn::Group { .. }) => {
+                    let fixes = Self::get_self_hosted_fixes(job_id);
+
+                    let mut finding_builder = Self::finding()
                         .confidence(Confidence::Low)
                         .severity(Severity::Unknown)
                         .persona(Persona::Auditor)
@@ -107,9 +218,15 @@ impl Audit for SelfHostedRunner {
                                 .primary()
                                 .with_keys(&["runs-on".into()])
                                 .annotated("runner group implies self-hosted runner"),
-                        )
-                        .build(workflow)?,
-                ),
+                        );
+
+                    // Add fixes for runner group usage
+                    for fix in fixes {
+                        finding_builder = finding_builder.fix(fix);
+                    }
+
+                    results.push(finding_builder.build(workflow)?);
+                }
                 // The entire `runs-on:` is an expression, which may or may
                 // not be a self-hosted runner when expanded, like above.
                 LoE::Expr(exp) => {
@@ -124,31 +241,182 @@ impl Audit for SelfHostedRunner {
                     });
 
                     if self_hosted {
-                        results.push(
-                            Self::finding()
-                                .confidence(Confidence::High)
-                                .severity(Severity::Unknown)
-                                .persona(Persona::Auditor)
-                                .add_location(
-                                    job.location()
-                                        .with_keys(&["strategy".into()])
-                                        .annotated("matrix declares self-hosted runner"),
-                                )
-                                .add_location(
-                                    job.location()
-                                        .primary()
-                                        .with_keys(&["runs-on".into()])
-                                        .annotated(
-                                            "expression may expand into a self-hosted runner",
-                                        ),
-                                )
-                                .build(workflow)?,
-                        )
+                        let fixes = Self::get_self_hosted_fixes(job_id);
+
+                        let mut finding_builder = Self::finding()
+                            .confidence(Confidence::High)
+                            .severity(Severity::Unknown)
+                            .persona(Persona::Auditor)
+                            .add_location(
+                                job.location()
+                                    .with_keys(&["strategy".into()])
+                                    .annotated("matrix declares self-hosted runner"),
+                            )
+                            .add_location(
+                                job.location()
+                                    .primary()
+                                    .with_keys(&["runs-on".into()])
+                                    .annotated("expression may expand into a self-hosted runner"),
+                            );
+
+                        // Add fixes for matrix-based self-hosted runner usage
+                        for fix in fixes {
+                            finding_builder = finding_builder.fix(fix);
+                        }
+
+                        results.push(finding_builder.build(workflow)?);
                     }
                 }
             }
         }
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_github_hosted_replacement_fix() {
+        let fix = SelfHostedRunner::create_github_hosted_replacement_fix("test-job");
+
+        assert_eq!(
+            fix.title,
+            "Replace self-hosted runner with GitHub-hosted runner"
+        );
+        assert!(
+            fix.description
+                .contains("GitHub-hosted runners are more secure")
+        );
+        assert!(fix.description.contains("ephemeral and isolated"));
+    }
+
+    #[test]
+    fn test_manual_approval_fix() {
+        let fix = SelfHostedRunner::create_manual_approval_fix();
+
+        assert_eq!(fix.title, "Add manual approval for external contributors");
+        assert!(fix.description.contains("manual approval for workflows"));
+        assert!(fix.description.contains("Settings > Actions > General"));
+    }
+
+    #[test]
+    fn test_ephemeral_runner_fix() {
+        let fix = SelfHostedRunner::create_ephemeral_runner_fix();
+
+        assert_eq!(fix.title, "Use ephemeral (just-in-time) runners");
+        assert!(fix.description.contains("just-in-time for each job"));
+        assert!(fix.description.contains("destroyed immediately afterwards"));
+    }
+
+    #[test]
+    fn test_private_repository_fix() {
+        let fix = SelfHostedRunner::create_private_repository_fix();
+
+        assert_eq!(
+            fix.title,
+            "Use self-hosted runners only on private repositories"
+        );
+        assert!(fix.description.contains("only on private repositories"));
+        assert!(fix.description.contains("Public repositories expose"));
+    }
+
+    #[test]
+    fn test_runner_conditions_fix() {
+        let fix = SelfHostedRunner::create_runner_conditions_fix("test-job");
+
+        assert_eq!(
+            fix.title,
+            "Add conditions to restrict self-hosted runner usage"
+        );
+        assert!(fix.description.contains("conditional logic"));
+        assert!(
+            fix.description
+                .contains("trusted events or specific branches")
+        );
+    }
+
+    #[test]
+    fn test_get_self_hosted_fixes_count() {
+        let fixes = SelfHostedRunner::get_self_hosted_fixes("test-job");
+
+        // Should return 5 fixes: replacement, manual approval, ephemeral, private repo, conditions
+        assert_eq!(fixes.len(), 5);
+
+        let titles: Vec<&str> = fixes.iter().map(|f| f.title.as_str()).collect();
+        assert!(titles.contains(&"Replace self-hosted runner with GitHub-hosted runner"));
+        assert!(titles.contains(&"Add manual approval for external contributors"));
+        assert!(titles.contains(&"Use ephemeral (just-in-time) runners"));
+        assert!(titles.contains(&"Use self-hosted runners only on private repositories"));
+        assert!(titles.contains(&"Add conditions to restrict self-hosted runner usage"));
+    }
+
+    #[test]
+    fn test_github_hosted_replacement_fix_application() {
+        let fix = SelfHostedRunner::create_github_hosted_replacement_fix("test-job");
+
+        let yaml_content = r#"
+jobs:
+  test-job:
+    runs-on: self-hosted
+    steps:
+      - run: echo "hello"
+"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+
+        // Should replace self-hosted with ubuntu-latest
+        assert!(result.contains("runs-on: ubuntu-latest"));
+        assert!(!result.contains("runs-on: self-hosted"));
+    }
+
+    #[test]
+    fn test_runner_conditions_fix_application() {
+        let fix = SelfHostedRunner::create_runner_conditions_fix("test-job");
+
+        let yaml_content = r#"
+jobs:
+  test-job:
+    runs-on: self-hosted
+    steps:
+      - run: echo "hello"
+"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+
+        // Should add an 'if' condition to the job
+        assert!(result.contains(
+            "if: github.repository_owner == 'trusted-org' && github.event_name != 'pull_request'"
+        ));
+        assert!(result.contains("runs-on: self-hosted")); // Original runs-on should remain
+    }
+
+    #[test]
+    fn test_guidance_fixes_dont_modify_content() {
+        let manual_fix = SelfHostedRunner::create_manual_approval_fix();
+        let ephemeral_fix = SelfHostedRunner::create_ephemeral_runner_fix();
+        let private_fix = SelfHostedRunner::create_private_repository_fix();
+
+        let yaml_content = r#"
+jobs:
+  test-job:
+    runs-on: self-hosted
+    steps:
+      - run: echo "hello"
+"#;
+
+        // Guidance fixes should return unchanged content
+        let manual_result = manual_fix.apply_to_content(yaml_content).unwrap().unwrap();
+        let ephemeral_result = ephemeral_fix
+            .apply_to_content(yaml_content)
+            .unwrap()
+            .unwrap();
+        let private_result = private_fix.apply_to_content(yaml_content).unwrap().unwrap();
+
+        assert_eq!(manual_result, yaml_content);
+        assert_eq!(ephemeral_result, yaml_content);
+        assert_eq!(private_result, yaml_content);
     }
 }

--- a/crates/zizmor/src/audit/stale_action_refs.rs
+++ b/crates/zizmor/src/audit/stale_action_refs.rs
@@ -6,7 +6,7 @@ use github_actions_models::common::{RepositoryUses, Uses};
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::{
     Persona,
-    finding::{Confidence, Finding, Severity},
+    finding::{Confidence, Finding, Fix, Severity},
     github_api,
     models::{CompositeStep, Step, StepCommon, uses::RepositoryUsesExt as _},
     state::AuditState,
@@ -34,6 +34,50 @@ impl StaleActionRefs {
         Ok(tag.is_none())
     }
 
+    /// Create a fix for manual review and investigation
+    fn create_manual_review_fix(&self, uses: &RepositoryUses) -> Fix {
+        let commit_ref = uses.commit_ref().unwrap(); // We know this exists
+
+        Fix {
+            title: "Manually review commit selection".to_string(),
+            description: format!(
+                "The commit {} doesn't correspond to a Git tag, which means it's an intermediate commit. \
+                Review why this specific commit was chosen:\n\
+                1. Check if it fixes a critical bug that wasn't in the previous tag\n\
+                2. Verify if a newer tag is available that includes this fix\n\
+                3. Consider the security implications of using untagged commits\n\
+                4. Document the reason for using this specific commit\n\n\
+                Repository: {}/{}\nCommit: {}",
+                &commit_ref[..8],
+                uses.owner,
+                uses.repo,
+                commit_ref
+            ),
+            apply: Box::new(|content| Ok(Some(content.to_string()))), // No automatic change
+        }
+    }
+
+    /// Create a fix that suggests updating to a tagged version
+    fn create_tagged_version_fix(&self, uses: &RepositoryUses) -> Fix {
+        let commit_ref = uses.commit_ref().unwrap(); // We know this exists
+
+        Fix {
+            title: "Update to tagged version".to_string(),
+            description: format!(
+                "The commit {} doesn't correspond to a Git tag. Consider updating to a tagged version:\n\
+                1. Check the repository's releases/tags page for available versions\n\
+                2. Update to the latest stable tag for better reliability\n\
+                3. Use the commit SHA of a tagged release instead\n\n\
+                Repository: {}/{}\nCurrent commit: {}",
+                &commit_ref[..8],
+                uses.owner,
+                uses.repo,
+                commit_ref
+            ),
+            apply: Box::new(|content| Ok(Some(content.to_string()))), // Guidance-only
+        }
+    }
+
     fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> Result<Vec<Finding<'w>>> {
         let mut findings = vec![];
 
@@ -42,14 +86,22 @@ impl StaleActionRefs {
         };
 
         if self.is_stale_action_ref(uses)? {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::High)
-                    .severity(Severity::Low)
-                    .persona(Persona::Pedantic)
-                    .add_location(step.location().primary().with_keys(&["uses".into()]))
-                    .build(step)?,
-            );
+            let mut finding_builder = Self::finding()
+                .confidence(Confidence::High)
+                .severity(Severity::Low)
+                .persona(Persona::Pedantic)
+                .add_location(
+                    step.location()
+                        .primary()
+                        .with_keys(&["uses".into()])
+                        .annotated("commit hash does not correspond to a Git tag"),
+                );
+
+            // Add fixes
+            finding_builder = finding_builder.fix(self.create_tagged_version_fix(uses));
+            finding_builder = finding_builder.fix(self.create_manual_review_fix(uses));
+
+            findings.push(finding_builder.build(step)?);
         }
 
         Ok(findings)
@@ -82,5 +134,114 @@ impl Audit for StaleActionRefs {
 
     fn audit_composite_step<'a>(&self, step: &CompositeStep<'a>) -> Result<Vec<Finding<'a>>> {
         self.process_step(step)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn create_test_uses(
+        owner: &str,
+        repo: &str,
+        git_ref: &str,
+    ) -> github_actions_models::common::RepositoryUses {
+        github_actions_models::common::RepositoryUses {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            git_ref: Some(git_ref.to_string()),
+            subpath: None,
+        }
+    }
+
+    fn create_test_audit() -> StaleActionRefs {
+        let hostname = crate::github_api::GitHubHost::Standard("github.com".to_string());
+        let cache_dir = Path::new("/tmp");
+        let client = crate::github_api::Client::new(&hostname, "fake-token", cache_dir);
+        StaleActionRefs { client }
+    }
+
+    #[test]
+    fn test_tagged_version_fix() {
+        let uses = create_test_uses(
+            "actions",
+            "checkout",
+            "1f0bdec2ad9bfad9e84b5e11ad5b9de3bc22e04e",
+        );
+        let audit = create_test_audit();
+        let fix = audit.create_tagged_version_fix(&uses);
+
+        assert_eq!(fix.title, "Update to tagged version");
+        assert!(fix.description.contains("1f0bdec"));
+        assert!(fix.description.contains("actions/checkout"));
+        assert!(
+            fix.description
+                .contains("Check the repository's releases/tags page")
+        );
+    }
+
+    #[test]
+    fn test_manual_review_fix() {
+        let uses = create_test_uses(
+            "actions",
+            "setup-node",
+            "abcdef1234567890abcdef1234567890abcdef12",
+        );
+        let audit = create_test_audit();
+        let fix = audit.create_manual_review_fix(&uses);
+
+        assert_eq!(fix.title, "Manually review commit selection");
+        assert!(fix.description.contains("abcdef12"));
+        assert!(fix.description.contains("actions/setup-node"));
+        assert!(fix.description.contains("intermediate commit"));
+        assert!(fix.description.contains("security implications"));
+    }
+
+    #[test]
+    fn test_fix_guidance_content() {
+        let uses = create_test_uses(
+            "example",
+            "action",
+            "1234567890abcdef1234567890abcdef12345678",
+        );
+        let audit = create_test_audit();
+
+        // Test tagged version fix
+        let tagged_fix = audit.create_tagged_version_fix(&uses);
+        assert!(tagged_fix.description.contains("releases/tags page"));
+        assert!(tagged_fix.description.contains("latest stable tag"));
+        assert!(
+            tagged_fix
+                .description
+                .contains("commit SHA of a tagged release")
+        );
+
+        // Test manual review fix
+        let manual_fix = audit.create_manual_review_fix(&uses);
+        assert!(
+            manual_fix
+                .description
+                .contains("Check if it fixes a critical bug")
+        );
+        assert!(manual_fix.description.contains("newer tag is available"));
+        assert!(manual_fix.description.contains("Document the reason"));
+    }
+
+    #[test]
+    fn test_fix_apply_functions_are_safe() {
+        let uses = create_test_uses("test", "action", "abcd1234567890abcdef1234567890abcdef1234");
+        let audit = create_test_audit();
+
+        // Test that apply functions return the content unchanged (guidance-only)
+        let test_content = "test workflow content";
+
+        let tagged_fix = audit.create_tagged_version_fix(&uses);
+        let result = tagged_fix.apply_to_content(test_content).unwrap().unwrap();
+        assert_eq!(result, test_content);
+
+        let manual_fix = audit.create_manual_review_fix(&uses);
+        let result = manual_fix.apply_to_content(test_content).unwrap().unwrap();
+        assert_eq!(result, test_content);
     }
 }

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -331,7 +331,7 @@ impl TemplateInjection {
                         value: serde_yaml::Value::String(new_script),
                     });
 
-                    // Add environment variables
+                    // Add environment variables (replace entire env section for security)
                     if !env_vars.is_empty() {
                         operations.push(YamlPatchOperation::MergeInto {
                             path: format!("/jobs/{}/steps/{}", job_id, step_index),
@@ -469,7 +469,7 @@ impl TemplateInjection {
                         value: serde_yaml::Value::String(new_script),
                     });
 
-                    // Add environment variables
+                    // Add environment variables (replace entire env section for security)
                     if !env_vars.is_empty() {
                         operations.push(YamlPatchOperation::MergeInto {
                             path: format!("/runs/steps/{}", step_index),

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -352,10 +352,63 @@ impl TemplateInjection {
     /// Generate a safe environment variable name from an expression
     fn generate_env_var_name(expr: &str) -> String {
         // Convert expressions like "github.event.issue.title" to "GITHUB_EVENT_ISSUE_TITLE"
-        expr.replace('.', "_")
-            .replace('-', "_")
-            .replace(' ', "_")
-            .to_uppercase()
+        // For fromJSON(secrets.foo).bar patterns, extract meaningful parts
+
+        let cleaned_expr = if expr.trim().starts_with("fromJSON(secrets.") {
+            // Handle patterns like "fromJSON(secrets.config).username"
+            // Extract the secret name and any property access
+            if let Some(closing_paren) = expr.find(')') {
+                let secrets_part = &expr[17..closing_paren]; // Skip "fromJSON(secrets."
+                let property_part = &expr[closing_paren + 1..]; // Everything after ")"
+
+                // Combine secret name with property access
+                if property_part.starts_with('.') {
+                    format!("{}_{}", secrets_part, &property_part[1..]) // Remove the leading dot
+                } else if property_part.is_empty() {
+                    secrets_part.to_string()
+                } else {
+                    format!("{}_{}", secrets_part, property_part)
+                }
+            } else {
+                // Malformed expression, fall back to original
+                expr.to_string()
+            }
+        } else if expr.trim().starts_with("fromJSON(") && expr.trim().contains(')') {
+            // Handle other fromJSON patterns like "fromJSON(github.event.config).field"
+            if let Some(closing_paren) = expr.find(')') {
+                let inner_part = &expr[9..closing_paren]; // Skip "fromJSON("
+                let property_part = &expr[closing_paren + 1..]; // Everything after ")"
+
+                if property_part.starts_with('.') {
+                    format!("{}_{}", inner_part, &property_part[1..]) // Remove the leading dot
+                } else if property_part.is_empty() {
+                    inner_part.to_string()
+                } else {
+                    format!("{}_{}", inner_part, property_part)
+                }
+            } else {
+                // Malformed expression, fall back to original
+                expr.to_string()
+            }
+        } else if expr.starts_with("secrets.") {
+            // For direct secrets references, extract just the secret name
+            expr.strip_prefix("secrets.").unwrap_or(expr).to_string()
+        } else {
+            // For other expressions, use as-is
+            expr.to_string()
+        };
+
+        // Replace all special characters with underscores to ensure valid environment variable names
+        cleaned_expr
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() {
+                    c.to_ascii_uppercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect()
     }
 
     /// Create a fix that moves template expressions to environment variables for composite actions
@@ -673,6 +726,71 @@ mod tests {
             Capability::from_context("runner.arch"),
             Some(Capability::Fixed)
         ));
+    }
+
+    #[test]
+    fn test_generate_env_var_name() {
+        use super::TemplateInjection;
+
+        // Test basic cases
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("github.event.issue.title"),
+            "GITHUB_EVENT_ISSUE_TITLE"
+        );
+
+        // Test direct secrets references (should strip secrets. prefix)
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("secrets.api-config"),
+            "API_CONFIG"
+        );
+
+        // Test fromJSON(secrets.*) patterns (should extract just the secret name)
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("fromJSON(secrets.config)"),
+            "CONFIG"
+        );
+
+        // Test fromJSON(secrets.*) with property access
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("fromJSON(secrets.database-config).username"),
+            "DATABASE_CONFIG_USERNAME"
+        );
+
+        // Test fromJSON(secrets.*) with special characters
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("fromJSON(secrets.api-config)"),
+            "API_CONFIG"
+        );
+
+        // Test fromJSON(secrets.*) with complex names and property access
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("fromJSON(secrets.database_config).password"),
+            "DATABASE_CONFIG_PASSWORD"
+        );
+
+        // Test fromJSON with non-secrets content
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("fromJSON(github.event.config)"),
+            "GITHUB_EVENT_CONFIG"
+        );
+
+        // Test with mixed special characters
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("github.event@issue.title"),
+            "GITHUB_EVENT_ISSUE_TITLE"
+        );
+
+        // Test with spaces and other special characters
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("my var.name-test@prod"),
+            "MY_VAR_NAME_TEST_PROD"
+        );
+
+        // Test with numbers (should be preserved)
+        assert_eq!(
+            TemplateInjection::generate_env_var_name("config.v2.test"),
+            "CONFIG_V2_TEST"
+        );
     }
 
     #[test]

--- a/crates/zizmor/src/audit/unpinned_images.rs
+++ b/crates/zizmor/src/audit/unpinned_images.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
 
 use crate::{
-    finding::{Confidence, Finding, Persona, Severity, SymbolicLocation},
+    apply_yaml_patch,
+    finding::{Confidence, Finding, Fix, Persona, Severity, SymbolicLocation},
     models::JobExt as _,
     state::AuditState,
+    yaml_patch::YamlPatchOperation,
 };
 
 use github_actions_models::common::DockerUses;
@@ -19,16 +21,154 @@ impl UnpinnedImages {
         location: SymbolicLocation<'doc>,
         annotation: &str,
         persona: Persona,
+        fixes: Vec<Fix>,
         job: &super::NormalJob<'doc>,
     ) -> Result<Finding<'doc>> {
         let mut annotated_location = location;
         annotated_location = annotated_location.annotated(annotation);
-        Self::finding()
+        let mut finding_builder = Self::finding()
             .severity(Severity::High)
             .confidence(Confidence::High)
             .add_location(annotated_location)
-            .persona(persona)
-            .build(job.parent())
+            .persona(persona);
+
+        for fix in fixes {
+            finding_builder = finding_builder.fix(fix);
+        }
+
+        finding_builder.build(job.parent())
+    }
+
+    /// Create a fix that provides guidance on pinning to SHA256 hash
+    fn create_sha256_pin_guidance_fix(image_name: &str) -> Fix {
+        Fix {
+            title: "Pin container image to SHA256 hash".to_string(),
+            description: format!(
+                "Pin the container image '{}' to a specific SHA256 hash for security and reproducibility. \
+                You can find the SHA256 hash by:\n\
+                1. Checking your container registry's web interface\n\
+                2. Running 'docker inspect {}' locally if you have the image\n\
+                3. Using 'docker pull {}' and checking the digest\n\
+                4. Looking at the registry API or manifest\n\n\
+                Example: {}@sha256:abcd1234...",
+                image_name, image_name, image_name, image_name
+            ),
+            apply: Box::new(|content| Ok(Some(content.to_string()))),
+        }
+    }
+
+    /// Create a fix that adds a specific tag instead of latest
+    fn create_specific_tag_fix(image_path: &str, image_name: &str) -> Fix {
+        Fix {
+            title: "Replace 'latest' tag with specific version".to_string(),
+            description: format!(
+                "Replace the 'latest' tag with a specific version tag for '{}'. \
+                Check the container registry for available tags and choose a specific version. \
+                This provides better reproducibility than 'latest' which can change over time.",
+                image_name
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: image_path.to_string(),
+                value: serde_yaml::Value::String(format!("{}:v1.0.0", image_name)),
+            }]),
+        }
+    }
+
+    /// Create a fix that adds a tag to completely unpinned images
+    fn create_add_tag_fix(image_path: &str, image_name: &str) -> Fix {
+        Fix {
+            title: "Add version tag to image".to_string(),
+            description: format!(
+                "Add a specific version tag to the unpinned image '{}'. \
+                Check the container registry for available tags and choose an appropriate version.",
+                image_name
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: image_path.to_string(),
+                value: serde_yaml::Value::String(format!("{}:v1.0.0", image_name)),
+            }]),
+        }
+    }
+
+    /// Create a fix that provides guidance on using docker inspect
+    fn create_docker_inspect_guidance_fix(image_name: &str) -> Fix {
+        Fix {
+            title: "Use docker inspect to find SHA256 hash".to_string(),
+            description: format!(
+                "Use 'docker inspect' to find the SHA256 hash for '{}'. \
+                Run the following commands:\n\
+                1. docker pull {}\n\
+                2. docker inspect {} --format='{{{{.RepoDigests}}}}'\n\
+                3. Use the SHA256 hash from the output to pin the image",
+                image_name, image_name, image_name
+            ),
+            apply: Box::new(|content| Ok(Some(content.to_string()))),
+        }
+    }
+
+    /// Create a fix that provides registry-specific guidance
+    fn create_registry_guidance_fix(image_name: &str) -> Fix {
+        let registry_hint = if image_name.contains("docker.io") || !image_name.contains('/') {
+            "Docker Hub"
+        } else if image_name.contains("ghcr.io") {
+            "GitHub Container Registry"
+        } else if image_name.contains("gcr.io") {
+            "Google Container Registry"
+        } else if image_name.contains("quay.io") {
+            "Quay.io"
+        } else {
+            "your container registry"
+        };
+
+        Fix {
+            title: "Check container registry for SHA256 hash".to_string(),
+            description: format!(
+                "Check {} for the SHA256 hash of '{}'. \
+                Most container registries display the SHA256 digest in their web interface. \
+                Look for the 'digest' or 'sha256' field in the image details.",
+                registry_hint, image_name
+            ),
+            apply: Box::new(|content| Ok(Some(content.to_string()))),
+        }
+    }
+
+    /// Get the appropriate fixes based on the image state
+    fn get_fixes_for_image(image: &DockerUses, image_path: &str) -> Vec<Fix> {
+        let image_name = if let Some(ref tag) = image.tag {
+            format!("{}:{}", image.image, tag)
+        } else {
+            image.image.clone()
+        };
+
+        let mut fixes = vec![];
+
+        match image.hash {
+            Some(_) => {
+                // Already has hash, no fixes needed
+            }
+            None => match image.tag.as_deref() {
+                Some("latest") => {
+                    // Has latest tag - suggest specific tag and SHA256
+                    fixes.push(Self::create_specific_tag_fix(image_path, &image.image));
+                    fixes.push(Self::create_sha256_pin_guidance_fix(&image.image));
+                    fixes.push(Self::create_registry_guidance_fix(&image.image));
+                }
+                None => {
+                    // Completely unpinned - suggest adding tag and SHA256
+                    fixes.push(Self::create_add_tag_fix(image_path, &image.image));
+                    fixes.push(Self::create_sha256_pin_guidance_fix(&image.image));
+                    fixes.push(Self::create_docker_inspect_guidance_fix(&image.image));
+                }
+                Some(_) => {
+                    // Has specific tag but no SHA256 - suggest SHA256 pinning
+                    fixes.push(Self::create_sha256_pin_guidance_fix(&image_name));
+                    fixes.push(Self::create_docker_inspect_guidance_fix(&image_name));
+                    fixes.push(Self::create_registry_guidance_fix(&image_name));
+                }
+            },
+        }
+
+        fixes
     }
 }
 
@@ -48,19 +188,23 @@ impl Audit for UnpinnedImages {
         job: &super::NormalJob<'doc>,
     ) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
-        let mut image_refs_with_locations: Vec<(DockerUses, SymbolicLocation<'doc>)> = vec![];
+        let mut image_refs_with_locations: Vec<(DockerUses, SymbolicLocation<'doc>, String)> =
+            vec![];
 
         if let Some(Container::Container { image, .. }) = &job.container {
+            let image_path = format!("/jobs/{}/container/image", job.id());
             image_refs_with_locations.push((
                 image.parse().unwrap(),
                 job.location()
                     .primary()
                     .with_keys(&["container".into(), "image".into()]),
+                image_path,
             ));
         }
 
         for (service, config) in job.services.iter() {
             if let Container::Container { image, .. } = &config {
+                let image_path = format!("/jobs/{}/services/{}/image", job.id(), service);
                 image_refs_with_locations.push((
                     image.parse().unwrap(),
                     job.location().primary().with_keys(&[
@@ -68,19 +212,23 @@ impl Audit for UnpinnedImages {
                         service.as_str().into(),
                         "image".into(),
                     ]),
+                    image_path,
                 ));
             }
         }
 
-        for (image, location) in image_refs_with_locations {
+        for (image, location, image_path) in image_refs_with_locations {
+            let fixes = Self::get_fixes_for_image(&image, &image_path);
+
             match image.hash {
-                Some(_) => continue,
+                Some(_) => continue, // Already pinned to hash, no finding needed
                 None => match image.tag.as_deref() {
                     Some("latest") => {
                         findings.push(self.build_finding(
                             location,
                             "container image is pinned to latest",
                             Persona::Regular,
+                            fixes,
                             job,
                         )?);
                     }
@@ -89,6 +237,7 @@ impl Audit for UnpinnedImages {
                             location,
                             "container image is unpinned",
                             Persona::Regular,
+                            fixes,
                             job,
                         )?);
                     }
@@ -97,6 +246,7 @@ impl Audit for UnpinnedImages {
                             location,
                             "container image is not pinned to a SHA256 hash",
                             Persona::Pedantic,
+                            fixes,
                             job,
                         )?);
                     }
@@ -105,5 +255,166 @@ impl Audit for UnpinnedImages {
         }
 
         Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use github_actions_models::common::DockerUses;
+
+    #[test]
+    fn test_sha256_pin_guidance_fix() {
+        let fix = UnpinnedImages::create_sha256_pin_guidance_fix("nginx");
+
+        assert_eq!(fix.title, "Pin container image to SHA256 hash");
+        assert!(fix.description.contains("nginx"));
+        assert!(fix.description.contains("docker inspect"));
+        assert!(fix.description.contains("sha256:abcd1234"));
+
+        // Test that the fix doesn't modify content (guidance only)
+        let result = fix.apply_to_content("test content").unwrap();
+        assert_eq!(result, Some("test content".to_string()));
+    }
+
+    #[test]
+    fn test_specific_tag_fix() {
+        let fix = UnpinnedImages::create_specific_tag_fix("/jobs/test/container/image", "nginx");
+
+        assert_eq!(fix.title, "Replace 'latest' tag with specific version");
+        assert!(fix.description.contains("nginx"));
+        assert!(fix.description.contains("latest"));
+    }
+
+    #[test]
+    fn test_add_tag_fix() {
+        let fix = UnpinnedImages::create_add_tag_fix("/jobs/test/container/image", "nginx");
+
+        assert_eq!(fix.title, "Add version tag to image");
+        assert!(fix.description.contains("nginx"));
+        assert!(fix.description.contains("unpinned"));
+    }
+
+    #[test]
+    fn test_docker_inspect_guidance_fix() {
+        let fix = UnpinnedImages::create_docker_inspect_guidance_fix("nginx:1.21");
+
+        assert_eq!(fix.title, "Use docker inspect to find SHA256 hash");
+        assert!(fix.description.contains("docker pull nginx:1.21"));
+        assert!(fix.description.contains("docker inspect nginx:1.21"));
+
+        // Test that the fix doesn't modify content (guidance only)
+        let result = fix.apply_to_content("test content").unwrap();
+        assert_eq!(result, Some("test content".to_string()));
+    }
+
+    #[test]
+    fn test_registry_guidance_fix() {
+        // Test Docker Hub detection
+        let fix = UnpinnedImages::create_registry_guidance_fix("nginx");
+        assert!(fix.description.contains("Docker Hub"));
+
+        // Test GitHub Container Registry detection
+        let fix = UnpinnedImages::create_registry_guidance_fix("ghcr.io/owner/repo");
+        assert!(fix.description.contains("GitHub Container Registry"));
+
+        // Test Google Container Registry detection
+        let fix = UnpinnedImages::create_registry_guidance_fix("gcr.io/project/image");
+        assert!(fix.description.contains("Google Container Registry"));
+
+        // Test Quay.io detection
+        let fix = UnpinnedImages::create_registry_guidance_fix("quay.io/org/image");
+        assert!(fix.description.contains("Quay.io"));
+
+        // Test generic registry
+        let fix = UnpinnedImages::create_registry_guidance_fix("registry.example.com/image");
+        assert!(fix.description.contains("your container registry"));
+    }
+
+    #[test]
+    fn test_get_fixes_for_image_with_hash() {
+        let image = DockerUses {
+            registry: None,
+            image: "nginx".to_string(),
+            tag: Some("1.21".to_string()),
+            hash: Some("sha256:abcd1234".to_string()),
+        };
+
+        let fixes = UnpinnedImages::get_fixes_for_image(&image, "/jobs/test/container/image");
+
+        // Should have no fixes since it already has a hash
+        assert_eq!(fixes.len(), 0);
+    }
+
+    #[test]
+    fn test_get_fixes_for_image_with_latest_tag() {
+        let image = DockerUses {
+            registry: None,
+            image: "nginx".to_string(),
+            tag: Some("latest".to_string()),
+            hash: None,
+        };
+
+        let fixes = UnpinnedImages::get_fixes_for_image(&image, "/jobs/test/container/image");
+
+        // Should have 3 fixes: specific tag, SHA256 guidance, registry guidance
+        assert_eq!(fixes.len(), 3);
+        assert_eq!(fixes[0].title, "Replace 'latest' tag with specific version");
+        assert_eq!(fixes[1].title, "Pin container image to SHA256 hash");
+        assert_eq!(fixes[2].title, "Check container registry for SHA256 hash");
+    }
+
+    #[test]
+    fn test_get_fixes_for_image_unpinned() {
+        let image = DockerUses {
+            registry: None,
+            image: "nginx".to_string(),
+            tag: None,
+            hash: None,
+        };
+
+        let fixes = UnpinnedImages::get_fixes_for_image(&image, "/jobs/test/container/image");
+
+        // Should have 3 fixes: add tag, SHA256 guidance, docker inspect guidance
+        assert_eq!(fixes.len(), 3);
+        assert_eq!(fixes[0].title, "Add version tag to image");
+        assert_eq!(fixes[1].title, "Pin container image to SHA256 hash");
+        assert_eq!(fixes[2].title, "Use docker inspect to find SHA256 hash");
+    }
+
+    #[test]
+    fn test_get_fixes_for_image_with_specific_tag() {
+        let image = DockerUses {
+            registry: None,
+            image: "nginx".to_string(),
+            tag: Some("1.21".to_string()),
+            hash: None,
+        };
+
+        let fixes = UnpinnedImages::get_fixes_for_image(&image, "/jobs/test/container/image");
+
+        // Should have 3 fixes: SHA256 guidance, docker inspect guidance, registry guidance
+        assert_eq!(fixes.len(), 3);
+        assert_eq!(fixes[0].title, "Pin container image to SHA256 hash");
+        assert_eq!(fixes[1].title, "Use docker inspect to find SHA256 hash");
+        assert_eq!(fixes[2].title, "Check container registry for SHA256 hash");
+    }
+
+    #[test]
+    fn test_fix_descriptions_are_informative() {
+        let fixes = [
+            UnpinnedImages::create_sha256_pin_guidance_fix("nginx"),
+            UnpinnedImages::create_specific_tag_fix("/path", "nginx"),
+            UnpinnedImages::create_add_tag_fix("/path", "nginx"),
+            UnpinnedImages::create_docker_inspect_guidance_fix("nginx"),
+            UnpinnedImages::create_registry_guidance_fix("nginx"),
+        ];
+
+        for fix in &fixes {
+            // Each fix should have a meaningful title and description
+            assert!(!fix.title.is_empty());
+            assert!(!fix.description.is_empty());
+            assert!(fix.description.len() > 50); // Should be reasonably detailed
+        }
     }
 }

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -5,9 +5,14 @@ use github_actions_models::common::{RepositoryUses, Uses};
 use serde::Deserialize;
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
-use crate::finding::{Confidence, Finding, Persona, Severity};
-use crate::models::uses::RepositoryUsesPattern;
-use crate::models::{CompositeStep, Step, StepCommon, uses::UsesExt as _};
+use crate::{
+    apply_yaml_patch,
+    finding::{Confidence, Finding, Fix, Persona, Severity},
+    models::uses::RepositoryUsesPattern,
+    models::{CompositeStep, JobExt as _, Step, StepCommon, uses::UsesExt as _},
+    oci_registry_client_with_fallback,
+    yaml_patch::YamlPatchOperation,
+};
 
 pub(crate) struct UnpinnedUses {
     policies: UnpinnedUsesPolicies,
@@ -87,33 +92,274 @@ impl UnpinnedUses {
         }
     }
 
-    fn process_step<'doc>(
+    /// Create a fix that adds a tag to completely unpinned repository actions
+    fn create_add_tag_fix(uses: &RepositoryUses, path: &str) -> Fix {
+        let suggested_ref = if uses.owner == "actions" || uses.owner == "github" {
+            // For official GitHub actions, suggest a common tag
+            match uses.repo.as_str() {
+                "checkout" => "v4",
+                "setup-node" => "v4",
+                "setup-python" => "v5",
+                "setup-java" => "v4",
+                "setup-go" => "v5",
+                "upload-artifact" => "v4",
+                "download-artifact" => "v4",
+                "cache" => "v4",
+                _ => "v1", // Generic fallback
+            }
+        } else {
+            "v1.0.0" // Generic version for third-party actions
+        };
+
+        let new_uses = if let Some(subpath) = &uses.subpath {
+            format!("{}/{}{}@{}", uses.owner, uses.repo, subpath, suggested_ref)
+        } else {
+            format!("{}/{}@{}", uses.owner, uses.repo, suggested_ref)
+        };
+
+        Fix {
+            title: format!("Add {} tag to action", suggested_ref),
+            description: format!(
+                "Add a tag reference '{}' to the unpinned action '{}/{}'. \
+                This provides better reproducibility than using the default branch. \
+                Check the action's repository for available tags and choose an appropriate version.",
+                suggested_ref, uses.owner, uses.repo
+            ),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: path.to_string(),
+                value: serde_yaml::Value::String(new_uses),
+            }]),
+        }
+    }
+
+    /// Create a fix that converts a tag/branch to hash-pinned reference
+    fn create_hash_pin_fix(uses: &RepositoryUses, _path: &str) -> Fix {
+        let current_ref = uses.git_ref.as_deref().unwrap_or("main");
+
+        Fix {
+            title: "Convert to hash-pinned reference".to_string(),
+            description: format!(
+                "Replace the symbolic reference '{}' with a hash-pinned reference for '{}/{}'. \
+                Visit https://github.com/{}/{}/commits/{} to find the latest commit SHA \
+                and replace '@{}' with '@<commit-sha>'. Hash-pinning provides the highest security \
+                by ensuring the exact code version is used.",
+                current_ref, uses.owner, uses.repo, uses.owner, uses.repo, current_ref, current_ref
+            ),
+            apply: Box::new(|content: &str| Ok(Some(content.to_string()))), // Manual fix
+        }
+    }
+
+    /// Create a fix that adds a Docker tag to unpinned Docker actions
+    fn create_docker_tag_fix(docker_image: &str, path: &str) -> Fix {
+        // Get actual tags from registry or fall back to static suggestions
+        let suggested_tags = Self::get_docker_tags_sync(docker_image);
+
+        let (title, description, apply_fn): (
+            String,
+            String,
+            Box<dyn Fn(&str) -> anyhow::Result<Option<String>> + Send + Sync>,
+        ) = if suggested_tags.is_empty() {
+            (
+                "Add version tag to Docker action".to_string(),
+                format!(
+                    "Add an appropriate version tag to the unpinned Docker action '{}'. \
+                        Check the Docker registry for available tags and choose a specific version. \
+                        This provides better reproducibility than using the implicit 'latest' tag.",
+                    docker_image
+                ),
+                Box::new(|content: &str| Ok(Some(content.to_string()))), // Manual fix - guidance only
+            )
+        } else {
+            let best_tag = &suggested_tags[0]; // Use the first (best) suggested tag
+            let new_uses = format!("docker://{}:{}", docker_image, best_tag);
+
+            (
+                format!("Add '{}' tag to Docker action", best_tag),
+                format!(
+                    "Add the '{}' tag to the unpinned Docker action '{}'. \
+                        This tag was fetched from the registry and provides better reproducibility than using the implicit 'latest' tag. \
+                        Other available tags include: {}.",
+                    best_tag,
+                    docker_image,
+                    suggested_tags
+                        .iter()
+                        .skip(1)
+                        .take(3) // Show up to 3 additional tags
+                        .map(|t| format!("'{}'", t))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                    path: path.to_string(),
+                    value: serde_yaml::Value::String(new_uses),
+                }]),
+            )
+        };
+
+        Fix {
+            title,
+            description,
+            apply: apply_fn,
+        }
+    }
+
+    /// Create a fix that suggests using hash-pinned Docker images
+    fn create_docker_hash_fix(docker_image: &str) -> Fix {
+        Fix {
+            title: "Convert to hash-pinned Docker image".to_string(),
+            description: format!(
+                "Replace the tag reference with a hash-pinned reference for the Docker image '{}'. \
+                Use 'docker inspect {}:<tag>' to find the SHA256 digest and replace the tag with '@sha256:<digest>'. \
+                Hash-pinning provides the highest security by ensuring the exact image version is used.",
+                docker_image, docker_image
+            ),
+            apply: Box::new(|content: &str| Ok(Some(content.to_string()))), // Manual fix
+        }
+    }
+
+    /// Create a fix that provides general pinning guidance
+    fn create_pinning_guidance_fix(uses: &Uses, policy: UsesPolicy) -> Fix {
+        let policy_desc = match policy {
+            UsesPolicy::Any => "no specific pinning requirements",
+            UsesPolicy::RefPin => "requires pinning to a tag, branch, or hash",
+            UsesPolicy::HashPin => "requires hash-pinning for maximum security",
+        };
+
+        let guidance = match uses {
+            Uses::Repository(repo_uses) => {
+                format!(
+                    "For repository action '{}/{}': {}. \
+                    Visit the action's repository to find appropriate tags or commit SHAs.",
+                    repo_uses.owner, repo_uses.repo, policy_desc
+                )
+            }
+            Uses::Docker(docker_uses) => {
+                format!(
+                    "For Docker action '{}': {}. \
+                    Check the Docker registry for available tags or use 'docker inspect' to find SHA256 digests.",
+                    docker_uses.image, policy_desc
+                )
+            }
+            Uses::Local(local_uses) => {
+                format!(
+                    "For local action '{}': {}. \
+                    Local actions are controlled by your repository, so pinning is less critical.",
+                    local_uses.path, policy_desc
+                )
+            }
+        };
+
+        Fix {
+            title: "Pinning guidance".to_string(),
+            description: guidance,
+            apply: Box::new(|content: &str| Ok(Some(content.to_string()))), // Guidance only
+        }
+    }
+
+    /// Get Docker tags from registry with fallback to static suggestions
+    fn get_docker_tags_sync(image_name: &str) -> Vec<String> {
+        // Try to get tags from registry using the macro
+        let get_tags = oci_registry_client_with_fallback!(3);
+
+        // Since we can't use async in this context, we'll use tokio::runtime::Handle
+        // to run the async operation if we're in a tokio context, otherwise fall back
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let tags = handle.block_on(get_tags(image_name));
+            if !tags.is_empty() {
+                return tags;
+            }
+        }
+
+        // Fall back to static suggestions if registry fetch fails or we're not in async context
+        Self::get_common_docker_tags(image_name)
+    }
+
+    /// Get common Docker tags for well-known images (fallback)
+    fn get_common_docker_tags(image_name: &str) -> Vec<String> {
+        match image_name {
+            "ubuntu" => vec![
+                "24.04".to_string(),
+                "22.04".to_string(),
+                "20.04".to_string(),
+            ],
+            "node" => vec!["20".to_string(), "18".to_string(), "16".to_string()],
+            "python" => vec!["3.12".to_string(), "3.11".to_string(), "3.10".to_string()],
+            "alpine" => vec!["3.19".to_string(), "3.18".to_string(), "latest".to_string()],
+            "nginx" => vec!["1.25".to_string(), "1.24".to_string(), "alpine".to_string()],
+            "redis" => vec!["7".to_string(), "6".to_string(), "alpine".to_string()],
+            "postgres" => vec!["16".to_string(), "15".to_string(), "14".to_string()],
+            "mysql" => vec!["8.0".to_string(), "5.7".to_string()],
+            _ => vec![], // No suggestions for unknown images
+        }
+    }
+
+    fn get_fixes_for_uses(
         &self,
-        step: &impl StepCommon<'doc>,
-    ) -> anyhow::Result<Vec<Finding<'doc>>> {
-        let mut findings = vec![];
+        uses: &Uses,
+        policy: UsesPolicy,
+        path: &str,
+        _item_type: &str,
+    ) -> Vec<Fix> {
+        let mut fixes = Vec::new();
 
-        let Some(uses) = step.uses() else {
-            return Ok(findings);
-        };
+        match uses {
+            Uses::Repository(repo_uses) => {
+                match policy {
+                    UsesPolicy::RefPin => {
+                        if uses.unpinned() {
+                            // Completely unpinned - suggest adding a tag
+                            fixes.push(Self::create_add_tag_fix(repo_uses, path));
+                            fixes.push(Self::create_pinning_guidance_fix(uses, policy));
+                        }
+                    }
+                    UsesPolicy::HashPin => {
+                        if uses.unpinned() {
+                            // Completely unpinned - suggest adding a tag first, then hash-pinning
+                            fixes.push(Self::create_add_tag_fix(repo_uses, path));
+                            fixes.push(Self::create_hash_pin_fix(repo_uses, path));
+                            fixes.push(Self::create_pinning_guidance_fix(uses, policy));
+                        } else if uses.unhashed() {
+                            // Has tag/branch but not hash-pinned
+                            fixes.push(Self::create_hash_pin_fix(repo_uses, path));
+                            fixes.push(Self::create_pinning_guidance_fix(uses, policy));
+                        }
+                    }
+                    UsesPolicy::Any => {
+                        // No restrictions, but still provide guidance
+                        if uses.unpinned() {
+                            fixes.push(Self::create_pinning_guidance_fix(uses, policy));
+                        }
+                    }
+                }
+            }
+            Uses::Docker(docker_uses) => {
+                if uses.unpinned() {
+                    // Unpinned Docker action - suggest adding a tag
+                    fixes.push(Self::create_docker_tag_fix(&docker_uses.image, path));
+                    fixes.push(Self::create_docker_hash_fix(&docker_uses.image));
+                } else if uses.unhashed() {
+                    // Has tag but not hash-pinned
+                    fixes.push(Self::create_docker_hash_fix(&docker_uses.image));
+                }
+                fixes.push(Self::create_pinning_guidance_fix(uses, policy));
+            }
+            Uses::Local(_) => {
+                // Local actions don't need pinning fixes, just provide guidance
+                fixes.push(Self::create_pinning_guidance_fix(uses, policy));
+            }
+        }
 
-        if let Some((annotation, severity, persona)) = self.evaluate_pinning(uses) {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::High)
-                    .severity(severity)
-                    .persona(persona)
-                    .add_location(
-                        step.location()
-                            .primary()
-                            .with_keys(&["uses".into()])
-                            .annotated(annotation),
-                    )
-                    .build(step)?,
-            );
-        };
+        fixes
+    }
 
-        Ok(findings)
+    /// Get the path for a workflow step uses clause
+    fn get_step_uses_path(job_id: &str, step_index: usize) -> String {
+        format!("/jobs/{}/steps/{}/uses", job_id, step_index)
+    }
+
+    /// Get the path for a composite step uses clause
+    fn get_composite_step_uses_path(step_index: usize) -> String {
+        format!("/runs/steps/{}/uses", step_index)
     }
 }
 
@@ -137,14 +383,104 @@ impl Audit for UnpinnedUses {
     }
 
     fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
-        self.process_step(step)
+        let mut findings = vec![];
+
+        let Some(uses) = step.uses() else {
+            return Ok(findings);
+        };
+
+        if let Some((annotation, severity, persona)) = self.evaluate_pinning(uses) {
+            // Determine the policy that triggered this finding
+            let policy = match uses {
+                Uses::Repository(repo_uses) => {
+                    let (_, policy) = self.policies.get_policy(repo_uses);
+                    policy
+                }
+                Uses::Docker(_) => {
+                    if uses.unpinned() {
+                        UsesPolicy::RefPin
+                    } else {
+                        UsesPolicy::HashPin
+                    }
+                }
+                Uses::Local(_) => UsesPolicy::Any,
+            };
+
+            // Construct the proper YAML path for this step
+            let step_path = Self::get_step_uses_path(step.job().id(), step.index);
+            let fixes = self.get_fixes_for_uses(uses, policy, &step_path, "step");
+
+            let mut finding_builder = Self::finding()
+                .severity(severity)
+                .confidence(Confidence::High)
+                .persona(persona)
+                .add_location(
+                    step.location()
+                        .with_keys(&["uses".into()])
+                        .primary()
+                        .annotated(annotation),
+                );
+
+            for fix in fixes {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(step.workflow())?);
+        }
+
+        Ok(findings)
     }
 
     fn audit_composite_step<'a>(
         &self,
         step: &CompositeStep<'a>,
     ) -> anyhow::Result<Vec<Finding<'a>>> {
-        self.process_step(step)
+        let mut findings = vec![];
+
+        let Some(uses) = step.uses() else {
+            return Ok(findings);
+        };
+
+        if let Some((annotation, severity, persona)) = self.evaluate_pinning(uses) {
+            // Determine the policy that triggered this finding
+            let policy = match uses {
+                Uses::Repository(repo_uses) => {
+                    let (_, policy) = self.policies.get_policy(repo_uses);
+                    policy
+                }
+                Uses::Docker(_) => {
+                    if uses.unpinned() {
+                        UsesPolicy::RefPin
+                    } else {
+                        UsesPolicy::HashPin
+                    }
+                }
+                Uses::Local(_) => UsesPolicy::Any,
+            };
+
+            // Construct the proper YAML path for this composite step
+            let step_path = Self::get_composite_step_uses_path(step.index);
+            let fixes = self.get_fixes_for_uses(uses, policy, &step_path, "composite step");
+
+            let mut finding_builder = Self::finding()
+                .severity(severity)
+                .confidence(Confidence::High)
+                .persona(persona)
+                .add_location(
+                    step.location()
+                        .with_keys(&["uses".into()])
+                        .primary()
+                        .annotated(annotation),
+                );
+
+            for fix in fixes {
+                finding_builder = finding_builder.fix(fix);
+            }
+
+            findings.push(finding_builder.build(step.action())?);
+        }
+
+        Ok(findings)
     }
 }
 
@@ -297,5 +633,183 @@ impl TryFrom<UnpinnedUsesConfig> for UnpinnedUsesPolicies {
             policy_tree,
             default_policy,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use github_actions_models::common::{DockerUses, RepositoryUses};
+
+    #[test]
+    fn test_add_tag_fix() {
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: None,
+            subpath: None,
+        };
+
+        let fix = UnpinnedUses::create_add_tag_fix(&uses, "/jobs/test/steps/0/uses");
+        assert_eq!(fix.title, "Add v4 tag to action");
+        assert!(fix.description.contains("actions/checkout"));
+        assert!(fix.description.contains("v4"));
+
+        // Test the fix application
+        let yaml_content = r#"jobs:
+  test:
+    steps:
+      - uses: actions/checkout"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+        assert!(result.contains("actions/checkout@v4"));
+    }
+
+    #[test]
+    fn test_add_tag_fix_third_party() {
+        let uses = RepositoryUses {
+            owner: "codecov".to_string(),
+            repo: "codecov-action".to_string(),
+            git_ref: None,
+            subpath: None,
+        };
+
+        let fix = UnpinnedUses::create_add_tag_fix(&uses, "/jobs/test/steps/0/uses");
+        assert_eq!(fix.title, "Add v1.0.0 tag to action");
+        assert!(fix.description.contains("codecov/codecov-action"));
+        assert!(fix.description.contains("v1.0.0"));
+    }
+
+    #[test]
+    fn test_hash_pin_fix() {
+        let uses = RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: Some("v4".to_string()),
+            subpath: None,
+        };
+
+        let fix = UnpinnedUses::create_hash_pin_fix(&uses, "/jobs/test/steps/0/uses");
+        assert_eq!(fix.title, "Convert to hash-pinned reference");
+        assert!(fix.description.contains("actions/checkout"));
+        assert!(fix.description.contains("v4"));
+        assert!(
+            fix.description
+                .contains("https://github.com/actions/checkout/commits/v4")
+        );
+    }
+
+    #[test]
+    fn test_docker_tag_fix() {
+        let fix = UnpinnedUses::create_docker_tag_fix("ubuntu", "/jobs/test/steps/0/uses");
+        // Now we expect the actual tag from registry (or fallback)
+        assert_eq!(fix.title, "Add '24.04' tag to Docker action");
+        assert!(fix.description.contains("ubuntu"));
+        assert!(fix.description.contains("24.04"));
+
+        // Test the fix application - should now actually apply the tag
+        let yaml_content = r#"jobs:
+  test:
+    steps:
+      - uses: docker://ubuntu"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+        assert!(result.contains("docker://ubuntu:24.04")); // Should be modified with the tag
+    }
+
+    #[test]
+    fn test_docker_hash_fix() {
+        let fix = UnpinnedUses::create_docker_hash_fix("ubuntu");
+        assert_eq!(fix.title, "Convert to hash-pinned Docker image");
+        assert!(fix.description.contains("ubuntu"));
+        assert!(fix.description.contains("docker inspect ubuntu"));
+    }
+
+    #[test]
+    fn test_pinning_guidance_fix() {
+        let uses = Uses::Repository(RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: None,
+            subpath: None,
+        });
+
+        let fix = UnpinnedUses::create_pinning_guidance_fix(&uses, UsesPolicy::HashPin);
+        assert_eq!(fix.title, "Pinning guidance");
+        assert!(fix.description.contains("actions/checkout"));
+        assert!(fix.description.contains("hash-pinning"));
+        assert!(fix.description.contains("repository"));
+    }
+
+    #[test]
+    fn test_get_fixes_for_uses_unpinned_repo() {
+        let uses = Uses::Repository(RepositoryUses {
+            owner: "actions".to_string(),
+            repo: "checkout".to_string(),
+            git_ref: None,
+            subpath: None,
+        });
+
+        let audit = create_test_audit();
+        let fixes = audit.get_fixes_for_uses(&uses, UsesPolicy::RefPin, "/test", "step");
+        assert_eq!(fixes.len(), 2); // add tag + guidance
+        assert_eq!(fixes[0].title, "Add v4 tag to action");
+        assert_eq!(fixes[1].title, "Pinning guidance");
+    }
+
+    #[test]
+    fn test_get_fixes_for_uses_hash_pin_policy() {
+        let uses = Uses::Repository(RepositoryUses {
+            owner: "third-party".to_string(),
+            repo: "action".to_string(),
+            git_ref: None,
+            subpath: None,
+        });
+
+        let audit = create_test_audit();
+        let fixes = audit.get_fixes_for_uses(&uses, UsesPolicy::HashPin, "/test", "step");
+        assert_eq!(fixes.len(), 3); // add tag + hash pin + guidance
+        assert_eq!(fixes[0].title, "Add v1.0.0 tag to action");
+        assert_eq!(fixes[1].title, "Convert to hash-pinned reference");
+        assert_eq!(fixes[2].title, "Pinning guidance");
+    }
+
+    #[test]
+    fn test_get_fixes_for_uses_tagged_but_unhashed() {
+        let uses = Uses::Repository(RepositoryUses {
+            owner: "third-party".to_string(),
+            repo: "action".to_string(),
+            git_ref: Some("v1.0.0".to_string()),
+            subpath: None,
+        });
+
+        let audit = create_test_audit();
+        let fixes = audit.get_fixes_for_uses(&uses, UsesPolicy::HashPin, "/test", "step");
+        assert_eq!(fixes.len(), 2); // hash pin + guidance
+        assert_eq!(fixes[0].title, "Convert to hash-pinned reference");
+        assert_eq!(fixes[1].title, "Pinning guidance");
+    }
+
+    #[test]
+    fn test_get_fixes_for_uses_docker_unpinned() {
+        let uses = Uses::Docker(DockerUses {
+            image: "ubuntu".to_string(),
+            tag: None,
+            hash: None,
+            registry: None,
+        });
+
+        let audit = create_test_audit();
+        let fixes = audit.get_fixes_for_uses(&uses, UsesPolicy::RefPin, "/test", "step");
+        assert_eq!(fixes.len(), 3); // docker tag + docker hash + guidance
+        assert_eq!(fixes[0].title, "Add '24.04' tag to Docker action"); // Now expects actual tag
+        assert_eq!(fixes[1].title, "Convert to hash-pinned Docker image");
+        assert_eq!(fixes[2].title, "Pinning guidance");
+    }
+
+    fn create_test_audit() -> UnpinnedUses {
+        UnpinnedUses {
+            policies: UnpinnedUsesPolicies::try_from(UnpinnedUsesConfig::default()).unwrap(),
+        }
     }
 }

--- a/crates/zizmor/src/audit/unredacted_secrets.rs
+++ b/crates/zizmor/src/audit/unredacted_secrets.rs
@@ -2,7 +2,7 @@ use github_actions_expressions::{Expr, context::Context};
 
 use crate::{
     Confidence, Severity,
-    finding::{Feature, Location},
+    finding::{Feature, Fix, Location},
     utils::parse_expressions_from_input,
 };
 
@@ -36,31 +36,75 @@ impl Audit for UnredactedSecrets {
                 continue;
             };
 
-            for _ in Self::secret_leakages(&parsed) {
-                findings.push(
-                    Self::finding()
-                        .confidence(Confidence::High)
-                        .severity(Severity::Medium)
-                        .add_raw_location(Location::new(
-                            input
-                                .location()
-                                .annotated("bypasses secret redaction")
-                                .primary(),
-                            Feature::from_span(&span, input),
-                        ))
-                        .build(input)?,
-                );
+            let leakages = Self::secret_leakages(&parsed);
+            for leakage in leakages {
+                let fixes = Self::create_fixes_for_leakage(&leakage, input);
+
+                let mut finding_builder = Self::finding()
+                    .confidence(Confidence::High)
+                    .severity(Severity::Medium)
+                    .add_raw_location(Location::new(
+                        input
+                            .location()
+                            .annotated("bypasses secret redaction")
+                            .primary(),
+                        Feature::from_span(&span, input),
+                    ));
+
+                for fix in fixes {
+                    finding_builder = finding_builder.fix(fix);
+                }
+
+                findings.push(finding_builder.build(input)?);
             }
         }
-
-        findings.len();
 
         Ok(findings)
     }
 }
 
+#[derive(Debug, Clone)]
+struct SecretLeakage {
+    /// The type of leakage detected
+    leakage_type: LeakageType,
+    /// The original expression that causes the leakage
+    original_expr: String,
+    /// The secret context being leaked (e.g., "secrets.foo")
+    secret_context: String,
+}
+
+#[derive(Debug, Clone)]
+enum LeakageType {
+    /// fromJSON(secrets.foo) - JSON parsing of secrets
+    FromJson,
+    // Future: other types of secret manipulation that bypass redaction
+}
+
 impl UnredactedSecrets {
-    fn secret_leakages(expr: &Expr) -> Vec<()> {
+    /// Normalize a secret name by replacing special characters with underscores
+    /// and converting to uppercase for consistency with GitHub Actions conventions
+    fn normalize_secret_name(name: &str) -> String {
+        // First, clean up any expression-like formatting that might be present
+        let cleaned = name
+            .replace("fromJSON(", "")
+            .replace("secrets.", "")
+            .replace(")", "")
+            .replace("(", "")
+            .replace("\"", "");
+
+        cleaned
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() {
+                    c.to_ascii_uppercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect()
+    }
+
+    fn secret_leakages(expr: &Expr) -> Vec<SecretLeakage> {
         let mut results = vec![];
 
         // We're looking for patterns like `fromJSON(secrets.foo)`,
@@ -69,14 +113,22 @@ impl UnredactedSecrets {
 
         match expr {
             Expr::Call { func, args } => {
-                if func == "fromJSON"
-                    && args
-                        .iter()
-                        .any(|arg| matches!(arg, Expr::Context(ctx) if ctx.child_of("secrets")))
-                {
-                    results.push(());
-                } else {
-                    results.extend(args.iter().flat_map(Self::secret_leakages));
+                if func == "fromJSON" {
+                    for arg in args {
+                        if let Expr::Context(ctx) = arg {
+                            if ctx.child_of("secrets") {
+                                results.push(SecretLeakage {
+                                    leakage_type: LeakageType::FromJson,
+                                    original_expr: format!("fromJSON({:?})", ctx),
+                                    secret_context: format!("{:?}", ctx),
+                                });
+                            }
+                        }
+                    }
+                }
+                // Recursively check arguments for nested expressions
+                for arg in args {
+                    results.extend(Self::secret_leakages(arg));
                 }
             }
             Expr::Index(expr) => results.extend(Self::secret_leakages(expr)),
@@ -92,6 +144,92 @@ impl UnredactedSecrets {
         }
 
         results
+    }
+
+    /// Create fixes for a detected secret leakage
+    fn create_fixes_for_leakage(leakage: &SecretLeakage, _input: &super::AuditInput) -> Vec<Fix> {
+        let mut fixes = vec![];
+
+        match leakage.leakage_type {
+            LeakageType::FromJson => {
+                // Fix 1: Replace with individual secret fields
+                fixes.push(Self::create_individual_secrets_fix(leakage));
+
+                // Fix 2: Guidance on secret structure
+                fixes.push(Self::create_secret_structure_guidance_fix(leakage));
+
+                // Fix 3: Alternative approaches
+                fixes.push(Self::create_alternative_approaches_fix(leakage));
+            }
+        }
+
+        fixes
+    }
+
+    /// Create a fix that suggests using individual secret fields instead of JSON parsing
+    fn create_individual_secrets_fix(leakage: &SecretLeakage) -> Fix {
+        let secret_name = leakage
+            .secret_context
+            .strip_prefix("secrets.")
+            .unwrap_or(&leakage.secret_context);
+
+        let normalized_name = Self::normalize_secret_name(secret_name);
+
+        Fix {
+            title: "Use individual secret fields instead of JSON parsing".to_string(),
+            description: format!(
+                "Instead of using '{}', store individual fields as separate secrets. \
+                For example, if '{}' contains JSON like {{\"username\": \"user\", \"password\": \"pass\"}}, \
+                create separate secrets like 'secrets.{}_USERNAME' and 'secrets.{}_PASSWORD'. \
+                This ensures each field is properly redacted in logs.",
+                leakage.original_expr, secret_name, normalized_name, normalized_name
+            ),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // This is a manual fix that requires restructuring secrets
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that provides guidance on proper secret structure
+    fn create_secret_structure_guidance_fix(leakage: &SecretLeakage) -> Fix {
+        Fix {
+            title: "Restructure secrets to avoid JSON parsing".to_string(),
+            description: format!(
+                "The expression '{}' bypasses GitHub's secret redaction because the parsed JSON fields \
+                are not recognized as secret values. To fix this:\n\
+                1. Avoid storing structured data (JSON, YAML) in secrets\n\
+                2. Store each sensitive value as a separate secret\n\
+                3. Use descriptive secret names like 'DATABASE_USERNAME', 'DATABASE_PASSWORD'\n\
+                4. Access secrets directly: ${{{{ secrets.DATABASE_USERNAME }}}}\n\n\
+                This ensures all sensitive values are properly redacted in workflow logs.",
+                leakage.original_expr
+            ),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Guidance-only fix
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that suggests alternative approaches
+    fn create_alternative_approaches_fix(leakage: &SecretLeakage) -> Fix {
+        Fix {
+            title: "Consider alternative approaches for structured secrets".to_string(),
+            description: format!(
+                "If you need to use structured secret data, consider these alternatives to '{}':\n\
+                1. Use environment files: Store secrets in a file and load them at runtime\n\
+                2. Use a secret management service: Azure Key Vault, AWS Secrets Manager, etc.\n\
+                3. Use GitHub's environment secrets with different scopes\n\
+                4. Pass secrets as separate environment variables to your application\n\n\
+                These approaches maintain security while avoiding the redaction bypass issue.",
+                leakage.original_expr
+            ),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Guidance-only fix
+                Ok(Some(content.to_string()))
+            }),
+        }
     }
 }
 
@@ -121,5 +259,150 @@ mod tests {
                 *count
             );
         }
+    }
+
+    #[test]
+    fn test_secret_leakage_details() {
+        let expr = Expr::parse("fromJSON(secrets.my_secret)").unwrap();
+        let leakages = unredacted_secrets::UnredactedSecrets::secret_leakages(&expr);
+
+        assert_eq!(leakages.len(), 1);
+        let leakage = &leakages[0];
+
+        assert!(matches!(
+            leakage.leakage_type,
+            unredacted_secrets::LeakageType::FromJson
+        ));
+        assert!(leakage.secret_context.contains("secrets"));
+        assert!(leakage.secret_context.contains("my_secret"));
+        assert!(leakage.original_expr.contains("fromJSON"));
+        assert!(leakage.original_expr.contains("secrets"));
+        assert!(leakage.original_expr.contains("my_secret"));
+    }
+
+    #[test]
+    fn test_normalize_secret_name() {
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name("database_config"),
+            "DATABASE_CONFIG"
+        );
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name("api-config"),
+            "API_CONFIG"
+        );
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name("my.secret.name"),
+            "MY_SECRET_NAME"
+        );
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name("config@prod"),
+            "CONFIG_PROD"
+        );
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name("test-123_config"),
+            "TEST_123_CONFIG"
+        );
+
+        // Test expressions with parentheses and function calls
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name(
+                "fromJSON(secrets.api-config)"
+            ),
+            "API_CONFIG"
+        );
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name("secrets.db.config"),
+            "DB_CONFIG"
+        );
+        assert_eq!(
+            unredacted_secrets::UnredactedSecrets::normalize_secret_name(
+                "fromJSON(\"secrets.MyApp-Config_v2\")"
+            ),
+            "MYAPP_CONFIG_V2"
+        );
+    }
+
+    #[test]
+    fn test_individual_secrets_fix() {
+        let leakage = unredacted_secrets::SecretLeakage {
+            leakage_type: unredacted_secrets::LeakageType::FromJson,
+            original_expr: "fromJSON(secrets.database_config)".to_string(),
+            secret_context: "secrets.database_config".to_string(),
+        };
+
+        let fix = unredacted_secrets::UnredactedSecrets::create_individual_secrets_fix(&leakage);
+
+        assert_eq!(
+            fix.title,
+            "Use individual secret fields instead of JSON parsing"
+        );
+        assert!(fix.description.contains("DATABASE_CONFIG_USERNAME"));
+        assert!(fix.description.contains("DATABASE_CONFIG_PASSWORD"));
+        assert!(
+            fix.description
+                .contains("fromJSON(secrets.database_config)")
+        );
+    }
+
+    #[test]
+    fn test_individual_secrets_fix_with_special_chars() {
+        let leakage = unredacted_secrets::SecretLeakage {
+            leakage_type: unredacted_secrets::LeakageType::FromJson,
+            original_expr: "fromJSON(secrets.api-config)".to_string(),
+            secret_context: "secrets.api-config".to_string(),
+        };
+
+        let fix = unredacted_secrets::UnredactedSecrets::create_individual_secrets_fix(&leakage);
+
+        assert_eq!(
+            fix.title,
+            "Use individual secret fields instead of JSON parsing"
+        );
+        assert!(fix.description.contains("API_CONFIG_USERNAME"));
+        assert!(fix.description.contains("API_CONFIG_PASSWORD"));
+        assert!(fix.description.contains("fromJSON(secrets.api-config)"));
+    }
+
+    #[test]
+    fn test_secret_structure_guidance_fix() {
+        let leakage = unredacted_secrets::SecretLeakage {
+            leakage_type: unredacted_secrets::LeakageType::FromJson,
+            original_expr: "fromJSON(secrets.api_config)".to_string(),
+            secret_context: "secrets.api_config".to_string(),
+        };
+
+        let fix =
+            unredacted_secrets::UnredactedSecrets::create_secret_structure_guidance_fix(&leakage);
+
+        assert_eq!(fix.title, "Restructure secrets to avoid JSON parsing");
+        assert!(
+            fix.description
+                .contains("bypasses GitHub's secret redaction")
+        );
+        assert!(
+            fix.description
+                .contains("Store each sensitive value as a separate secret")
+        );
+        assert!(fix.description.contains("fromJSON(secrets.api_config)"));
+    }
+
+    #[test]
+    fn test_alternative_approaches_fix() {
+        let leakage = unredacted_secrets::SecretLeakage {
+            leakage_type: unredacted_secrets::LeakageType::FromJson,
+            original_expr: "fromJSON(secrets.config)".to_string(),
+            secret_context: "secrets.config".to_string(),
+        };
+
+        let fix =
+            unredacted_secrets::UnredactedSecrets::create_alternative_approaches_fix(&leakage);
+
+        assert_eq!(
+            fix.title,
+            "Consider alternative approaches for structured secrets"
+        );
+        assert!(fix.description.contains("secret management service"));
+        assert!(fix.description.contains("Azure Key Vault"));
+        assert!(fix.description.contains("AWS Secrets Manager"));
     }
 }

--- a/crates/zizmor/src/audit/unsound_contains.rs
+++ b/crates/zizmor/src/audit/unsound_contains.rs
@@ -3,7 +3,7 @@ use github_actions_models::common::{If, expr::ExplicitExpr};
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
 use crate::{
-    finding::{Confidence, Severity},
+    finding::{Confidence, Fix, Severity},
     models::{JobExt, StepCommon as _},
 };
 
@@ -41,37 +41,52 @@ impl Audit for UnsoundContains {
         &self,
         job: &super::NormalJob<'w>,
     ) -> anyhow::Result<Vec<super::Finding<'w>>> {
+        let mut findings = Vec::new();
+
         let conditions = job
             .r#if
             .iter()
-            .map(|cond| (cond, job.location()))
-            .chain(
-                job.steps()
-                    .filter_map(|step| step.r#if.as_ref().map(|cond| (cond, step.location()))),
-            )
-            .filter_map(|(cond, loc)| {
+            .map(|cond| (cond, job.location(), "job".to_string()))
+            .chain(job.steps().enumerate().filter_map(|(step_index, step)| {
+                step.r#if
+                    .as_ref()
+                    .map(|cond| (cond, step.location(), step_index.to_string()))
+            }))
+            .filter_map(|(cond, loc, step_info)| {
                 if let If::Expr(expr) = cond {
-                    Some((expr.as_str(), loc))
+                    Some((expr.as_str(), loc, step_info))
                 } else {
                     None
                 }
             });
 
-        conditions
-            .flat_map(|(expr, loc)| {
-                Self::unsound_contains(expr).into_iter().map(move |(severity, context)| {
-                    Self::finding()
-                        .severity(severity)
-                        .confidence(Confidence::High)
-                        .add_location(
-                            loc.with_keys(&["if".into()])
-                                .primary()
-                                .annotated(format!("contains(..) condition can be bypassed if attacker can control '{context}'")),
-                        )
-                        .build(job.parent())
-                })
-            })
-            .collect()
+        for (expr, loc, step_info) in conditions {
+            let unsound_results = Self::unsound_contains(expr);
+            for (severity, context, string_arg, context_arg) in unsound_results {
+                let fixes = Self::create_fixes_for_unsound_contains(
+                    expr,
+                    &string_arg,
+                    &context_arg,
+                    job.id(),
+                    step_info.clone(),
+                );
+
+                let mut finding_builder = Self::finding()
+                    .severity(severity)
+                    .confidence(Confidence::High)
+                    .add_location(loc.with_keys(&["if".into()]).primary().annotated(format!(
+                        "contains(..) condition can be bypassed if attacker can control '{context}'"
+                    )));
+
+                for fix in fixes {
+                    finding_builder = finding_builder.fix(fix);
+                }
+
+                findings.push(finding_builder.build(job.parent())?);
+            }
+        }
+
+        Ok(findings)
     }
 }
 
@@ -103,7 +118,7 @@ impl UnsoundContains {
         }
     }
 
-    fn unsound_contains(expr: &str) -> Vec<(Severity, String)> {
+    fn unsound_contains(expr: &str) -> Vec<(Severity, String, String, String)> {
         let bare = match ExplicitExpr::from_curly(expr) {
             Some(raw_expr) => raw_expr.as_bare().to_string(),
             None => expr.to_string(),
@@ -113,7 +128,7 @@ impl UnsoundContains {
             .inspect_err(|_err| tracing::warn!("couldn't parse expression: {expr}"))
             .iter()
             .flat_map(|expression| Self::walk_tree_for_unsound_contains(expression))
-            .map(|(_s, ctx)| {
+            .map(|(s, ctx)| {
                 let severity = if USER_CONTROLLABLE_CONTEXTS
                     .iter()
                     .any(|item| ctx.child_of(*item))
@@ -122,9 +137,129 @@ impl UnsoundContains {
                 } else {
                     Severity::Informational
                 };
-                (severity, ctx.as_str().to_string())
+                (
+                    severity,
+                    ctx.as_str().to_string(),
+                    s.to_string(),
+                    ctx.as_str().to_string(),
+                )
             })
             .collect()
+    }
+
+    /// Create fixes for unsound contains conditions
+    fn create_fixes_for_unsound_contains(
+        _expr: &str,
+        string_arg: &str,
+        context_arg: &str,
+        _job_id: &str,
+        _step_info: String,
+    ) -> Vec<Fix> {
+        let mut fixes = vec![];
+
+        // Fix 1: Use fromJSON with array instead of string
+        fixes.push(Self::create_fromjson_array_fix(string_arg, context_arg));
+
+        // Fix 2: Use explicit equality checks
+        fixes.push(Self::create_equality_checks_fix(string_arg, context_arg));
+
+        // Fix 3: Add input validation guidance
+        fixes.push(Self::create_validation_guidance_fix(context_arg));
+
+        fixes
+    }
+
+    /// Create a fix that suggests using fromJSON with an array instead of a string
+    fn create_fromjson_array_fix(string_arg: &str, context_arg: &str) -> Fix {
+        // Parse the string argument to extract individual values
+        let values: Vec<&str> = string_arg
+            .split_whitespace()
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let json_array = format!(
+            "[{}]",
+            values
+                .iter()
+                .map(|v| format!("\"{}\"", v))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        Fix {
+            title: "Use fromJSON with array for safe contains check".to_string(),
+            description: format!(
+                "Replace 'contains('{}', {})' with 'contains(fromJSON('{}'), {})'. \
+                This ensures that the contains() function checks for exact matches in an array \
+                rather than substring matches in a string, preventing bypass attacks.",
+                string_arg, context_arg, json_array, context_arg
+            ),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // This is a manual fix that requires updating the expression
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that suggests using explicit equality checks
+    fn create_equality_checks_fix(string_arg: &str, context_arg: &str) -> Fix {
+        // Parse the string argument to extract individual values
+        let values: Vec<&str> = string_arg
+            .split_whitespace()
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let equality_checks = values
+            .iter()
+            .map(|v| format!("{} == '{}'", context_arg, v))
+            .collect::<Vec<_>>()
+            .join(" || ");
+
+        Fix {
+            title: "Use explicit equality checks instead of contains".to_string(),
+            description: format!(
+                "Replace 'contains('{}', {})' with '{}'. \
+                This uses explicit equality comparisons that cannot be bypassed with substring attacks. \
+                Each condition checks for an exact match rather than a substring match.",
+                string_arg, context_arg, equality_checks
+            ),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // This is a manual fix that requires updating the expression
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that provides input validation guidance
+    fn create_validation_guidance_fix(context_arg: &str) -> Fix {
+        let guidance = if context_arg.starts_with("github.") {
+            "For GitHub context variables, consider adding additional validation to ensure \
+            the values match expected patterns. Use regular expressions or allowlists to \
+            validate the format before using in conditions."
+        } else if context_arg.starts_with("env.") {
+            "For environment variables, ensure they are set to known safe values. \
+            Consider using a validation step that checks the environment variable \
+            against an allowlist of expected values."
+        } else if context_arg.starts_with("inputs.") {
+            "For workflow inputs, add input validation using the 'type' and 'options' \
+            fields in your workflow definition. This restricts the possible values \
+            that can be passed to your workflow."
+        } else {
+            "Add validation for user-controllable inputs to ensure they match expected \
+            patterns before using them in security-sensitive conditions."
+        };
+
+        Fix {
+            title: "Add input validation for security-sensitive conditions".to_string(),
+            description: format!(
+                "The context variable '{}' can be controlled by attackers. {}",
+                context_arg, guidance
+            ),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Guidance-only fix
+                Ok(Some(content.to_string()))
+            }),
+        }
     }
 }
 
@@ -138,35 +273,75 @@ mod tests {
             // Vulnerable conditions
             (
                 "contains('refs/heads/main refs/heads/develop', github.ref)",
-                vec![(Severity::High, String::from("github.ref"))],
+                vec![(
+                    Severity::High,
+                    String::from("github.ref"),
+                    String::from("refs/heads/main refs/heads/develop"),
+                    String::from("github.ref"),
+                )],
             ),
             (
                 "contains('refs/heads/main refs/heads/develop', github.REF)",
-                vec![(Severity::High, String::from("github.REF"))], // case insensitive
+                vec![(
+                    Severity::High,
+                    String::from("github.REF"),
+                    String::from("refs/heads/main refs/heads/develop"),
+                    String::from("github.REF"),
+                )], // case insensitive
             ),
             (
                 "false || contains('main,develop', github.head_ref)",
-                vec![(Severity::High, String::from("github.head_ref"))],
+                vec![(
+                    Severity::High,
+                    String::from("github.head_ref"),
+                    String::from("main,develop"),
+                    String::from("github.head_ref"),
+                )],
             ),
             (
                 "!contains('main|develop', github.base_ref)",
-                vec![(Severity::High, String::from("github.base_ref"))],
+                vec![(
+                    Severity::High,
+                    String::from("github.base_ref"),
+                    String::from("main|develop"),
+                    String::from("github.base_ref"),
+                )],
             ),
             (
                 "contains(fromJSON('[true]'), contains('refs/heads/main refs/heads/develop', env.GITHUB_REF))",
-                vec![(Severity::High, String::from("env.GITHUB_REF"))],
+                vec![(
+                    Severity::High,
+                    String::from("env.GITHUB_REF"),
+                    String::from("refs/heads/main refs/heads/develop"),
+                    String::from("env.GITHUB_REF"),
+                )],
             ),
             (
                 "contains(fromJSON('[true]'), contains('refs/heads/main refs/heads/develop', env.github_ref))",
-                vec![(Severity::High, String::from("env.github_ref"))],
+                vec![(
+                    Severity::High,
+                    String::from("env.github_ref"),
+                    String::from("refs/heads/main refs/heads/develop"),
+                    String::from("env.github_ref"),
+                )],
             ),
             (
                 "contains(fromJSON('[true]'), contains('refs/heads/main refs/heads/develop', env.SOMETHING_RANDOM))",
-                vec![(Severity::High, String::from("env.SOMETHING_RANDOM"))],
+                vec![(
+                    Severity::High,
+                    String::from("env.SOMETHING_RANDOM"),
+                    String::from("refs/heads/main refs/heads/develop"),
+                    String::from("env.SOMETHING_RANDOM"),
+                )],
             ),
             (
                 "contains('push pull_request', github.event_name)",
-                vec![(Severity::Informational, String::from("github.event_name"))],
+                vec![(
+                    Severity::Informational,
+                    String::from("github.event_name"),
+                    String::from("push pull_request"),
+                    String::from("github.event_name"),
+                )],
             ),
             // These are okay.
             (
@@ -183,5 +358,95 @@ mod tests {
                 severity.as_slice()
             );
         }
+    }
+
+    #[test]
+    fn test_fromjson_array_fix() {
+        let fix = UnsoundContains::create_fromjson_array_fix(
+            "refs/heads/main refs/heads/develop",
+            "github.ref",
+        );
+
+        assert_eq!(fix.title, "Use fromJSON with array for safe contains check");
+        assert!(
+            fix.description
+                .contains("fromJSON('[\"refs/heads/main\", \"refs/heads/develop\"]')")
+        );
+        assert!(fix.description.contains("github.ref"));
+        assert!(fix.description.contains("exact matches in an array"));
+
+        // Test that the fix doesn't modify content (guidance only)
+        let result = fix.apply_to_content("test content").unwrap();
+        assert_eq!(result, Some("test content".to_string()));
+    }
+
+    #[test]
+    fn test_equality_checks_fix() {
+        let fix = UnsoundContains::create_equality_checks_fix("main develop", "github.head_ref");
+
+        assert_eq!(
+            fix.title,
+            "Use explicit equality checks instead of contains"
+        );
+        assert!(
+            fix.description
+                .contains("github.head_ref == 'main' || github.head_ref == 'develop'")
+        );
+        assert!(fix.description.contains("explicit equality comparisons"));
+
+        // Test that the fix doesn't modify content (guidance only)
+        let result = fix.apply_to_content("test content").unwrap();
+        assert_eq!(result, Some("test content".to_string()));
+    }
+
+    #[test]
+    fn test_validation_guidance_fix() {
+        // Test GitHub context guidance
+        let fix = UnsoundContains::create_validation_guidance_fix("github.ref");
+        assert_eq!(
+            fix.title,
+            "Add input validation for security-sensitive conditions"
+        );
+        assert!(fix.description.contains("GitHub context variables"));
+        assert!(fix.description.contains("regular expressions"));
+
+        // Test environment variable guidance
+        let fix = UnsoundContains::create_validation_guidance_fix("env.ENVIRONMENT");
+        assert!(fix.description.contains("environment variables"));
+        assert!(fix.description.contains("allowlist"));
+
+        // Test input guidance
+        let fix = UnsoundContains::create_validation_guidance_fix("inputs.deployment_type");
+        assert!(fix.description.contains("workflow inputs"));
+        assert!(fix.description.contains("type"));
+
+        // Test generic guidance
+        let fix = UnsoundContains::create_validation_guidance_fix("some.other.context");
+        assert!(fix.description.contains("user-controllable inputs"));
+    }
+
+    #[test]
+    fn test_create_fixes_for_unsound_contains() {
+        let fixes = UnsoundContains::create_fixes_for_unsound_contains(
+            "contains('main develop', github.head_ref)",
+            "main develop",
+            "github.head_ref",
+            "test-job",
+            "0".to_string(),
+        );
+
+        assert_eq!(fixes.len(), 3);
+        assert_eq!(
+            fixes[0].title,
+            "Use fromJSON with array for safe contains check"
+        );
+        assert_eq!(
+            fixes[1].title,
+            "Use explicit equality checks instead of contains"
+        );
+        assert_eq!(
+            fixes[2].title,
+            "Add input validation for security-sensitive conditions"
+        );
     }
 }

--- a/crates/zizmor/src/audit/use_trusted_publishing.rs
+++ b/crates/zizmor/src/audit/use_trusted_publishing.rs
@@ -8,9 +8,11 @@ use indexmap::IndexMap;
 
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::{
-    finding::{Confidence, Severity},
-    models::{StepCommon, uses::RepositoryUsesExt as _},
+    apply_yaml_patch,
+    finding::{Confidence, Fix, Severity},
+    models::{JobExt, StepCommon, uses::RepositoryUsesExt as _},
     state::AuditState,
+    yaml_patch::YamlPatchOperation,
 };
 
 const USES_MANUAL_CREDENTIAL: &str =
@@ -64,6 +66,147 @@ impl UseTrustedPublishing {
     ) -> bool {
         with.contains_key("api-token")
     }
+
+    /// Create a fix that removes the password field and adds id-token permission for PyPI
+    fn create_pypi_trusted_publishing_fix(job_id: String, step_index: usize) -> Fix {
+        let step_path = format!("/jobs/{}/steps/{}", job_id, step_index);
+        let password_path = format!("{}/with/password", step_path);
+        let job_path = format!("/jobs/{}", job_id);
+
+        Fix {
+            title: "Enable Trusted Publishing for PyPI".to_string(),
+            description: "Remove the 'password' field and ensure 'id-token: write' permission is set. \
+                Trusted Publishing uses OIDC tokens instead of manual API tokens, providing better security. \
+                You'll need to configure the trusted publisher in your PyPI project settings first.".to_string(),
+            apply: Box::new(move |old_content: &str| -> anyhow::Result<Option<String>> {
+                // First, remove the password field
+                let content_without_password = crate::yaml_patch::apply_yaml_patch(
+                    old_content,
+                    vec![YamlPatchOperation::Remove {
+                        path: password_path.clone(),
+                    }]
+                )?;
+
+                // Then, use MergeInto to add id-token permission to the job
+                // This will create the permissions section if it doesn't exist, or add to it if it does
+                let final_content = crate::yaml_patch::apply_yaml_patch(
+                    &content_without_password,
+                    vec![YamlPatchOperation::MergeInto {
+                        path: job_path.clone(),
+                        key: "permissions".to_string(),
+                        value: {
+                            let mut permissions_map = serde_yaml::Mapping::new();
+                            permissions_map.insert(
+                                serde_yaml::Value::String("id-token".to_string()),
+                                serde_yaml::Value::String("write".to_string()),
+                            );
+                            serde_yaml::Value::Mapping(permissions_map)
+                        },
+                    }]
+                )?;
+
+                Ok(Some(final_content))
+            }),
+        }
+    }
+
+    /// Create a fix that provides guidance on setting up PyPI trusted publishing
+    fn create_pypi_setup_guidance_fix() -> Fix {
+        Fix {
+            title: "Set up PyPI Trusted Publishing".to_string(),
+            description: "To use Trusted Publishing with PyPI:\n\
+                1. Go to your PyPI project settings\n\
+                2. Navigate to the 'Publishing' section\n\
+                3. Add a new trusted publisher for GitHub Actions\n\
+                4. Specify your repository owner, name, and workflow filename\n\
+                5. Optionally specify the environment name if using deployment environments\n\
+                6. Remove the 'password' field from your workflow and ensure 'id-token: write' permission is set\n\n\
+                This eliminates the need for long-lived API tokens and provides better security through OIDC.".to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Guidance-only fix
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create a fix that enables trusted publishing for RubyGems release-gem action
+    fn create_rubygems_release_gem_fix(job_id: String, step_index: usize) -> Fix {
+        let setup_trusted_publisher_path = format!(
+            "/jobs/{}/steps/{}/with/setup-trusted-publisher",
+            job_id, step_index
+        );
+
+        Fix {
+            title: "Enable Trusted Publishing for RubyGems".to_string(),
+            description:
+                "Set 'setup-trusted-publisher: true' to enable Trusted Publishing for RubyGems. \
+                This uses OIDC tokens instead of manual API tokens for better security."
+                    .to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Replace {
+                path: setup_trusted_publisher_path,
+                value: serde_yaml::Value::String("true".to_string()),
+            }]),
+        }
+    }
+
+    /// Create a fix that removes api-token and provides guidance for RubyGems credential action
+    fn create_rubygems_credential_fix(job_id: String, step_index: usize) -> Fix {
+        let api_token_path = format!("/jobs/{}/steps/{}/with/api-token", job_id, step_index);
+
+        Fix {
+            title: "Remove manual API token for RubyGems".to_string(),
+            description: "Remove the 'api-token' field and use Trusted Publishing instead. \
+                Configure the trusted publisher in your RubyGems.org account settings first."
+                .to_string(),
+            apply: apply_yaml_patch!(vec![YamlPatchOperation::Remove {
+                path: api_token_path,
+            }]),
+        }
+    }
+
+    /// Create a fix that provides guidance on setting up RubyGems trusted publishing
+    fn create_rubygems_setup_guidance_fix() -> Fix {
+        Fix {
+            title: "Set up RubyGems Trusted Publishing".to_string(),
+            description: "To use Trusted Publishing with RubyGems:\n\
+                1. Go to your RubyGems.org account settings\n\
+                2. Navigate to the 'Trusted Publishing' section\n\
+                3. Add a new trusted publisher for GitHub Actions\n\
+                4. Specify your repository owner, name, and workflow filename\n\
+                5. Optionally specify the environment name if using deployment environments\n\
+                6. Update your workflow to use trusted publishing instead of API tokens\n\n\
+                This provides better security through OIDC tokens instead of long-lived API keys."
+                .to_string(),
+            apply: Box::new(|content: &str| -> anyhow::Result<Option<String>> {
+                // Guidance-only fix
+                Ok(Some(content.to_string()))
+            }),
+        }
+    }
+
+    /// Create fixes for PyPI trusted publishing
+    fn create_pypi_fixes(job_id: String, step_index: usize) -> Vec<Fix> {
+        vec![
+            Self::create_pypi_trusted_publishing_fix(job_id, step_index),
+            Self::create_pypi_setup_guidance_fix(),
+        ]
+    }
+
+    /// Create fixes for RubyGems release-gem trusted publishing
+    fn create_rubygems_release_gem_fixes(job_id: String, step_index: usize) -> Vec<Fix> {
+        vec![
+            Self::create_rubygems_release_gem_fix(job_id, step_index),
+            Self::create_rubygems_setup_guidance_fix(),
+        ]
+    }
+
+    /// Create fixes for RubyGems credential trusted publishing
+    fn create_rubygems_credential_fixes(job_id: String, step_index: usize) -> Vec<Fix> {
+        vec![
+            Self::create_rubygems_credential_fix(job_id, step_index),
+            Self::create_rubygems_setup_guidance_fix(),
+        ]
+    }
 }
 
 impl Audit for UseTrustedPublishing {
@@ -85,7 +228,7 @@ impl Audit for UseTrustedPublishing {
             return Ok(findings);
         };
 
-        let candidate = Self::finding()
+        let mut candidate = Self::finding()
             .severity(Severity::Informational)
             .confidence(Confidence::High)
             .add_location(
@@ -98,6 +241,14 @@ impl Audit for UseTrustedPublishing {
         if uses.matches("pypa/gh-action-pypi-publish")
             && self.pypi_publish_uses_manual_credentials(with)
         {
+            let job_id = step.job().id().to_string();
+            let step_index = step.index;
+            let fixes = Self::create_pypi_fixes(job_id, step_index);
+
+            for fix in fixes {
+                candidate = candidate.fix(fix);
+            }
+
             findings.push(
                 candidate
                     .add_location(
@@ -108,11 +259,33 @@ impl Audit for UseTrustedPublishing {
                     )
                     .build(step.workflow())?,
             );
-        } else if ((uses.matches("rubygems/release-gem"))
-            && self.release_gem_uses_manual_credentials(with))
-            || (uses.matches("rubygems/configure-rubygems-credential")
-                && self.rubygems_credential_uses_manual_credentials(with))
+        } else if uses.matches("rubygems/release-gem")
+            && self.release_gem_uses_manual_credentials(with)
         {
+            let job_id = step.job().id().to_string();
+            let step_index = step.index;
+            let fixes = Self::create_rubygems_release_gem_fixes(job_id, step_index);
+
+            for fix in fixes {
+                candidate = candidate.fix(fix);
+            }
+
+            findings.push(
+                candidate
+                    .add_location(step.location().primary().annotated(USES_MANUAL_CREDENTIAL))
+                    .build(step.workflow())?,
+            );
+        } else if uses.matches("rubygems/configure-rubygems-credential")
+            && self.rubygems_credential_uses_manual_credentials(with)
+        {
+            let job_id = step.job().id().to_string();
+            let step_index = step.index;
+            let fixes = Self::create_rubygems_credential_fixes(job_id, step_index);
+
+            for fix in fixes {
+                candidate = candidate.fix(fix);
+            }
+
             findings.push(
                 candidate
                     .add_location(step.location().primary().annotated(USES_MANUAL_CREDENTIAL))
@@ -121,5 +294,160 @@ impl Audit for UseTrustedPublishing {
         }
 
         Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pypi_trusted_publishing_fix() {
+        let fix =
+            UseTrustedPublishing::create_pypi_trusted_publishing_fix("publish".to_string(), 1);
+
+        assert_eq!(fix.title, "Enable Trusted Publishing for PyPI");
+        assert!(fix.description.contains("Remove the 'password' field"));
+        assert!(fix.description.contains("id-token: write"));
+        assert!(fix.description.contains("OIDC tokens"));
+
+        // Test the fix application on a simple workflow
+        let yaml_content = r#"jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          repository-url: https://upload.pypi.org/legacy/"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+
+        // Should remove password and add id-token permission
+        assert!(!result.contains("password: ${{ secrets.PYPI_TOKEN }}"));
+        assert!(result.contains("id-token: write"));
+    }
+
+    #[test]
+    fn test_pypi_setup_guidance_fix() {
+        let fix = UseTrustedPublishing::create_pypi_setup_guidance_fix();
+
+        assert_eq!(fix.title, "Set up PyPI Trusted Publishing");
+        assert!(fix.description.contains("PyPI project settings"));
+        assert!(fix.description.contains("Publishing"));
+        assert!(fix.description.contains("trusted publisher"));
+        assert!(fix.description.contains("OIDC"));
+
+        // Test that the fix doesn't modify content (guidance only)
+        let result = fix.apply_to_content("test content").unwrap();
+        assert_eq!(result, Some("test content".to_string()));
+    }
+
+    #[test]
+    fn test_rubygems_release_gem_fix() {
+        let fix = UseTrustedPublishing::create_rubygems_release_gem_fix("publish".to_string(), 0);
+
+        assert_eq!(fix.title, "Enable Trusted Publishing for RubyGems");
+        assert!(fix.description.contains("setup-trusted-publisher: true"));
+        assert!(fix.description.contains("OIDC tokens"));
+
+        // Test the fix application
+        let yaml_content = r#"jobs:
+  publish:
+    steps:
+      - uses: rubygems/release-gem@v1
+        with:
+          setup-trusted-publisher: false"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+        // The YAML patch will quote the value, so check for both possibilities
+        assert!(
+            result.contains("setup-trusted-publisher: true")
+                || result.contains("setup-trusted-publisher: 'true'")
+        );
+        // Make sure the old value is gone
+        assert!(!result.contains("setup-trusted-publisher: false"));
+    }
+
+    #[test]
+    fn test_rubygems_credential_fix() {
+        let fix = UseTrustedPublishing::create_rubygems_credential_fix("publish".to_string(), 0);
+
+        assert_eq!(fix.title, "Remove manual API token for RubyGems");
+        assert!(fix.description.contains("Remove the 'api-token' field"));
+        assert!(fix.description.contains("Trusted Publishing"));
+
+        // Test the fix application
+        let yaml_content = r#"jobs:
+  publish:
+    steps:
+      - uses: rubygems/configure-rubygems-credential@v1
+        with:
+          api-token: ${{ secrets.RUBYGEMS_TOKEN }}"#;
+
+        let result = fix.apply_to_content(yaml_content).unwrap().unwrap();
+        assert!(!result.contains("api-token: ${{ secrets.RUBYGEMS_TOKEN }}"));
+    }
+
+    #[test]
+    fn test_rubygems_setup_guidance_fix() {
+        let fix = UseTrustedPublishing::create_rubygems_setup_guidance_fix();
+
+        assert_eq!(fix.title, "Set up RubyGems Trusted Publishing");
+        assert!(fix.description.contains("RubyGems.org account settings"));
+        assert!(fix.description.contains("Trusted Publishing"));
+        assert!(fix.description.contains("OIDC tokens"));
+
+        // Test that the fix doesn't modify content (guidance only)
+        let result = fix.apply_to_content("test content").unwrap();
+        assert_eq!(result, Some("test content".to_string()));
+    }
+
+    #[test]
+    fn test_create_pypi_fixes() {
+        let fixes = UseTrustedPublishing::create_pypi_fixes("test-job".to_string(), 1);
+
+        assert_eq!(fixes.len(), 2);
+        assert_eq!(fixes[0].title, "Enable Trusted Publishing for PyPI");
+        assert_eq!(fixes[1].title, "Set up PyPI Trusted Publishing");
+    }
+
+    #[test]
+    fn test_create_rubygems_release_gem_fixes() {
+        let fixes =
+            UseTrustedPublishing::create_rubygems_release_gem_fixes("test-job".to_string(), 0);
+
+        assert_eq!(fixes.len(), 2);
+        assert_eq!(fixes[0].title, "Enable Trusted Publishing for RubyGems");
+        assert_eq!(fixes[1].title, "Set up RubyGems Trusted Publishing");
+    }
+
+    #[test]
+    fn test_create_rubygems_credential_fixes() {
+        let fixes =
+            UseTrustedPublishing::create_rubygems_credential_fixes("test-job".to_string(), 0);
+
+        assert_eq!(fixes.len(), 2);
+        assert_eq!(fixes[0].title, "Remove manual API token for RubyGems");
+        assert_eq!(fixes[1].title, "Set up RubyGems Trusted Publishing");
+    }
+
+    #[test]
+    fn test_fix_descriptions_are_informative() {
+        let fixes = [
+            UseTrustedPublishing::create_pypi_trusted_publishing_fix("job".to_string(), 0),
+            UseTrustedPublishing::create_pypi_setup_guidance_fix(),
+            UseTrustedPublishing::create_rubygems_release_gem_fix("job".to_string(), 0),
+            UseTrustedPublishing::create_rubygems_credential_fix("job".to_string(), 0),
+            UseTrustedPublishing::create_rubygems_setup_guidance_fix(),
+        ];
+
+        for fix in &fixes {
+            // Each fix should have a meaningful title and description
+            assert!(!fix.title.is_empty());
+            assert!(!fix.description.is_empty());
+            assert!(fix.description.len() > 50); // Should be reasonably detailed
+        }
     }
 }

--- a/crates/zizmor/src/finding/mod.rs
+++ b/crates/zizmor/src/finding/mod.rs
@@ -468,7 +468,7 @@ pub(crate) struct Finding<'doc> {
     pub(crate) locations: Vec<Location<'doc>>,
     pub(crate) ignored: bool,
     #[serde(skip_serializing)]
-    pub(crate) fix: Option<Fix>,
+    pub(crate) fixes: Vec<Fix>,
 }
 
 impl<'doc> Finding<'doc> {
@@ -496,7 +496,7 @@ pub(crate) struct FindingBuilder<'doc> {
     persona: Persona,
     raw_locations: Vec<Location<'doc>>,
     locations: Vec<SymbolicLocation<'doc>>,
-    fix: Option<Fix>,
+    fixes: Vec<Fix>,
 }
 
 impl<'doc> FindingBuilder<'doc> {
@@ -510,7 +510,7 @@ impl<'doc> FindingBuilder<'doc> {
             persona: Default::default(),
             raw_locations: vec![],
             locations: vec![],
-            fix: None,
+            fixes: vec![],
         }
     }
 
@@ -540,7 +540,12 @@ impl<'doc> FindingBuilder<'doc> {
     }
 
     pub fn fix(mut self, fix: Fix) -> Self {
-        self.fix = Some(fix);
+        self.fixes.push(fix);
+        self
+    }
+
+    pub fn fixes(mut self, fixes: Vec<Fix>) -> Self {
+        self.fixes.extend(fixes);
         self
     }
 
@@ -575,7 +580,7 @@ impl<'doc> FindingBuilder<'doc> {
             },
             locations,
             ignored: should_ignore,
-            fix: self.fix,
+            fixes: self.fixes,
         })
     }
 

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -31,6 +31,7 @@ mod config;
 mod finding;
 mod github_api;
 mod models;
+mod oci_registry;
 mod output;
 mod registry;
 mod state;

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -13,6 +13,7 @@ use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::Generator;
 use clap_verbosity_flag::InfoLevel;
 use config::Config;
+use diff;
 use finding::{Confidence, Persona, Severity};
 use github_actions_models::common::Uses;
 use github_api::GitHubHost;
@@ -34,6 +35,7 @@ mod output;
 mod registry;
 mod state;
 mod utils;
+pub mod yaml_patch;
 
 /// Finds security issues in GitHub Actions setups.
 #[derive(Parser)]
@@ -141,6 +143,22 @@ struct App {
     /// to audit the repository at a particular git reference state.
     #[arg(required = true)]
     inputs: Vec<String>,
+
+    /// Apply fixes automatically if available.
+    #[arg(long)]
+    fix: bool,
+
+    /// Skip confirmation prompt when applying fixes.
+    #[arg(long, requires = "fix")]
+    yes: bool,
+
+    /// Show what fixes would be applied without actually writing them.
+    #[arg(long, requires = "fix")]
+    dry_run: bool,
+
+    /// Show a diff of the changes before applying them.
+    #[arg(long, requires = "fix")]
+    diff: bool,
 }
 
 /// Shell with auto-generated completion script available.
@@ -472,6 +490,53 @@ fn completions<G: clap_complete::Generator>(generator: G, cmd: &mut clap::Comman
     );
 }
 
+/// Format severity and rule name with appropriate color based on the same scheme used in plain output
+fn format_severity_and_rule(severity: &finding::Severity, rule_name: &str) -> String {
+    use owo_colors::OwoColorize;
+    let severity_name = match severity {
+        finding::Severity::Unknown => "note",
+        finding::Severity::Informational => "info",
+        finding::Severity::Low => "help",
+        finding::Severity::Medium => "warning",
+        finding::Severity::High => "error",
+    };
+
+    let formatted = format!("{}[{}]", severity_name, rule_name);
+
+    match severity {
+        finding::Severity::Unknown => formatted,
+        finding::Severity::Informational => formatted.purple().to_string(),
+        finding::Severity::Low => formatted.cyan().to_string(),
+        finding::Severity::Medium => formatted.yellow().to_string(),
+        finding::Severity::High => formatted.red().to_string(),
+    }
+}
+
+/// Get the primary line number for a finding, if available
+fn get_primary_line_number(finding: &finding::Finding) -> Option<usize> {
+    finding
+        .locations
+        .iter()
+        .find(|loc| loc.symbolic.is_primary())
+        .or_else(|| finding.locations.first())
+        .map(|loc| loc.concrete.location.start_point.row + 1) // Convert to 1-based line number
+}
+
+#[macro_export]
+macro_rules! colorize_diff {
+    ($diff:expr) => {
+        $diff
+            .iter()
+            .map(|line| match line {
+                diff::Result::Left(l) => format!("{}{}", "-".red(), l.red()),
+                diff::Result::Right(r) => format!("{}{}", "+".green(), r.green()),
+                diff::Result::Both(l, _) => format!(" {}", l),
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+}
+
 fn run() -> Result<ExitCode> {
     human_panic::setup_panic!();
 
@@ -652,6 +717,231 @@ fn run() -> Result<ExitCode> {
         }
         OutputFormat::Github => output::github::output(stdout(), results.findings())?,
     };
+
+    if app.fix {
+        use std::collections::HashMap;
+
+        // Collect all applicable fixes grouped by file
+        let mut file_fixes: HashMap<String, Vec<(&'static str, &finding::Finding)>> =
+            HashMap::new();
+
+        for finding in results.findings() {
+            if let Some(location) = finding.locations.first() {
+                let file_path = location.symbolic.key.presentation_path().to_string();
+                if finding.fix.is_some() {
+                    file_fixes
+                        .entry(file_path)
+                        .or_default()
+                        .push((finding.ident, finding));
+                }
+            }
+        }
+
+        if file_fixes.is_empty() {
+            println!("No fixes available to apply.");
+        } else {
+            // Process each file
+            let mut applied_fixes = Vec::new();
+            let mut failed_fixes = Vec::new();
+
+            for (file_path, fixes) in &file_fixes {
+                let original_content = match std::fs::read_to_string(&file_path) {
+                    Ok(content) => content,
+                    Err(e) => {
+                        eprintln!("Failed to read {}: {}", file_path, e);
+                        continue;
+                    }
+                };
+
+                let mut current_content = original_content.clone();
+                let mut file_applied_fixes = Vec::new();
+                let mut successful_fixes = Vec::new();
+
+                // First, try to apply each fix independently to the original content
+                // to collect which fixes can be applied successfully
+                for (ident, finding) in fixes {
+                    if let Some(fix) = &finding.fix {
+                        match fix.apply_to_content(&original_content) {
+                            Ok(Some(_)) => {
+                                successful_fixes.push((ident, fix, finding));
+                            }
+                            Ok(None) => {
+                                // Fix didn't apply (no changes needed)
+                            }
+                            Err(e) => {
+                                failed_fixes.push((*ident, file_path.clone(), format!("{}", e)));
+                            }
+                        }
+                    }
+                }
+
+                // Then apply successful fixes sequentially, handling conflicts gracefully
+                for (ident, fix, finding) in successful_fixes {
+                    match fix.apply_to_content(&current_content) {
+                        Ok(Some(new_content)) => {
+                            current_content = new_content;
+                            file_applied_fixes.push((ident, fix, finding));
+                        }
+                        Ok(None) => {
+                            // Fix didn't apply to modified content (possibly due to conflicts)
+                        }
+                        Err(e) => {
+                            // If the fix fails on modified content, it might be due to conflicts
+                            // with previously applied fixes. Record this as a failed fix.
+                            failed_fixes.push((
+                                ident,
+                                file_path.clone(),
+                                format!("conflict after applying previous fixes: {}", e),
+                            ));
+                        }
+                    }
+                }
+
+                // Only proceed if there are changes to apply
+                if current_content != original_content {
+                    if app.dry_run {
+                        println!("\n{}: {}", "File".green(), file_path);
+                        println!(
+                            "{}: {} fixes would be applied",
+                            "Fixes".green(),
+                            file_applied_fixes.len()
+                        );
+                        for (ident, fix, finding) in &file_applied_fixes {
+                            let line_info = if let Some(line) = get_primary_line_number(finding) {
+                                format!(" at line {}", line)
+                            } else {
+                                String::new()
+                            };
+                            println!(
+                                "  - {}{}: {}",
+                                format_severity_and_rule(&finding.determinations.severity, ident),
+                                line_info,
+                                fix.title
+                            );
+                        }
+                        println!("{}:\n{}", "New content".green(), current_content);
+                    } else if app.diff {
+                        println!("\n{}: {}", "File".green(), file_path);
+                        println!(
+                            "{}: {} fixes to apply",
+                            "Fixes".green(),
+                            file_applied_fixes.len()
+                        );
+                        for (ident, fix, finding) in &file_applied_fixes {
+                            let line_info = if let Some(line) = get_primary_line_number(finding) {
+                                format!(" at line {}", line)
+                            } else {
+                                String::new()
+                            };
+                            println!(
+                                "  - {}{}: {}",
+                                format_severity_and_rule(&finding.determinations.severity, ident),
+                                line_info,
+                                fix.title
+                            );
+                        }
+                        println!("{}:", "Diff".green());
+                        println!(
+                            "{}",
+                            colorize_diff!(diff::lines(&original_content, &current_content))
+                        );
+
+                        print!("Apply all fixes to this file? [y/N] ");
+                        stdout().flush()?;
+                        let mut input = String::new();
+                        std::io::stdin().read_line(&mut input)?;
+
+                        if input.trim().eq_ignore_ascii_case("y") {
+                            match std::fs::write(&file_path, &current_content) {
+                                Ok(_) => {
+                                    let num_fixes = file_applied_fixes.len();
+                                    applied_fixes.push((file_path.clone(), file_applied_fixes));
+                                    println!("Applied {} fixes to {}", num_fixes, file_path);
+                                }
+                                Err(e) => {
+                                    eprintln!("Failed to write {}: {}", file_path, e);
+                                }
+                            }
+                        } else {
+                            println!("Skipped fixes for {}", file_path);
+                        }
+                    } else if app.yes {
+                        match std::fs::write(&file_path, &current_content) {
+                            Ok(_) => {
+                                let num_fixes = file_applied_fixes.len();
+                                applied_fixes.push((file_path.clone(), file_applied_fixes));
+                                println!("Applied {} fixes to {}", num_fixes, file_path);
+                            }
+                            Err(e) => {
+                                eprintln!("Failed to write {}: {}", file_path, e);
+                            }
+                        }
+                    } else {
+                        println!("\n{}: {}", "File".green(), file_path);
+                        println!(
+                            "{}: {} fixes to apply",
+                            "Fixes".green(),
+                            file_applied_fixes.len()
+                        );
+                        for (ident, fix, finding) in &file_applied_fixes {
+                            let line_info = if let Some(line) = get_primary_line_number(finding) {
+                                format!(" at line {}", line)
+                            } else {
+                                String::new()
+                            };
+                            println!(
+                                "  - {}{}: {}",
+                                format_severity_and_rule(&finding.determinations.severity, ident),
+                                line_info,
+                                fix.title
+                            );
+                        }
+
+                        print!("Apply all fixes to this file? [y/N] ");
+                        stdout().flush()?;
+                        let mut input = String::new();
+                        std::io::stdin().read_line(&mut input)?;
+
+                        if input.trim().eq_ignore_ascii_case("y") {
+                            match std::fs::write(&file_path, &current_content) {
+                                Ok(_) => {
+                                    let num_fixes = file_applied_fixes.len();
+                                    applied_fixes.push((file_path.clone(), file_applied_fixes));
+                                    println!("Applied {} fixes to {}", num_fixes, file_path);
+                                }
+                                Err(e) => {
+                                    eprintln!("Failed to write {}: {}", file_path, e);
+                                }
+                            }
+                        } else {
+                            println!("Skipped fixes for {}", file_path);
+                        }
+                    }
+                }
+            }
+
+            // Summary
+            if !app.dry_run && (!applied_fixes.is_empty() || !failed_fixes.is_empty()) {
+                println!("\n{}", "Fix Summary".green().bold());
+                if !applied_fixes.is_empty() {
+                    println!(
+                        "Successfully applied fixes to {} files:",
+                        applied_fixes.len()
+                    );
+                    for (file_path, fixes) in applied_fixes {
+                        println!("  {}: {} fixes", file_path, fixes.len());
+                    }
+                }
+
+                if !failed_fixes.is_empty() {
+                    println!("Failed to apply {} fixes:", failed_fixes.len());
+                    for (ident, file_path, error) in failed_fixes {
+                        println!("  {}: {} ({})", ident, file_path, error);
+                    }
+                }
+            }
+        }
+    }
 
     if app.no_exit_codes || matches!(app.format, OutputFormat::Sarif) {
         Ok(ExitCode::SUCCESS)

--- a/crates/zizmor/src/oci_registry.rs
+++ b/crates/zizmor/src/oci_registry.rs
@@ -1,0 +1,739 @@
+use anyhow::{Result, anyhow};
+use oci_client::{Client, Reference};
+use std::collections::HashMap;
+
+/// Configuration for different OCI registries
+#[derive(Debug, Clone)]
+pub struct RegistryConfig {
+    pub name: &'static str,
+    pub registry_url: &'static str,
+    pub requires_auth: bool,
+    pub namespace_format: NamespaceFormat,
+}
+
+#[derive(Debug, Clone)]
+pub enum NamespaceFormat {
+    /// Docker Hub format: library/image for official images, user/image for user images
+    DockerHub,
+    /// GitHub Container Registry format: ghcr.io/owner/image
+    GHCR,
+    /// Google Container Registry format: gcr.io/project/image
+    GCR,
+    /// Generic format: registry.com/namespace/image
+    Generic,
+}
+
+/// OCI registry client for fetching image tags and manifests
+pub struct OciRegistryClient {
+    client: Client,
+    configs: HashMap<&'static str, RegistryConfig>,
+}
+
+impl OciRegistryClient {
+    /// Create a new OCI registry client with default configurations
+    pub fn new() -> Result<Self> {
+        let client = Client::default();
+
+        let mut configs = HashMap::new();
+
+        // Docker Hub configuration
+        configs.insert(
+            "docker.io",
+            RegistryConfig {
+                name: "Docker Hub",
+                registry_url: "registry-1.docker.io",
+                requires_auth: false,
+                namespace_format: NamespaceFormat::DockerHub,
+            },
+        );
+
+        // GitHub Container Registry configuration
+        configs.insert(
+            "ghcr.io",
+            RegistryConfig {
+                name: "GitHub Container Registry",
+                registry_url: "ghcr.io",
+                requires_auth: true,
+                namespace_format: NamespaceFormat::GHCR,
+            },
+        );
+
+        // Google Container Registry configuration
+        configs.insert(
+            "gcr.io",
+            RegistryConfig {
+                name: "Google Container Registry",
+                registry_url: "gcr.io",
+                requires_auth: true,
+                namespace_format: NamespaceFormat::GCR,
+            },
+        );
+
+        // Quay.io configuration
+        configs.insert(
+            "quay.io",
+            RegistryConfig {
+                name: "Quay.io",
+                registry_url: "quay.io",
+                requires_auth: false,
+                namespace_format: NamespaceFormat::Generic,
+            },
+        );
+
+        Ok(Self { client, configs })
+    }
+
+    /// Add a custom registry configuration
+    pub fn add_registry(&mut self, domain: &'static str, config: RegistryConfig) {
+        self.configs.insert(domain, config);
+    }
+
+    /// Fetch available tags for a Docker/OCI image
+    pub async fn get_image_tags(&self, image_ref: &str) -> Result<Vec<String>> {
+        let (registry, repository) = self.parse_image_reference(image_ref)?;
+
+        let config = self
+            .configs
+            .get(registry)
+            .ok_or_else(|| anyhow!("Unsupported registry: {}", registry))?;
+
+        // Create a reference for the image
+        let reference_str = format!("{}{}", config.registry_url, repository);
+        let reference = Reference::try_from(reference_str)?;
+
+        // Get tags from the registry - use anonymous auth for public registries
+        let auth = &oci_client::secrets::RegistryAuth::Anonymous;
+        let tag_response = self.client.list_tags(&reference, auth, None, None).await?;
+        let tags = tag_response.tags;
+
+        // Filter and sort the tags
+        let filtered_tags = self.filter_and_sort_tags(tags);
+        Ok(filtered_tags)
+    }
+
+    /// Get the manifest digest for a specific image tag
+    pub async fn get_image_digest(&self, image_ref: &str, tag: &str) -> Result<String> {
+        let (registry, repository) = self.parse_image_reference(image_ref)?;
+
+        let config = self
+            .configs
+            .get(registry)
+            .ok_or_else(|| anyhow!("Unsupported registry: {}", registry))?;
+
+        // Create a reference for the image with tag
+        let reference_str = format!("{}{}:{}", config.registry_url, repository, tag);
+        let reference = Reference::try_from(reference_str)?;
+
+        // Get the manifest to extract the digest
+        let auth = &oci_client::secrets::RegistryAuth::Anonymous;
+        let (_, digest) = self.client.pull_manifest(&reference, auth).await?;
+        Ok(digest)
+    }
+
+    /// Parse a Docker image reference into registry and repository
+    fn parse_image_reference<'a>(&self, image_ref: &'a str) -> Result<(&'a str, String)> {
+        // Check for empty string
+        if image_ref.is_empty() {
+            return Err(anyhow!("Empty image reference"));
+        }
+
+        // Remove docker:// prefix if present
+        let image_ref = image_ref.strip_prefix("docker://").unwrap_or(image_ref);
+
+        // Split by '/' to get components
+        let parts: Vec<&str> = image_ref.split('/').collect();
+
+        match parts.len() {
+            1 => {
+                // Just image name, assume Docker Hub official image
+                Ok(("docker.io", format!("/library/{}", parts[0])))
+            }
+            2 => {
+                // Check if first part looks like a registry domain
+                if parts[0].contains('.') || parts[0].contains(':') {
+                    // registry.com/image format
+                    Ok((parts[0], format!("/{}", parts[1])))
+                } else {
+                    // user/image format, assume Docker Hub
+                    Ok(("docker.io", format!("/{}/{}", parts[0], parts[1])))
+                }
+            }
+            3 => {
+                // registry.com/namespace/image format
+                Ok((parts[0], format!("/{}/{}", parts[1], parts[2])))
+            }
+            _ => {
+                // More complex paths like registry.com/namespace/subnamespace/image
+                let registry = parts[0];
+                let repository = format!("/{}", parts[1..].join("/"));
+                Ok((registry, repository))
+            }
+        }
+    }
+
+    /// Filter and sort tags to return the most useful ones
+    fn filter_and_sort_tags(&self, mut tags: Vec<String>) -> Vec<String> {
+        // Filter out unwanted tags
+        tags.retain(|tag| {
+            !tag.contains("latest")
+                && !tag.contains("edge")
+                && !tag.contains("dev")
+                && !tag.contains("alpha")
+                && !tag.contains("beta")
+                && !tag.contains("rc")
+                && !tag.contains("nightly")
+                && !tag.starts_with("sha256:")
+                && !tag.is_empty()
+        });
+
+        // Sort by semantic version preference
+        tags.sort_by(|a, b| {
+            let a_is_semver = a.chars().next().map_or(false, |c| c.is_ascii_digit());
+            let b_is_semver = b.chars().next().map_or(false, |c| c.is_ascii_digit());
+
+            match (a_is_semver, b_is_semver) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => {
+                    // For version strings, try to do a more intelligent sort
+                    if a_is_semver && b_is_semver {
+                        // Simple version comparison (this could be improved with a proper semver crate)
+                        b.cmp(a) // Reverse order to get newest first
+                    } else {
+                        a.cmp(b) // Alphabetical for non-version tags
+                    }
+                }
+            }
+        });
+
+        // Return top 5 most relevant tags
+        tags.into_iter().take(5).collect()
+    }
+
+    /// Get supported registries
+    pub fn supported_registries(&self) -> Vec<&str> {
+        self.configs.keys().copied().collect()
+    }
+
+    /// Check if an image exists in the registry
+    pub async fn image_exists(&self, image_ref: &str, tag: Option<&str>) -> Result<bool> {
+        let (registry, repository) = self.parse_image_reference(image_ref)?;
+
+        let config = self
+            .configs
+            .get(registry)
+            .ok_or_else(|| anyhow!("Unsupported registry: {}", registry))?;
+
+        let reference_str = if let Some(tag) = tag {
+            format!("{}{}:{}", config.registry_url, repository, tag)
+        } else {
+            format!("{}{}:latest", config.registry_url, repository)
+        };
+
+        let reference = Reference::try_from(reference_str)?;
+
+        // Try to get the manifest - if it exists, the image exists
+        let auth = &oci_client::secrets::RegistryAuth::Anonymous;
+        match self.client.pull_manifest(&reference, auth).await {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
+    /// Normalize an image reference to a standard format
+    pub fn normalize_image_reference(&self, image_ref: &str) -> String {
+        match self.parse_image_reference(image_ref) {
+            Ok((registry, repository)) => {
+                if registry == "docker.io" && repository.starts_with("/library/") {
+                    format!("docker.io{}", repository)
+                } else {
+                    format!("{}{}", registry, repository)
+                }
+            }
+            Err(_) => image_ref.to_string(), // Return original if parsing fails
+        }
+    }
+}
+
+/// Macro for creating an OCI registry client with timeout and fallback
+#[macro_export]
+macro_rules! oci_registry_client_with_fallback {
+    ($timeout_secs:expr) => {{
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        async move |image_ref: &str| -> Vec<String> {
+            match $crate::oci_registry::OciRegistryClient::new() {
+                Ok(client) => {
+                    match timeout(
+                        Duration::from_secs($timeout_secs),
+                        client.get_image_tags(image_ref),
+                    )
+                    .await
+                    {
+                        Ok(Ok(tags)) if !tags.is_empty() => tags,
+                        Ok(Ok(_)) => Vec::new(), // Empty tags
+                        Ok(Err(e)) => {
+                            tracing::debug!("OCI registry API error for {}: {}", image_ref, e);
+                            Vec::new()
+                        }
+                        Err(_) => {
+                            tracing::debug!("OCI registry API timeout for {}", image_ref);
+                            Vec::new()
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to create OCI registry client: {}", e);
+                    Vec::new()
+                }
+            }
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_image_reference() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test Docker Hub official image
+        let (registry, repo) = client.parse_image_reference("ubuntu").unwrap();
+        assert_eq!(registry, "docker.io");
+        assert_eq!(repo, "/library/ubuntu");
+
+        // Test Docker Hub user image
+        let (registry, repo) = client.parse_image_reference("nginx/nginx").unwrap();
+        assert_eq!(registry, "docker.io");
+        assert_eq!(repo, "/nginx/nginx");
+
+        // Test GHCR image
+        let (registry, repo) = client.parse_image_reference("ghcr.io/owner/repo").unwrap();
+        assert_eq!(registry, "ghcr.io");
+        assert_eq!(repo, "/owner/repo");
+
+        // Test GCR image
+        let (registry, repo) = client
+            .parse_image_reference("gcr.io/project/image")
+            .unwrap();
+        assert_eq!(registry, "gcr.io");
+        assert_eq!(repo, "/project/image");
+
+        // Test with docker:// prefix
+        let (registry, repo) = client.parse_image_reference("docker://ubuntu").unwrap();
+        assert_eq!(registry, "docker.io");
+        assert_eq!(repo, "/library/ubuntu");
+
+        // Test complex path
+        let (registry, repo) = client
+            .parse_image_reference("registry.example.com/namespace/subnamespace/image")
+            .unwrap();
+        assert_eq!(registry, "registry.example.com");
+        assert_eq!(repo, "/namespace/subnamespace/image");
+    }
+
+    #[test]
+    fn test_filter_and_sort_tags() {
+        let client = OciRegistryClient::new().unwrap();
+
+        let tags = vec![
+            "latest".to_string(),
+            "1.0.0".to_string(),
+            "2.1.0".to_string(),
+            "edge".to_string(),
+            "1.5.0".to_string(),
+            "dev".to_string(),
+            "alpine".to_string(),
+            "3.0.0-beta".to_string(),
+        ];
+
+        let filtered = client.filter_and_sort_tags(tags);
+
+        // Should filter out latest, edge, dev, beta
+        assert!(!filtered.contains(&"latest".to_string()));
+        assert!(!filtered.contains(&"edge".to_string()));
+        assert!(!filtered.contains(&"dev".to_string()));
+        assert!(!filtered.contains(&"3.0.0-beta".to_string()));
+
+        // Should contain version numbers and alpine
+        assert!(filtered.contains(&"2.1.0".to_string()));
+        assert!(filtered.contains(&"1.5.0".to_string()));
+        assert!(filtered.contains(&"1.0.0".to_string()));
+        assert!(filtered.contains(&"alpine".to_string()));
+    }
+
+    #[test]
+    fn test_supported_registries() {
+        let client = OciRegistryClient::new().unwrap();
+        let registries = client.supported_registries();
+
+        assert!(registries.contains(&"docker.io"));
+        assert!(registries.contains(&"ghcr.io"));
+        assert!(registries.contains(&"gcr.io"));
+        assert!(registries.contains(&"quay.io"));
+    }
+
+    #[tokio::test]
+    async fn test_oci_registry_client_macro() {
+        let get_tags = oci_registry_client_with_fallback!(3);
+
+        let tags = get_tags("ubuntu").await;
+        // This should either return tags or an empty vec (fallback)
+        // We can't assert on specific content due to network variability
+        println!("OCI macro test tags: {:?}", tags);
+    }
+
+    #[tokio::test]
+    async fn test_docker_hub_integration() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test with a well-known image
+        match client.get_image_tags("ubuntu").await {
+            Ok(tags) => {
+                assert!(!tags.is_empty(), "Should return some tags for ubuntu");
+                assert!(tags.len() <= 5, "Should return at most 5 tags");
+
+                // Check that we got reasonable version tags
+                let has_version_tag = tags
+                    .iter()
+                    .any(|tag| tag.chars().next().map_or(false, |c| c.is_ascii_digit()));
+                assert!(has_version_tag, "Should include at least one version tag");
+
+                println!("Ubuntu tags: {:?}", tags);
+            }
+            Err(e) => {
+                // Network tests might fail in CI, so we'll just log the error
+                println!(
+                    "Docker Hub test failed (this might be expected in CI): {}",
+                    e
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_image_exists() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test with a well-known image that should exist
+        match client.image_exists("ubuntu", Some("20.04")).await {
+            Ok(exists) => {
+                println!("Ubuntu 20.04 exists: {}", exists);
+                // We can't assert true because network might fail
+            }
+            Err(e) => {
+                println!("Image exists test failed (might be expected): {}", e);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_image_digest() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test getting digest for a specific tag
+        match client.get_image_digest("ubuntu", "20.04").await {
+            Ok(digest) => {
+                assert!(digest.starts_with("sha256:"));
+                println!("Ubuntu 20.04 digest: {}", digest);
+            }
+            Err(e) => {
+                println!("Get digest test failed (might be expected): {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_oci_registry_client_creation() {
+        let client = OciRegistryClient::new().unwrap();
+        assert!(client.configs.contains_key("docker.io"));
+        assert!(client.configs.contains_key("ghcr.io"));
+        assert!(client.configs.contains_key("gcr.io"));
+    }
+
+    #[test]
+    fn test_parse_docker_image_reference() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test various Docker image formats (only registry and repository, no tag parsing)
+        let test_cases = vec![
+            ("ubuntu", ("docker.io", "/library/ubuntu")),
+            ("nginx/nginx", ("docker.io", "/nginx/nginx")),
+            ("ghcr.io/owner/repo", ("ghcr.io", "/owner/repo")),
+            ("gcr.io/project/image", ("gcr.io", "/project/image")),
+            ("docker://ubuntu", ("docker.io", "/library/ubuntu")),
+            (
+                "registry.example.com/namespace/subnamespace/image",
+                ("registry.example.com", "/namespace/subnamespace/image"),
+            ),
+        ];
+
+        for (input, expected) in test_cases {
+            let result = client.parse_image_reference(input);
+            assert!(result.is_ok(), "Failed to parse: {}", input);
+            let (registry, repository) = result.unwrap();
+            assert_eq!(
+                (registry, repository.as_str()),
+                expected,
+                "Mismatch for input: {}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_docker_image_reference_with_sha() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test SHA256 digests (simplified - just test that they parse correctly)
+        let test_cases = vec![
+            ("ubuntu", ("docker.io", "/library/ubuntu")),
+            ("docker.io/library/ubuntu", ("docker.io", "/library/ubuntu")),
+            ("ghcr.io/owner/repo", ("ghcr.io", "/owner/repo")),
+            ("myuser/myapp", ("docker.io", "/myuser/myapp")),
+        ];
+
+        for (input, expected) in test_cases {
+            let result = client.parse_image_reference(input);
+            assert!(result.is_ok(), "Failed to parse: {}", input);
+            let (registry, repository) = result.unwrap();
+            assert_eq!(
+                (registry, repository.as_str()),
+                expected,
+                "Mismatch for input: {}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_docker_image_reference_invalid() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test invalid formats - empty string should fail
+        let invalid_cases = vec![""];
+
+        for input in invalid_cases {
+            let result = client.parse_image_reference(input);
+            assert!(result.is_err(), "Should fail to parse: {}", input);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_image_tags_docker_hub() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test with a well-known image that should have tags
+        let result = client.get_image_tags("alpine").await;
+
+        // We can't guarantee the exact tags, but alpine should have some tags
+        match result {
+            Ok(tags) => {
+                assert!(!tags.is_empty(), "Alpine should have tags");
+                // Alpine typically has version tags like "3.18", "3.19", etc.
+                // We filter out 'latest' so we expect version numbers
+                let has_version_tag = tags
+                    .iter()
+                    .any(|tag| tag.chars().next().map_or(false, |c| c.is_ascii_digit()));
+                assert!(has_version_tag, "Alpine should have version tags");
+            }
+            Err(e) => {
+                // Network errors are acceptable in tests
+                println!("Network error (acceptable in tests): {}", e);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_image_tags_with_registry() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test with GitHub Container Registry
+        let result = client.get_image_tags("ghcr.io/actions/runner").await;
+
+        match result {
+            Ok(tags) => {
+                assert!(!tags.is_empty(), "GitHub Actions runner should have tags");
+            }
+            Err(e) => {
+                // Network errors are acceptable in tests
+                println!("Network error (acceptable in tests): {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_normalize_image_reference() {
+        let client = OciRegistryClient::new().unwrap();
+
+        let test_cases = vec![
+            // Docker Hub official images
+            ("ubuntu", "docker.io/library/ubuntu"),
+            ("nginx", "docker.io/library/nginx"),
+            ("alpine", "docker.io/library/alpine"),
+            ("node", "docker.io/library/node"),
+            ("python", "docker.io/library/python"),
+            // Docker Hub user images
+            ("myuser/myapp", "docker.io/myuser/myapp"),
+            ("organization/service", "docker.io/organization/service"),
+            // Already normalized
+            ("docker.io/library/ubuntu", "docker.io/library/ubuntu"),
+            ("ghcr.io/owner/repo", "ghcr.io/owner/repo"),
+            ("gcr.io/project/image", "gcr.io/project/image"),
+            // Custom registries
+            (
+                "registry.example.com/namespace/image",
+                "registry.example.com/namespace/image",
+            ),
+            ("localhost:5000/myimage", "localhost:5000/myimage"),
+        ];
+
+        for (input, expected) in test_cases {
+            let result = client.normalize_image_reference(input);
+            assert_eq!(result, expected, "Mismatch for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_registry_config_creation() {
+        let config = RegistryConfig {
+            name: "Docker Hub",
+            registry_url: "https://registry-1.docker.io",
+            requires_auth: false,
+            namespace_format: NamespaceFormat::DockerHub,
+        };
+
+        assert_eq!(config.name, "Docker Hub");
+        assert_eq!(config.registry_url, "https://registry-1.docker.io");
+        assert!(!config.requires_auth);
+        matches!(config.namespace_format, NamespaceFormat::DockerHub);
+    }
+
+    #[test]
+    fn test_namespace_format_variants() {
+        // Test that all namespace format variants can be created
+        let _docker_hub = NamespaceFormat::DockerHub;
+        let _ghcr = NamespaceFormat::GHCR;
+        let _gcr = NamespaceFormat::GCR;
+        let _generic = NamespaceFormat::Generic;
+    }
+
+    #[test]
+    fn test_client_with_custom_registry() {
+        let mut client = OciRegistryClient::new().unwrap();
+
+        let custom_config = RegistryConfig {
+            name: "Custom Registry",
+            registry_url: "https://registry.example.com",
+            requires_auth: true,
+            namespace_format: NamespaceFormat::Generic,
+        };
+
+        client.add_registry("registry.example.com", custom_config);
+
+        assert!(client.configs.contains_key("registry.example.com"));
+        assert_eq!(client.configs.len(), 5); // 4 default + 1 custom
+    }
+
+    #[test]
+    fn test_supported_registries_comprehensive() {
+        let client = OciRegistryClient::new().unwrap();
+        let supported = client.supported_registries();
+
+        assert!(supported.contains(&"docker.io"));
+        assert!(supported.contains(&"ghcr.io"));
+        assert!(supported.contains(&"gcr.io"));
+        assert_eq!(supported.len(), 4); // Updated to 4 since we have 4 default registries
+    }
+
+    #[tokio::test]
+    async fn test_image_exists_comprehensive() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test with a well-known image
+        let result = client.image_exists("alpine", Some("latest")).await;
+
+        match result {
+            Ok(exists) => {
+                assert!(exists, "Alpine:latest should exist");
+            }
+            Err(e) => {
+                // Network errors are acceptable in tests
+                println!("Network error (acceptable in tests): {}", e);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_image_exists_nonexistent() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test with a non-existent image
+        let result = client
+            .image_exists("nonexistent-image-12345", Some("nonexistent-tag"))
+            .await;
+
+        match result {
+            Ok(exists) => {
+                assert!(!exists, "Non-existent image should not exist");
+            }
+            Err(_) => {
+                // Errors are acceptable for non-existent images
+            }
+        }
+    }
+
+    #[test]
+    fn test_comprehensive_docker_image_parsing() {
+        let client = OciRegistryClient::new().unwrap();
+
+        // Test cases from GitHub Actions documentation examples (simplified)
+        let github_actions_examples = vec![
+            // From the uses documentation
+            ("ubuntu", ("docker.io", "/library/ubuntu")),
+            ("alpine", ("docker.io", "/library/alpine")),
+            (
+                "gcr.io/cloud-builders/gradle",
+                ("gcr.io", "/cloud-builders/gradle"),
+            ),
+            // Real-world examples from popular actions
+            ("node", ("docker.io", "/library/node")),
+            ("python", ("docker.io", "/library/python")),
+            ("golang", ("docker.io", "/library/golang")),
+            ("ruby", ("docker.io", "/library/ruby")),
+            ("openjdk", ("docker.io", "/library/openjdk")),
+            // Container images used in CI/CD
+            ("postgres", ("docker.io", "/library/postgres")),
+            ("redis", ("docker.io", "/library/redis")),
+            ("mysql", ("docker.io", "/library/mysql")),
+            ("mongodb", ("docker.io", "/library/mongodb")),
+            ("elasticsearch", ("docker.io", "/library/elasticsearch")),
+            // GitHub Container Registry examples
+            ("ghcr.io/actions/runner", ("ghcr.io", "/actions/runner")),
+            ("ghcr.io/microsoft/dotnet", ("ghcr.io", "/microsoft/dotnet")),
+            (
+                "ghcr.io/github/super-linter",
+                ("ghcr.io", "/github/super-linter"),
+            ),
+        ];
+
+        for (input, expected) in github_actions_examples {
+            let result = client.parse_image_reference(input);
+            assert!(
+                result.is_ok(),
+                "Failed to parse GitHub Actions example: {}",
+                input
+            );
+            let (registry, repository) = result.unwrap();
+            assert_eq!(
+                (registry, repository.as_str()),
+                expected,
+                "Mismatch for GitHub Actions example: {}",
+                input
+            );
+        }
+    }
+}

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -110,9 +110,25 @@ impl InputKey {
             return Err(InputError::MissingName);
         }
 
+        // Resolve the absolute path, handling both existing and non-existing files
+        let given_path = if path.as_ref().exists() {
+            path.as_ref()
+                .canonicalize()
+                .map_err(|e| InputError::Io(e))?
+                .try_into()
+                .map_err(|e| InputError::Other(anyhow!("failed to convert path to UTF-8: {}", e)))?
+        } else {
+            // For non-existing files, resolve relative to current directory
+            std::env::current_dir()
+                .map_err(|e| InputError::Io(e))?
+                .join(path.as_ref())
+                .try_into()
+                .map_err(|e| InputError::Other(anyhow!("failed to convert path to UTF-8: {}", e)))?
+        };
+
         Ok(Self::Local(LocalKey {
             prefix: prefix.map(|p| p.as_ref().to_path_buf()),
-            given_path: path.as_ref().to_path_buf(),
+            given_path,
         }))
     }
 

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -126,8 +126,37 @@ impl InputKey {
                 .map_err(|e| InputError::Other(anyhow!("failed to convert path to UTF-8: {}", e)))?
         };
 
+        // Also canonicalize the prefix if provided, to ensure consistent path resolution
+        let canonicalized_prefix = if let Some(prefix) = prefix.as_ref() {
+            if prefix.as_ref().exists() {
+                Some(
+                    prefix
+                        .as_ref()
+                        .canonicalize()
+                        .map_err(|e| InputError::Io(e))?
+                        .try_into()
+                        .map_err(|e| {
+                            InputError::Other(anyhow!("failed to convert prefix to UTF-8: {}", e))
+                        })?,
+                )
+            } else {
+                // For non-existing prefix, resolve relative to current directory
+                Some(
+                    std::env::current_dir()
+                        .map_err(|e| InputError::Io(e))?
+                        .join(prefix.as_ref())
+                        .try_into()
+                        .map_err(|e| {
+                            InputError::Other(anyhow!("failed to convert prefix to UTF-8: {}", e))
+                        })?,
+                )
+            }
+        } else {
+            None
+        };
+
         Ok(Self::Local(LocalKey {
-            prefix: prefix.map(|p| p.as_ref().to_path_buf()),
+            prefix: canonicalized_prefix,
             given_path,
         }))
     }

--- a/crates/zizmor/src/yaml_patch/mod.rs
+++ b/crates/zizmor/src/yaml_patch/mod.rs
@@ -1,0 +1,1154 @@
+//! Comment and format-preserving YAML patch operations.
+//!
+//! This module provides functionality to modify YAML documents while preserving
+//! comments, formatting, and structure. Unlike standard YAML->JSON->YAML round-trips
+//! that lose comments, this implementation uses precise byte-level operations
+//! guided by the yamlpath library.
+//!
+//! # Example
+//!
+//! ```rust
+//! use crate::yaml_patch::{YamlPatchOperation, apply_yaml_patch};
+//!
+//! let yaml = r#"
+//! # Configuration
+//! permissions: # Security settings
+//!   contents: read  # Only read access
+//!   actions: write  # Write access for actions
+//! "#;
+//!
+//! let operations = vec![YamlPatchOperation::Replace {
+//!     path: "/permissions/contents".to_string(),
+//!     value: serde_yaml::Value::String("write".to_string()),
+//! }];
+//!
+//! let result = apply_yaml_patch(yaml, operations).unwrap();
+//! // Comments are preserved!
+//! ```
+
+use anyhow::Result;
+
+/// Error types for YAML patch operations
+#[derive(thiserror::Error, Debug)]
+pub enum YamlPatchError {
+    #[error("Path not found: {0}")]
+    PathNotFound(String),
+    #[error("Invalid path format: {0}")]
+    InvalidPath(String),
+    #[error("YAML query error: {0}")]
+    QueryError(#[from] yamlpath::QueryError),
+    #[error("YAML serialization error: {0}")]
+    SerializationError(#[from] serde_yaml::Error),
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
+}
+
+/// Represents a YAML patch operation that preserves comments and formatting
+#[derive(Debug, Clone)]
+pub enum YamlPatchOperation {
+    /// Replace the value at the given path
+    Replace {
+        path: String,
+        value: serde_yaml::Value,
+    },
+    /// Add a new key-value pair at the given path (path should point to a mapping)
+    Add {
+        path: String,
+        key: String,
+        value: serde_yaml::Value,
+    },
+    /// Remove the key at the given path
+    Remove { path: String },
+}
+
+/// Apply YAML patch operations while preserving comments and formatting
+///
+/// This function takes a YAML string and a list of patch operations, applying them
+/// in order while preserving all comments, formatting, and structure that isn't
+/// directly modified.
+///
+/// Operations are applied from the end of the document backwards to avoid
+/// invalidating byte positions during modification.
+pub fn apply_yaml_patch(
+    content: &str,
+    operations: Vec<YamlPatchOperation>,
+) -> Result<String, YamlPatchError> {
+    let mut result = content.to_string();
+
+    // Sort operations by byte position (reverse order) so we can apply them without
+    // invalidating subsequent positions
+    let mut positioned_ops = Vec::new();
+
+    for op in operations {
+        let doc = yamlpath::Document::new(&result)?;
+        match &op {
+            YamlPatchOperation::Replace { path, value: _ } => {
+                if path == "/" {
+                    // Handle root replacement - use the document root
+                    let feature = doc.root();
+                    positioned_ops.push((feature.location.byte_span.0, op));
+                } else {
+                    let query = parse_json_pointer_to_query(path)?;
+                    let feature = doc.query(&query)?;
+                    positioned_ops.push((feature.location.byte_span.0, op));
+                }
+            }
+            YamlPatchOperation::Add { path, .. } => {
+                if path == "/" {
+                    // Handle root addition - use the document root
+                    let feature = doc.root();
+                    positioned_ops.push((feature.location.byte_span.1, op));
+                } else {
+                    let query = parse_json_pointer_to_query(path)?;
+                    let feature = doc.query(&query)?;
+                    positioned_ops.push((feature.location.byte_span.1, op));
+                }
+            }
+            YamlPatchOperation::Remove { path } => {
+                if path == "/" {
+                    return Err(YamlPatchError::InvalidOperation(
+                        "Cannot remove root document".to_string(),
+                    ));
+                } else {
+                    let query = parse_json_pointer_to_query(path)?;
+                    let feature = doc.query(&query)?;
+                    positioned_ops.push((feature.location.byte_span.0, op));
+                }
+            }
+        }
+    }
+
+    // Sort by position (descending) so we apply changes from end to beginning
+    positioned_ops.sort_by(|a, b| b.0.cmp(&a.0));
+
+    for (_, op) in positioned_ops {
+        result = apply_single_operation(&result, op)?;
+    }
+
+    Ok(result)
+}
+
+/// Apply a single YAML patch operation
+fn apply_single_operation(
+    content: &str,
+    operation: YamlPatchOperation,
+) -> Result<String, YamlPatchError> {
+    let doc = yamlpath::Document::new(content)?;
+
+    match operation {
+        YamlPatchOperation::Replace { path, value } => {
+            let feature = if path == "/" {
+                doc.root()
+            } else {
+                let query = parse_json_pointer_to_query(&path)?;
+                doc.query(&query)?
+            };
+
+            // Convert the new value to YAML string
+            let new_value_str = serialize_yaml_value(&value)?;
+            let new_value_str = new_value_str.trim_end(); // Remove trailing newline
+
+            // Extract the current content to see what we're replacing
+            let current_content = doc.extract(&feature);
+            let current_content_with_ws = doc.extract_with_leading_whitespace(&feature);
+
+            // For mapping values, we need to preserve the key part
+            let replacement = if let Some(colon_pos) = current_content_with_ws.find(':') {
+                // This is a key-value pair, preserve the key and whitespace
+                let key_part = &current_content_with_ws[..colon_pos + 1];
+                format!("{} {}", key_part, new_value_str)
+            } else {
+                // This is just a value, replace it directly
+                let leading_whitespace =
+                    extract_leading_whitespace(content, feature.location.byte_span.0);
+                if current_content.contains('\n') {
+                    indent_multiline_yaml(&new_value_str, &leading_whitespace)
+                } else {
+                    new_value_str.to_string()
+                }
+            };
+
+            // Find the span to replace - use the span with leading whitespace if it's a key-value pair
+            let (start_span, end_span) = if current_content_with_ws.contains(':') {
+                // Replace the entire key-value pair span
+                let ws_start = feature.location.byte_span.0
+                    - (current_content_with_ws.len() - current_content.len());
+                (ws_start, feature.location.byte_span.1)
+            } else {
+                // Replace just the value
+                (feature.location.byte_span.0, feature.location.byte_span.1)
+            };
+
+            // Replace the content
+            let mut result = content.to_string();
+            result.replace_range(start_span..end_span, &replacement);
+            Ok(result)
+        }
+
+        YamlPatchOperation::Add { path, key, value } => {
+            if path == "/" {
+                // Handle root-level additions specially
+                return handle_root_level_addition(content, &key, &value);
+            }
+
+            let query = parse_json_pointer_to_query(&path)?;
+            let feature = doc.query(&query)?;
+
+            // Convert the new value to YAML string
+            let new_value_str = serialize_yaml_value(&value)?;
+            let new_value_str = new_value_str.trim_end(); // Remove trailing newline
+
+            // Extract the feature content with leading whitespace to analyze structure
+            let feature_with_ws = doc.extract_with_leading_whitespace(&feature);
+
+            // Check if we're adding to a list item by examining the path
+            let is_list_item = path.contains("/steps/");
+
+            let indent = if is_list_item {
+                // For list items (steps), we need to calculate the proper indentation
+                // by looking at the existing step structure
+                let lines: Vec<&str> = feature_with_ws.lines().collect();
+                if let Some(first_line) = lines.first() {
+                    if let Some(dash_pos) = first_line.find('-') {
+                        // For steps, find existing key indentation by looking at the content
+                        let mut found_indent = None;
+                        if lines.len() > 1 {
+                            // Find a line that contains a key (has a colon)
+                            for line in lines.iter().skip(1) {
+                                if line.contains(':') && !line.trim().starts_with('#') {
+                                    // Use this line's indentation as our reference
+                                    let key_indent = line.len() - line.trim_start().len();
+                                    found_indent = Some(" ".repeat(key_indent));
+                                    break;
+                                }
+                            }
+                        }
+                        if let Some(indent) = found_indent {
+                            indent
+                        } else {
+                            // Fallback: dash position + 2 spaces (standard YAML step indentation)
+                            let dash_base_indent = &first_line[..dash_pos];
+                            format!("{}  ", dash_base_indent)
+                        }
+                    } else {
+                        // Fallback: use the leading whitespace + 2 spaces
+                        let leading_whitespace =
+                            extract_leading_whitespace(content, feature.location.byte_span.0);
+                        format!("{}  ", leading_whitespace)
+                    }
+                } else {
+                    // Fallback to standard indentation
+                    let leading_whitespace =
+                        extract_leading_whitespace(content, feature.location.byte_span.0);
+                    format!("{}  ", leading_whitespace)
+                }
+            } else {
+                // For regular mappings, add 2 spaces to current indentation
+                let leading_whitespace =
+                    extract_leading_whitespace(content, feature.location.byte_span.0);
+                format!("{}  ", leading_whitespace)
+            };
+
+            // Handle different value types for proper YAML formatting
+            let new_entry = if let serde_yaml::Value::Mapping(ref mapping) = value {
+                if mapping.is_empty() {
+                    // For empty mappings, format inline
+                    format!("\n{}{}: {}", indent, key, new_value_str)
+                } else {
+                    // For non-empty mappings, format as a nested structure
+                    let value_lines: Vec<&str> = new_value_str.lines().collect();
+                    let mut result = format!("\n{}{}:", indent, key);
+                    for line in value_lines.iter() {
+                        if !line.trim().is_empty() {
+                            result.push('\n');
+                            result.push_str(&indent);
+                            result.push_str("  "); // Additional 2 spaces for nested content
+                            result.push_str(line.trim_start());
+                        }
+                    }
+                    result
+                }
+            } else {
+                // For scalar values, simple key: value format
+                format!("\n{}{}: {}", indent, key, new_value_str)
+            };
+
+            // Find the actual insertion point
+            let insertion_point = if is_list_item {
+                // For list items, we need to find the end of the actual step content,
+                // not including trailing comments that yamlpath may have included
+                find_step_content_end(content, &feature, &doc)
+            } else {
+                feature.location.byte_span.1
+            };
+
+            // Insert the new content
+            let mut result = content.to_string();
+
+            // Check if we need to add a leading newline
+            let needs_leading_newline = if insertion_point > 0 {
+                !content
+                    .chars()
+                    .nth(insertion_point - 1)
+                    .map_or(false, |c| c == '\n')
+            } else {
+                true
+            };
+
+            let final_entry = if needs_leading_newline && !new_entry.starts_with('\n') {
+                format!("\n{}", new_entry.trim_start_matches('\n'))
+            } else if !needs_leading_newline && new_entry.starts_with('\n') {
+                new_entry.trim_start_matches('\n').to_string()
+            } else {
+                new_entry
+            };
+
+            result.insert_str(insertion_point, &final_entry);
+            Ok(result)
+        }
+
+        YamlPatchOperation::Remove { path } => {
+            if path == "/" {
+                return Err(YamlPatchError::InvalidOperation(
+                    "Cannot remove root document".to_string(),
+                ));
+            }
+            let query = parse_json_pointer_to_query(&path)?;
+            let feature = doc.query(&query)?;
+
+            // For removal, we need to remove the entire line including leading whitespace
+            let start_pos = find_line_start(content, feature.location.byte_span.0);
+            let end_pos = find_line_end(content, feature.location.byte_span.1);
+
+            let mut result = content.to_string();
+            result.replace_range(start_pos..end_pos, "");
+            Ok(result)
+        }
+    }
+}
+
+/// Convert a JSON Pointer path (like "/permissions/contents") to a yamlpath Query
+pub fn parse_json_pointer_to_query(path: &str) -> Result<yamlpath::Query, YamlPatchError> {
+    if !path.starts_with('/') {
+        return Err(YamlPatchError::InvalidPath(format!(
+            "Path must start with '/': {}",
+            path
+        )));
+    }
+
+    let components = path[1..] // Skip the leading '/'
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(|component| {
+            // Try to parse as integer (for array indices)
+            if let Ok(index) = component.parse::<usize>() {
+                yamlpath::Component::Index(index)
+            } else {
+                // Decode URI encoding if present
+                let decoded = component.replace("~1", "/").replace("~0", "~");
+                yamlpath::Component::Key(decoded)
+            }
+        })
+        .collect();
+
+    yamlpath::Query::new(components)
+        .ok_or_else(|| YamlPatchError::InvalidPath("Empty path".to_string()))
+}
+
+/// Serialize a serde_yaml::Value to a YAML string, handling different types appropriately
+fn serialize_yaml_value(value: &serde_yaml::Value) -> Result<String, YamlPatchError> {
+    match value {
+        serde_yaml::Value::String(s) => {
+            // For strings, we may need to quote them if they contain special characters
+            if needs_quoting(s) {
+                Ok(serde_yaml::to_string(value)?)
+            } else {
+                Ok(s.clone())
+            }
+        }
+        _ => {
+            let yaml_str = serde_yaml::to_string(value)?;
+            Ok(yaml_str.trim_end().to_string()) // Remove trailing newline
+        }
+    }
+}
+
+/// Check if a string needs to be quoted in YAML
+fn needs_quoting(s: &str) -> bool {
+    s.is_empty()
+        || s.contains(':')
+        || s.contains('#')
+        || s.contains('\n')
+        || s.starts_with(' ')
+        || s.ends_with(' ')
+        || s.chars().all(|c| c.is_ascii_digit() || c == '.')
+        || matches!(
+            s.to_lowercase().as_str(),
+            "true" | "false" | "null" | "yes" | "no" | "on" | "off"
+        )
+}
+
+/// Extract leading whitespace from the beginning of the line containing the given position
+fn extract_leading_whitespace(content: &str, pos: usize) -> String {
+    let line_start = find_line_start(content, pos);
+    let line_content = &content[line_start..];
+
+    line_content
+        .chars()
+        .take_while(|&c| c == ' ' || c == '\t')
+        .collect()
+}
+
+/// Find the start of the line containing the given position
+fn find_line_start(content: &str, pos: usize) -> usize {
+    content[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0)
+}
+
+/// Find the end of the line containing the given position
+fn find_line_end(content: &str, pos: usize) -> usize {
+    content[pos..]
+        .find('\n')
+        .map(|i| pos + i + 1)
+        .unwrap_or(content.len())
+}
+
+/// Indent multi-line YAML content to match the target indentation
+fn indent_multiline_yaml(content: &str, base_indent: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.len() <= 1 {
+        return content.to_string();
+    }
+
+    let mut result = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        if i == 0 {
+            result.push_str(line);
+        } else {
+            result.push('\n');
+            result.push_str(base_indent);
+            if !line.trim().is_empty() {
+                result.push_str("  "); // Additional indentation for continuation
+                result.push_str(line.trim_start());
+            }
+        }
+    }
+    result
+}
+
+/// Find the end of actual step content, excluding trailing comments
+fn find_step_content_end(
+    _content: &str,
+    feature: &yamlpath::Feature,
+    doc: &yamlpath::Document,
+) -> usize {
+    let feature_content = doc.extract(feature);
+    let feature_start = feature.location.byte_span.0;
+
+    // Split the feature content into lines to analyze
+    let lines: Vec<&str> = feature_content.lines().collect();
+
+    // Find the last line that contains actual YAML content (not a comment or empty line)
+    for (i, line) in lines.iter().enumerate().rev() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            // This is the last line with actual content
+            // Calculate its position relative to the start of the feature
+            let mut current_pos = 0;
+            for j in 0..=i {
+                if j == i {
+                    // This is our target line, find the end of it
+                    current_pos += lines[j].len();
+                    return feature_start + current_pos;
+                } else {
+                    current_pos += lines[j].len() + 1; // +1 for newline
+                }
+            }
+        }
+    }
+
+    // Fallback to original end if no content found
+    feature.location.byte_span.1
+}
+
+/// Handle root-level additions by finding the best insertion point at the document root
+fn handle_root_level_addition(
+    content: &str,
+    key: &str,
+    value: &serde_yaml::Value,
+) -> Result<String, YamlPatchError> {
+    // Convert the new value to YAML string
+    let new_value_str = serialize_yaml_value(value)?;
+    let new_value_str = new_value_str.trim_end(); // Remove trailing newline
+
+    // For root-level additions, we want to insert at the end of the document
+    // but before any trailing whitespace or comments
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Find the last line that contains actual YAML content (not empty or comment-only)
+    let mut last_content_line_idx = None;
+    for (i, line) in lines.iter().enumerate().rev() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            last_content_line_idx = Some(i);
+            break;
+        }
+    }
+
+    // Format the new entry for root level (no indentation)
+    let new_entry = if let serde_yaml::Value::Mapping(mapping) = value {
+        if mapping.is_empty() {
+            // For empty mappings, format inline
+            format!("{}: {}", key, new_value_str)
+        } else {
+            // For non-empty mappings, format as a nested structure
+            let value_lines: Vec<&str> = new_value_str.lines().collect();
+            let mut result = format!("{}:", key);
+            for line in value_lines.iter() {
+                if !line.trim().is_empty() {
+                    result.push('\n');
+                    result.push_str("  "); // 2 spaces for nested content
+                    result.push_str(line.trim_start());
+                }
+            }
+            result
+        }
+    } else {
+        // For scalar values, simple key: value format
+        format!("{}: {}", key, new_value_str)
+    };
+
+    let mut result = content.to_string();
+
+    if let Some(last_idx) = last_content_line_idx {
+        // Calculate the insertion point after the last content line
+        let mut insertion_point = 0;
+        for (i, line) in lines.iter().enumerate() {
+            if i <= last_idx {
+                insertion_point += line.len();
+                if i < lines.len() - 1 {
+                    insertion_point += 1; // +1 for newline
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Insert the new entry with a leading newline
+        let final_entry = format!("\n{}", new_entry);
+        result.insert_str(insertion_point, &final_entry);
+    } else {
+        // If there's no content, just append at the end
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&new_entry);
+    }
+
+    Ok(result)
+}
+
+/// Macro for creating comment-preserving YAML patches
+///
+/// This macro creates a function that can be used with the Fix system to apply
+/// YAML patch operations while preserving comments and formatting.
+///
+/// # Example
+///
+/// ```rust
+/// let fix = Fix {
+///     title: "Update permission".to_string(),
+///     description: "Change permission from write to read".to_string(),
+///     apply: apply_yaml_patch!(vec![
+///         YamlPatchOperation::Replace {
+///             path: "/permissions/contents".to_string(),
+///             value: serde_yaml::Value::String("read".to_string()),
+///         }
+///     ]),
+/// };
+/// ```
+#[macro_export]
+macro_rules! apply_yaml_patch {
+    ($operations:expr) => {{
+        let operations = $operations;
+        Box::new(move |old_content: &str| -> anyhow::Result<Option<String>> {
+            match crate::yaml_patch::apply_yaml_patch(old_content, operations.clone()) {
+                Ok(new_content) => Ok(Some(new_content)),
+                Err(e) => Err(anyhow::anyhow!("YAML patch failed: {}", e)),
+            }
+        })
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_yaml_patch_replace_preserves_comments() {
+        let original = r#"
+# This is a workflow file
+name: CI
+on: push
+
+permissions: # This configures permissions
+  contents: read  # Only read access
+  actions: write  # Write access for actions
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"#;
+
+        let operations = vec![YamlPatchOperation::Replace {
+            path: "/permissions/contents".to_string(),
+            value: serde_yaml::Value::String("write".to_string()),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+
+        // The result should preserve all comments
+        assert!(result.contains("# This is a workflow file"));
+        assert!(result.contains("# This configures permissions"));
+        assert!(result.contains("# Only read access"));
+        assert!(result.contains("# Write access for actions"));
+
+        // But should change the value
+        assert!(result.contains("contents: write"));
+        assert!(!result.contains("contents: read"));
+    }
+
+    #[test]
+    fn test_yaml_patch_add_preserves_formatting() {
+        let original = r#"
+permissions:
+  contents: read
+  actions: write
+"#;
+
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/permissions".to_string(),
+            key: "issues".to_string(),
+            value: serde_yaml::Value::String("read".to_string()),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+
+        // Should preserve original content and add new key
+        assert!(result.contains("contents: read"));
+        assert!(result.contains("actions: write"));
+        assert!(result.contains("issues: read"));
+
+        // Should maintain proper indentation
+        assert!(result.contains("  issues: read"));
+    }
+
+    #[test]
+    fn test_yaml_patch_remove_preserves_structure() {
+        let original = r#"
+permissions:
+  contents: read  # Keep this comment
+  actions: write  # Remove this line
+  issues: read
+"#;
+
+        let operations = vec![YamlPatchOperation::Remove {
+            path: "/permissions/actions".to_string(),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+
+        // Should preserve other content and comments
+        assert!(result.contains("contents: read"));
+        assert!(result.contains("# Keep this comment"));
+        assert!(result.contains("issues: read"));
+
+        // Should remove the target line
+        assert!(!result.contains("actions: write"));
+        assert!(!result.contains("# Remove this line"));
+    }
+
+    #[test]
+    fn test_multiple_operations_preserve_comments() {
+        let original = r#"
+# Main configuration
+name: Test Workflow
+on:
+  push: # Trigger on push
+    branches: [main]
+
+permissions:  # Security settings
+  contents: read
+  actions: read
+
+jobs:
+  build: # Main job
+    runs-on: ubuntu-latest
+"#;
+
+        let operations = vec![
+            YamlPatchOperation::Replace {
+                path: "/permissions/contents".to_string(),
+                value: serde_yaml::Value::String("write".to_string()),
+            },
+            YamlPatchOperation::Add {
+                path: "/permissions".to_string(),
+                key: "issues".to_string(),
+                value: serde_yaml::Value::String("write".to_string()),
+            },
+        ];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+
+        // All comments should be preserved
+        assert!(result.contains("# Main configuration"));
+        assert!(result.contains("# Trigger on push"));
+        assert!(result.contains("# Security settings"));
+        assert!(result.contains("# Main job"));
+
+        // Changes should be applied
+        assert!(result.contains("contents: write"));
+        assert!(result.contains("issues: write"));
+        assert!(!result.contains("contents: read"));
+    }
+
+    #[test]
+    fn test_json_pointer_parsing() {
+        // Test basic path parsing
+        let query = parse_json_pointer_to_query("/permissions/contents");
+        assert!(query.is_ok());
+
+        // Test array index parsing
+        let query = parse_json_pointer_to_query("/jobs/0/steps/1");
+        assert!(query.is_ok());
+
+        // Test URI encoding
+        let query = parse_json_pointer_to_query("/path/with~1slash/and~0tilde");
+        assert!(query.is_ok());
+
+        // Test error cases
+        assert!(parse_json_pointer_to_query("no-leading-slash").is_err());
+        assert!(parse_json_pointer_to_query("").is_err());
+    }
+
+    #[test]
+    fn test_string_quoting_detection() {
+        assert!(!needs_quoting("simple"));
+        assert!(!needs_quoting("snake_case"));
+        assert!(!needs_quoting("kebab-case"));
+
+        assert!(needs_quoting(""));
+        assert!(needs_quoting("has: colon"));
+        assert!(needs_quoting("has # hash"));
+        assert!(needs_quoting(" leading space"));
+        assert!(needs_quoting("trailing space "));
+        assert!(needs_quoting("true"));
+        assert!(needs_quoting("false"));
+        assert!(needs_quoting("null"));
+        assert!(needs_quoting("123"));
+        assert!(needs_quoting("3.14"));
+    }
+
+    #[test]
+    fn test_whitespace_extraction() {
+        let content = "line1\n  indented\n    more-indented";
+        assert_eq!(extract_leading_whitespace(content, 6), "  ");
+        assert_eq!(extract_leading_whitespace(content, 17), "    ");
+        assert_eq!(extract_leading_whitespace(content, 0), "");
+    }
+
+    #[test]
+    fn test_line_boundaries() {
+        let content = "line1\nline2\nline3";
+        assert_eq!(find_line_start(content, 0), 0);
+        assert_eq!(find_line_start(content, 3), 0);
+        assert_eq!(find_line_start(content, 6), 6);
+        assert_eq!(find_line_start(content, 9), 6);
+
+        assert_eq!(find_line_end(content, 0), 6);
+        assert_eq!(find_line_end(content, 3), 6);
+        assert_eq!(find_line_end(content, 6), 12);
+        assert_eq!(find_line_end(content, 15), 17);
+    }
+
+    #[test]
+    fn test_full_demo_workflow() {
+        // This test demonstrates the complete workflow for comment-preserving YAML patches
+        let original_yaml = r#"
+# GitHub Actions Workflow
+name: CI
+on: push
+
+# Security permissions
+permissions: # This section defines permissions
+  contents: read  # Only read access to repository contents
+  actions: write  # Write access for GitHub Actions
+  issues: read    # Read access to issues
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"#;
+
+        let operations = vec![
+            YamlPatchOperation::Replace {
+                path: "/permissions/contents".to_string(),
+                value: serde_yaml::Value::String("write".to_string()),
+            },
+            YamlPatchOperation::Add {
+                path: "/permissions".to_string(),
+                key: "packages".to_string(),
+                value: serde_yaml::Value::String("read".to_string()),
+            },
+        ];
+
+        let result = apply_yaml_patch(original_yaml, operations).unwrap();
+
+        // Verify all comments are preserved
+        assert!(result.contains("# GitHub Actions Workflow"));
+        assert!(result.contains("# Security permissions"));
+        assert!(result.contains("# This section defines permissions"));
+        assert!(result.contains("# Only read access to repository contents"));
+        assert!(result.contains("# Write access for GitHub Actions"));
+        assert!(result.contains("# Read access to issues"));
+
+        // Verify changes were applied
+        assert!(result.contains("contents: write"));
+        assert!(result.contains("packages: read"));
+        assert!(!result.contains("contents: read"));
+
+        println!("✅ Full demo test passed!");
+        println!("📝 Original YAML had comments preserved while applying transformations");
+    }
+
+    #[test]
+    fn test_empty_mapping_formatting() {
+        let original = r#"name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest"#;
+
+        // Test empty mapping formatting
+        let empty_mapping = serde_yaml::Mapping::new();
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/jobs/test".to_string(),
+            key: "permissions".to_string(),
+            value: serde_yaml::Value::Mapping(empty_mapping),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+
+        // Empty mapping should be formatted inline
+        assert!(result.contains("    permissions: {}"));
+        assert!(!result.contains("permissions:\n      {}"));
+    }
+
+    #[test]
+    fn test_no_empty_lines_after_insertion() {
+        let original = r#"name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test""#;
+
+        // Test with trailing newline (common in real files)
+        let original_with_newline = format!("{}\n", original);
+
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/jobs/test".to_string(),
+            key: "permissions".to_string(),
+            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        }];
+
+        let result = apply_yaml_patch(&original_with_newline, operations).unwrap();
+
+        // Should not have empty lines between content and new addition
+        assert!(!result.contains("\"test\"\n\n    permissions"));
+        assert!(result.contains("\"test\"\n    permissions: {}"));
+
+        // Should have proper structure without extra empty lines
+        let lines: Vec<&str> = result.lines().collect();
+        let steps_line = lines
+            .iter()
+            .position(|&line| line.contains("- run: echo \"test\""))
+            .unwrap();
+        let permissions_line = lines
+            .iter()
+            .position(|&line| line.contains("permissions: {}"))
+            .unwrap();
+
+        // permissions should come immediately after the step (no empty line in between)
+        assert_eq!(permissions_line, steps_line + 1);
+    }
+
+    #[test]
+    fn test_debug_comments_and_spacing() {
+        let original = r#"# GitHub Actions Workflow
+name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest  # Use latest Ubuntu
+
+    # Steps section with comments
+    steps:
+      # Checkout step
+      - name: Checkout repository
+        uses: actions/checkout@v4  # Latest checkout action
+        # No persist-credentials set
+
+      # Build step
+      - name: Build project
+        run: echo "Building...""#;
+
+        // Test what yamlpath extracts for the checkout step
+        let doc = yamlpath::Document::new(original).unwrap();
+        let checkout_query =
+            crate::yaml_patch::parse_json_pointer_to_query("/jobs/test/steps/0").unwrap();
+        let checkout_feature = doc.query(&checkout_query).unwrap();
+
+        println!("Checkout step extraction:");
+        println!("Exact span: '{}'", doc.extract(&checkout_feature));
+        println!(
+            "With leading whitespace: '{}'",
+            doc.extract_with_leading_whitespace(&checkout_feature)
+        );
+        println!("Byte span: {:?}", checkout_feature.location.byte_span);
+
+        // Test what yamlpath extracts for the test job
+        let job_query = crate::yaml_patch::parse_json_pointer_to_query("/jobs/test").unwrap();
+        let job_feature = doc.query(&job_query).unwrap();
+
+        println!("\nJob extraction:");
+        println!("Exact span: '{}'", doc.extract(&job_feature));
+        println!(
+            "With leading whitespace: '{}'",
+            doc.extract_with_leading_whitespace(&job_feature)
+        );
+        println!("Byte span: {:?}", job_feature.location.byte_span);
+
+        // Show what's around the insertion points
+        let checkout_end = checkout_feature.location.byte_span.1;
+        let job_end = job_feature.location.byte_span.1;
+
+        println!("\nAround checkout insertion point:");
+        let start = checkout_end.saturating_sub(20);
+        let end = (checkout_end + 20).min(original.len());
+        println!("Context: '{}'", &original[start..end]);
+        println!(
+            "Insertion point character: {:?}",
+            original.chars().nth(checkout_end - 1)
+        );
+
+        println!("\nAround job insertion point:");
+        let start = job_end.saturating_sub(20);
+        let end = (job_end + 20).min(original.len());
+        println!("Context: '{}'", &original[start..end]);
+        println!(
+            "Insertion point character: {:?}",
+            original.chars().nth(job_end - 1)
+        );
+    }
+
+    #[test]
+    fn test_step_insertion_with_comments() {
+        let original = r#"steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+    # This is a comment after the step
+
+  - name: Build
+    run: echo "build""#;
+
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/steps/0".to_string(),
+            key: "with".to_string(),
+            value: serde_yaml::Value::Mapping({
+                let mut map = serde_yaml::Mapping::new();
+                map.insert(
+                    serde_yaml::Value::String("persist-credentials".to_string()),
+                    serde_yaml::Value::Bool(false),
+                );
+                map
+            }),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+        println!("Result:\n{}", result);
+
+        // The with section should be added to the first step correctly
+        assert!(result.contains("uses: actions/checkout@v4"));
+        assert!(result.contains("with:"));
+        assert!(result.contains("persist-credentials: false"));
+        assert!(result.contains("# This is a comment after the step"));
+
+        // Should not break the structure
+        assert!(result.contains("- name: Build"));
+    }
+
+    #[test]
+    fn test_comment_boundary_issue() {
+        let original = r#"steps:
+  - name: Step1
+    uses: actions/checkout@v4
+    # Comment after step1
+
+  # Comment before step2
+  - name: Step2
+    run: echo "test""#;
+
+        // See what yamlpath extracts for step 0
+        let doc = yamlpath::Document::new(original).unwrap();
+        let step0_query = crate::yaml_patch::parse_json_pointer_to_query("/steps/0").unwrap();
+        let step0_feature = doc.query(&step0_query).unwrap();
+
+        println!("Step 0 extraction:");
+        println!("'{}'", doc.extract(&step0_feature));
+        println!("Byte span: {:?}", step0_feature.location.byte_span);
+
+        // See what yamlpath extracts for step 1
+        let step1_query = crate::yaml_patch::parse_json_pointer_to_query("/steps/1").unwrap();
+        let step1_feature = doc.query(&step1_query).unwrap();
+
+        println!("\nStep 1 extraction:");
+        println!("'{}'", doc.extract(&step1_feature));
+        println!("Byte span: {:?}", step1_feature.location.byte_span);
+
+        // Check for overlaps
+        if step0_feature.location.byte_span.1 > step1_feature.location.byte_span.0 {
+            println!("\n⚠️  OVERLAP DETECTED!");
+            println!("Step 0 ends at: {}", step0_feature.location.byte_span.1);
+            println!("Step 1 starts at: {}", step1_feature.location.byte_span.0);
+        }
+
+        // Show the characters around the boundaries
+        let content_between =
+            &original[step0_feature.location.byte_span.1..step1_feature.location.byte_span.0];
+        println!("\nContent between step spans: '{}'", content_between);
+    }
+
+    #[test]
+    fn test_root_level_addition_preserves_formatting() {
+        let original = r#"# GitHub Actions Workflow
+name: CI
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"#;
+
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/".to_string(),
+            key: "permissions".to_string(),
+            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+
+        // Should preserve all comments and structure
+        assert!(result.contains("# GitHub Actions Workflow"));
+        assert!(result.contains("name: CI"));
+        assert!(result.contains("on: push"));
+
+        // Should add permissions at the root level exactly once
+        assert!(result.contains("permissions: {}"));
+
+        // Should NOT have duplicated permissions (check that it only appears once)
+        let permissions_count = result.matches("permissions:").count();
+        assert_eq!(permissions_count, 1, "permissions should only appear once");
+
+        // Should maintain proper structure
+        assert!(result.contains("jobs:"));
+        assert!(result.contains("  test:"));
+        assert!(result.contains("    runs-on: ubuntu-latest"));
+
+        println!("Root-level addition result:\n{}", result);
+    }
+
+    #[test]
+    fn test_root_level_path_handling() {
+        // Test that root path "/" is handled correctly
+        let original = r#"name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest"#;
+
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/".to_string(),
+            key: "permissions".to_string(),
+            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        }];
+
+        let result = apply_yaml_patch(original, operations);
+        assert!(result.is_ok());
+
+        let result = result.unwrap();
+        assert!(result.contains("permissions: {}"));
+        assert!(result.contains("name: Test"));
+        assert!(result.contains("on: push"));
+    }
+
+    #[test]
+    fn test_step_content_end_detection() {
+        let original = r#"steps:
+  - name: Step1
+    uses: actions/checkout@v4
+    # Comment after step1
+
+  # Comment before step2
+  - name: Step2
+    run: echo "test""#;
+
+        let operations = vec![YamlPatchOperation::Add {
+            path: "/steps/0".to_string(),
+            key: "with".to_string(),
+            value: serde_yaml::Value::Mapping({
+                let mut map = serde_yaml::Mapping::new();
+                map.insert(
+                    serde_yaml::Value::String("persist-credentials".to_string()),
+                    serde_yaml::Value::Bool(false),
+                );
+                map
+            }),
+        }];
+
+        let result = apply_yaml_patch(original, operations).unwrap();
+        println!("Result:\n{}", result);
+
+        // The with section should be added to the first step correctly, not mixed with comments
+        assert!(result.contains("uses: actions/checkout@v4"));
+        assert!(result.contains("with:"));
+        assert!(result.contains("persist-credentials: false"));
+        assert!(result.contains("# Comment after step1"));
+        assert!(result.contains("# Comment before step2"));
+        assert!(result.contains("- name: Step2"));
+
+        // Verify the structure is correct - with should come right after uses
+        let lines: Vec<&str> = result.lines().collect();
+        let uses_line = lines
+            .iter()
+            .position(|&line| line.contains("uses: actions/checkout@v4"))
+            .unwrap();
+        let with_line = lines
+            .iter()
+            .position(|&line| line.contains("with:"))
+            .unwrap();
+
+        // with should come immediately after uses (or with one comment line in between)
+        assert!(with_line > uses_line && with_line <= uses_line + 2);
+
+        // Step2 should still be intact
+        let step2_line = lines
+            .iter()
+            .position(|&line| line.contains("- name: Step2"))
+            .unwrap();
+        assert!(step2_line > with_line);
+    }
+}

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-8.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-8.snap
@@ -1,19 +1,18 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Action
 
 Caused by:
     0: input does not match expected validation schema
-    1: runs: Additional properties are not allowed ('image' was unexpected)
-       runs: "using" is a required property
+    1: runs: "using" is a required property
        runs: "main" is a required property
        runs: Additional properties are not allowed ('image' was unexpected)
        runs: "using" is a required property
        runs: "steps" is a required property
+       runs: Additional properties are not allowed ('image' was unexpected)
        runs: "using" is a required property
        outputs.some-output: "value" is a required property
        "description" is a required property

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
@@ -9,5 +8,5 @@ failed to load input as Workflow
 Caused by:
     0: input does not match expected validation schema
     1: jobs.invalid: "runs-on" is a required property
-       jobs.invalid: Additional properties are not allowed ('steps' was unexpected)
        jobs.invalid: "uses" is a required property
+       jobs.invalid: Additional properties are not allowed ('steps' was unexpected)

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_612_repro.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_612_repro.snap
@@ -2,4 +2,4 @@
 source: crates/zizmor/tests/integration/e2e.rs
 expression: "zizmor().input(input_under_test(\"issue-612-repro/action.yml\")).run()?"
 ---
-No findings to report. Good job! (2 ignored, 2 suppressed)
+No findings to report. Good job! (1 ignored)

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__github_output.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__github_output.snap
@@ -5,5 +5,4 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
 ::error file=@@INPUT@@,line=5,title=excessive-permissions::several-vulnerabilities.yml:5: overly broad permissions: uses write-all permissions
 ::error file=@@INPUT@@,line=11,title=excessive-permissions::several-vulnerabilities.yml:11: overly broad permissions: uses write-all permissions
 ::error file=@@INPUT@@,line=2,title=dangerous-triggers::several-vulnerabilities.yml:2: use of fundamentally insecure workflow trigger: pull_request_target is almost always used insecurely
-::notice file=@@INPUT@@,line=15,title=template-injection::several-vulnerabilities.yml:15: code injection via template expansion: ${{ github.event.pull_request.title }} may expand into attacker-controllable code
-::error file=@@INPUT@@,line=15,title=template-injection::several-vulnerabilities.yml:15: code injection via template expansion: github.event.pull_request.title may expand into attacker-controllable code
+::error file=@@INPUT@@,line=15,title=template-injection::several-vulnerabilities.yml:15: code injection via template expansion: ${{ github.event.pull_request.title }} may expand into attacker-controllable code

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__obfuscation.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__obfuscation.snap
@@ -186,4 +186,4 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
    |
    = note: audit confidence → High
 
-39 findings (1 ignored, 15 suppressed): 0 unknown, 0 informational, 23 low, 0 medium, 0 high
+26 findings (1 ignored, 2 suppressed): 0 unknown, 0 informational, 23 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-11.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-11.snap
@@ -11,8 +11,8 @@ error[template-injection]: code injection via template expansion
 16 | |           cmd: ${{ github.event.pull_request.title }}
    | |___________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
    |             |
-   |             github.event.pull_request.title may expand into attacker-controllable code
+   |             ${{ github.event.pull_request.title }} may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
-2 findings (1 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 1 high
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-12.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-12.snap
@@ -14,8 +14,8 @@ error[template-injection]: code injection via template expansion
    | ||                                                                                                ^
    | ||________________________________________________________________________________________________|
    |  |________________________________________________________________________________________________this step
-   |                                                                                                   github.event.pull_request.title may expand into attacker-controllable code
+   |                                                                                                   ${{ github.event.pull_request.title }} may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
-2 findings (1 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 1 high
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-2.snap
@@ -2,17 +2,6 @@
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/template-injection-dynamic-matrix.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
-note[template-injection]: code injection via template expansion
-  --> @@INPUT@@:19:9
-   |
-19 |         - name: Please dont
-   |           ----------------- note: this step
-20 | /         run: |
-21 | |           echo "doing a thing: ${{ matrix.dynamic }}"
-   | |______________________________________________________- note: ${{ matrix.dynamic }} may expand into attacker-controllable code
-   |
-   = note: audit confidence → Unknown
-
 warning[template-injection]: code injection via template expansion
   --> @@INPUT@@:19:9
    |
@@ -20,8 +9,8 @@ warning[template-injection]: code injection via template expansion
    |           ----------------- this step
 20 | /         run: |
 21 | |           echo "doing a thing: ${{ matrix.dynamic }}"
-   | |______________________________________________________- matrix.dynamic may expand into attacker-controllable code
+   | |______________________________________________________- ${{ matrix.dynamic }} may expand into attacker-controllable code
    |
    = note: audit confidence → Medium
 
-2 findings: 1 unknown, 0 informational, 0 low, 1 medium, 0 high
+1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-3.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-3.snap
@@ -2,4 +2,4 @@
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/issue-22-repro.yml\")).run()?"
 ---
-No findings to report. Good job! (5 suppressed)
+No findings to report. Good job! (2 suppressed)

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-4.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-4.snap
@@ -11,8 +11,8 @@ warning[template-injection]: code injection via template expansion
    | |                                 -
    | |_________________________________|
    |                                   this step
-   |                                   matrix.bar may expand into attacker-controllable code
+   |                                   ${{ matrix.bar }} may expand into attacker-controllable code
    |
    = note: audit confidence → Medium
 
-2 findings (1 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 0 high
+1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-5.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-5.snap
@@ -9,7 +9,7 @@ help[template-injection]: code injection via template expansion
    |           --------------------------- help: this step
 42 | /         run: |
 43 | |           echo ${{ env.bar }}
-   | |_____________________________- help: env.bar may expand into attacker-controllable code
+   | |_____________________________- help: ${{ env.bar }} may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
@@ -20,7 +20,7 @@ help[template-injection]: code injection via template expansion
    |           -------------------------- help: this step
 49 | /         run: |
 50 | |           echo ${{ env.foo }}
-   | |_____________________________- help: env.foo may expand into attacker-controllable code
+   | |_____________________________- help: ${{ env.foo }} may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
@@ -31,8 +31,8 @@ help[template-injection]: code injection via template expansion
    |           ------------------------------- help: this step
 54 | /         run: |
 55 | |           echo ${{ env.quux }}
-   | |_______________________________- help: env.quux may expand into attacker-controllable code
+   | |_______________________________- help: ${{ env.quux }} may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
-9 findings (6 suppressed): 0 unknown, 0 informational, 3 low, 0 medium, 0 high
+6 findings (3 suppressed): 0 unknown, 0 informational, 3 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-6.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-6.snap
@@ -10,8 +10,8 @@ info[template-injection]: code injection via template expansion
 28 |           id: run-id
 29 | /         run: |
 30 | |           echo "run-id=${{ fromJson(steps.runs.outputs.data).workflow_runs[0].id }}" >> "$GITHUB_OUTPUT"
-   | |_________________________________________________________________________________________________________- info: fromJson(steps.runs.outputs.data).workflow_runs[0].id may expand into attacker-controllable code
+   | |_________________________________________________________________________________________________________- info: ${{ fromJson(steps.runs.outputs.data).workflow_runs[0].id }} may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
-2 findings (1 suppressed): 0 unknown, 1 informational, 0 low, 0 medium, 0 high
+1 finding: 0 unknown, 1 informational, 0 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-8.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-8.snap
@@ -9,7 +9,7 @@ error[template-injection]: code injection via template expansion
    |         ^^^^^^^^^^^ this step
 13 | /       run: |
 14 | |         hello ${{ inputs.expandme }}
-   | |____________________________________^ inputs.expandme may expand into attacker-controllable code
+   | |____________________________________^ ${{ inputs.expandme }} may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
@@ -21,7 +21,7 @@ error[template-injection]: code injection via template expansion
 18 |       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
 19 |       with:
 20 |         script: return "${{ inputs.expandme }}"
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.expandme may expand into attacker-controllable code
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ${{ inputs.expandme }} may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
@@ -34,7 +34,7 @@ error[template-injection]: code injection via template expansion
 24 |         with:
 25 | /         inlineScript: |
 26 | |           echo "hello ${{ inputs.expandme }}"
-   | |_____________________________________________^ inputs.expandme may expand into attacker-controllable code
+   | |_____________________________________________^ ${{ inputs.expandme }} may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
@@ -46,7 +46,7 @@ error[template-injection]: code injection via template expansion
 29 |       uses: azure/powershell
 30 |       with:
 31 |         inlineScript: Get-AzVM -ResourceGroupName "${{ inputs.expandme }}"
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.expandme may expand into attacker-controllable code
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ${{ inputs.expandme }} may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
@@ -58,4 +58,4 @@ error[unpinned-uses]: unpinned action reference
    |
    = note: audit confidence → High
 
-9 findings (4 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 5 high
+5 findings: 0 unknown, 0 informational, 0 low, 0 medium, 5 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-9.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-9.snap
@@ -2,4 +2,4 @@
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/false-positive-menagerie.yml\")).run()?"
 ---
-No findings to report. Good job! (6 suppressed)
+No findings to report. Good job! (1 suppressed)

--- a/massive-vulnerable-workflow.yml
+++ b/massive-vulnerable-workflow.yml
@@ -1,0 +1,513 @@
+name: "Massive Vulnerable Workflow - All Zizmor Issues"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  push:
+    branches:
+      - main
+      - develop
+  release:
+    types:
+      - published
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+  actions: write
+  checks: write
+  deployments: write
+  id-token: write
+  pages: write
+  repository-projects: write
+  security-events: write
+  statuses: write
+
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+  GLOBAL_SECRET: ${{ secrets.SUPER_SECRET }}
+  ALL_SECRETS: ${{ toJSON(secrets) }}
+  ISSUE_TITLE: ${{ github.event.issue.title }}
+  PR_BODY: ${{ github.event.pull_request.body }}
+
+jobs:
+  artipacked-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout without persist-credentials config
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Upload artifact with git config
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-with-git
+          path: .
+
+  bot-conditions-vulnerable:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Auto-merge PR
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cache-poisoning-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node with cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      - name: Build and publish
+        run: npm ci && npm run build && npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  excessive-permissions-vulnerable:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: write
+      actions: write
+      checks: write
+      deployments: write
+      id-token: write
+    steps:
+      - name: Simple echo
+        run: echo 'Hello World'
+
+  forbidden-uses-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use potentially forbidden action
+        uses: some-untrusted-org/dangerous-action@v1
+      - name: Use another forbidden action
+        uses: malicious-user/backdoor-action@main
+
+  github-env-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dangerous GITHUB_ENV usage
+        run: echo "DANGEROUS_VAR=${{ github.event.issue.title }}" >> $GITHUB_ENV
+      - name: Dangerous GITHUB_PATH usage
+        run: echo "${{ github.event.pull_request.head.ref }}" >> $GITHUB_PATH
+      - name: Use environment variable
+        run: echo $DANGEROUS_VAR
+
+  hardcoded-container-credentials-vulnerable:
+    runs-on: ubuntu-latest
+    container:
+      image: private.registry.com/myapp:latest
+      credentials:
+        username: hardcoded-user
+        password: hardcoded-password-123
+    services:
+      database:
+        image: private.registry.com/postgres:13
+        credentials:
+          username: db-user
+          password: super-secret-password
+    steps:
+      - name: Run tests
+        run: echo 'Running tests with hardcoded credentials'
+
+  impostor-commit-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use impostor commit
+        uses: actions/checkout@565ece486c7c1652754d7b6d2b5ed9cb4097f9d5
+      - name: Another impostor commit
+        uses: github/super-linter@fakehash123456789abcdef
+
+  insecure-commands-vulnerable:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+    steps:
+      - name: Use deprecated set-env
+        run: echo "::set-env name=MY_VAR::dangerous-value"
+      - name: Use deprecated add-path
+        run: echo "::add-path::/dangerous/path"
+
+  known-vulnerable-actions-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use known vulnerable action
+        uses: actions/checkout@v1
+      - name: Another vulnerable action
+        uses: actions/upload-artifact@v1
+
+  obfuscation-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obfuscated uses path
+        uses: actions/../actions/checkout@v4
+      - name: Obfuscated expression
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ format('{0}/{1}', 'octocat', 'hello-world') }}
+      - name: No-op JSON transformation
+        run: echo '${{ fromJSON(toJSON(github.repository)) }}'
+
+  overprovisioned-secrets-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Expose all secrets
+        run: ./deploy.sh
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+      - name: Another secrets exposure
+        run: echo '${{ toJSON(secrets) }}' | base64
+
+  ref-confusion-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use confusable ref
+        uses: actions/checkout@v4
+      - name: Another confusable ref
+        uses: actions/setup-node@main
+      - name: Tag that could be branch
+        uses: some-org/some-action@release
+
+  secrets-inherit-vulnerable:
+    uses: ./.github/workflows/reusable.yml
+    secrets: inherit
+
+  self-hosted-runner-vulnerable:
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    steps:
+      - name: Run on self-hosted
+        run: echo 'Running on potentially insecure self-hosted runner'
+
+  stale-action-refs-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use stale SHA reference
+        uses: actions/checkout@abcdef1234567890abcdef1234567890abcdef12
+
+  template-injection-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Vulnerable template injection in run
+        run: |
+          echo "Issue title: ${{ github.event.issue.title }}"
+      - name: Vulnerable template injection in shell command
+        run: title="${{ github.event.issue.title }}"; echo $title
+      - name: Vulnerable in script
+        run: python -c "print('${{ github.event.pull_request.body }}')"
+      - name: Vulnerable in environment
+        run: echo $USER_INPUT
+        env:
+          USER_INPUT: ${{ github.event.issue.body }}
+
+  unpinned-images-vulnerable:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu
+    services:
+      redis:
+        image: redis:latest
+      postgres:
+        image: postgres
+    steps:
+      - name: Use unpinned Docker action
+        uses: docker://ubuntu
+      - name: Another unpinned Docker action
+        uses: docker://node:latest
+
+  unpinned-uses-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Completely unpinned action
+        uses: actions/checkout
+      - name: Tag-pinned action (should be hash-pinned)
+        uses: actions/setup-node@v4
+      - name: Branch-pinned action
+        uses: some-org/some-action@main
+      - name: Unpinned Docker action
+        uses: docker://ubuntu
+
+  unredacted-secrets-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unredacted JSON secret
+        run: ./deploy.sh
+        env:
+          USERNAME: ${{ fromJSON(secrets.MY_SECRET).username }}
+          PASSWORD: ${{ fromJSON(secrets.MY_SECRET).password }}
+          API_KEY: ${{ fromJSON(secrets.CONFIG).api_key }}
+
+  unsound-contains-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to production
+        run: terraform apply -auto-approve
+        if: contains('refs/heads/main refs/heads/develop', github.ref)
+      - name: Another unsound contains
+        run: echo 'Deploying'
+        if: contains('production staging', github.event.deployment.environment)
+
+  use-trusted-publishing-vulnerable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI with manual token
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  multiple-vulnerabilities-combined:
+    runs-on:
+      - self-hosted
+    if: ${{ github.actor == 'dependabot[bot]' && contains('main develop', github.ref) }}
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    container:
+      image: ubuntu:latest
+      credentials:
+        username: hardcoded
+        password: password123
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+      ALL_SECRETS: ${{ toJSON(secrets) }}
+    steps:
+      - name: Unpinned checkout
+        uses: actions/checkout
+      - name: Template injection vulnerability
+        run: |
+          echo "User input: ${{ github.event.issue.title }}"
+      - name: GITHUB_ENV manipulation
+        run: echo "MALICIOUS_VAR=${{ github.event.pull_request.body }}" >> $GITHUB_ENV
+      - name: Insecure command
+        run: echo "::set-env name=DANGEROUS::${{ github.event.issue.body }}"
+      - name: Unredacted secrets
+        run: ./script.sh
+        env:
+          SECRET_VALUE: ${{ fromJSON(secrets.CONFIG).secret }}
+      - name: Cache for release
+        uses: actions/cache@v4
+        with:
+          path: dist/
+          key: build-${{ github.sha }}
+      - name: Upload with git credentials
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-package
+          path: .
+
+  reusable-workflow-secrets-inherit:
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit
+    with:
+      environment: production
+
+  dangerous-expressions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obfuscated format expression
+        run: echo 'Processing'
+        env:
+          REPO: ${{ format('{0}', github.repository) }}
+      - name: Redundant JSON operations
+        run: echo '${{ fromJSON(toJSON(github.event)) }}'
+
+  # Additional edge cases and variations
+  more-template-injection-variants:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Template injection in if condition
+        run: echo "Conditional execution"
+        if: ${{ github.event.issue.title == 'deploy' }}
+      - name: Template injection in with parameters
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Template injection in working directory
+        run: ls -la
+        working-directory: ${{ github.event.issue.title }}
+
+  more-github-env-variants:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Multiple GITHUB_ENV writes
+        run: |
+          echo "VAR1=${{ github.event.issue.title }}" >> $GITHUB_ENV
+          echo "VAR2=${{ github.event.pull_request.body }}" >> $GITHUB_ENV
+          echo "VAR3=${{ github.event.comment.body }}" >> $GITHUB_ENV
+      - name: GITHUB_PATH with user input
+        run: echo "/tmp/${{ github.event.issue.title }}" >> $GITHUB_PATH
+      - name: GITHUB_OUTPUT with potential issues
+        run: echo "result=${{ github.event.issue.body }}" >> $GITHUB_OUTPUT
+
+  more-unpinned-variations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Local action without version
+        uses: ./local-action
+      - name: Marketplace action without pin
+        uses: crazy-max/ghaction-docker-buildx
+      - name: Third party action with latest
+        uses: some-org/some-action@latest
+      - name: Action with floating tag
+        uses: docker/build-push-action@master
+
+  more-obfuscation-patterns:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Complex path obfuscation
+        uses: actions/./checkout/../checkout@v4
+      - name: Nested format expressions
+        run: echo "Processing"
+        env:
+          COMPLEX: ${{ format('{0}', format('{0}', github.repository)) }}
+      - name: Multiple JSON transformations
+        run: echo '${{ toJSON(fromJSON(toJSON(secrets))) }}'
+
+  more-secrets-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Secrets in run command
+        run: echo "Secret is ${{ secrets.MY_SECRET }}"
+      - name: Multiple fromJSON secrets
+        run: ./script.sh
+        env:
+          USER: ${{ fromJSON(secrets.CREDENTIALS).user }}
+          PASS: ${{ fromJSON(secrets.CREDENTIALS).pass }}
+          TOKEN: ${{ fromJSON(secrets.CREDENTIALS).token }}
+          API_KEY: ${{ fromJSON(secrets.API_CONFIG).key }}
+
+  more-dangerous-conditions:
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'dependabot[bot]' ||
+      github.actor == 'renovate[bot]' ||
+      contains('refs/heads/main refs/heads/master', github.ref)
+    steps:
+      - name: Dangerous auto-action
+        run: |
+          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+          gh release create "v1.0.0" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  container-variations:
+    runs-on: ubuntu-latest
+    container:
+      image: node:18
+      credentials:
+        username: ${{ secrets.REGISTRY_USER }}
+        password: plaintext-password
+    services:
+      mysql:
+        image: mysql
+        credentials:
+          username: root
+          password: root123
+      redis:
+        image: redis:6
+        credentials:
+          username: admin
+          password: ${{ secrets.REDIS_PASS }}
+    steps:
+      - name: Use services
+        run: echo "Using services with mixed credential types"
+
+  workflow-command-variations:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    steps:
+      - name: Various deprecated commands
+        run: |
+          echo "::set-env name=VAR1::value1"
+          echo "::add-path::/usr/local/bin"
+          echo "::set-output name=result::success"
+          echo "::save-state name=state::saved"
+      - name: Commands with user input
+        run: |
+          echo "::set-env name=USER_VAR::${{ github.event.issue.title }}"
+          echo "::add-path::${{ github.event.pull_request.head.ref }}"
+
+  permission-escalation-patterns:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      repository-projects: write
+      packages: write
+      pages: write
+      actions: write
+      checks: write
+      deployments: write
+      statuses: write
+      security-events: write
+      id-token: write
+    steps:
+      - name: Minimal task with excessive permissions
+        run: echo "Hello World"
+      - name: Another simple task
+        run: date
+
+  cache-poisoning-variations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python with cache
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Setup Ruby with cache
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build and release
+        run: |
+          pip install build
+          python -m build
+          twine upload dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+  expression-injection-variants:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Processing ${{ github.event.issue.title }}"
+        run: echo "Step with dynamic name"
+      - name: Injection in timeout
+        run: sleep 10
+        timeout-minutes: ${{ github.event.issue.number }}
+      - name: Injection in continue-on-error
+        run: echo "Might fail"
+        continue-on-error: ${{ github.event.issue.title == 'ignore-errors' }}


### PR DESCRIPTION
Hey,

This PR introduces a comprehensive auto-fix feature that allows zizmor to suggest and automatically apply security fixes to GitHub Actions workflows while preserving YAML formatting and comments, on a best-effort basis.

### Auto-Fix CLI Options
* `--fix`: Apply fixes automatically if available
* `--yes`: Skip confirmation prompt when applying fixes
* `--dry-run`: Preview fixes without applying them
* `--diff`: Show a diff of changes before applying

### New Features
* `Fix`: each finding will have one or more Fixes, that either suggest and/or automatically apply fixes to the findings of each audit rule.
* Fixes for all audit rules.
* `yaml_patch`: custom YAML patch engine that maintains formatting, comments, and structure
* `oci_registry`: OCI registry client to figure out the version tags of a Docker image on any registry.
* `massive_vulnerable_workflow.yml`: a god-mode test for all the findings and fixes.
* Lots of tests.

### How-to use
```bash
# Preview fixes without applying
zizmor --fix --dry-run workflow.yml

# Apply fixes with confirmation
zizmor --fix workflow.yml

# Apply fixes automatically with diff preview
zizmor --fix --diff --yes workflow.yml
```

Note to the reviewer(s): this is not perfect and I'd be happy to change and adapt it.