### PR TITLE
Update usage directions to explicitly state permissions needed

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,10 +109,16 @@ zizmor --offline workflow.yml
 # passing a token explicitly will enable online mode
 zizmor --gh-token ghp-... workflow.yml
 
+# use the [GitHub CLI](https://cli.github.com/) token instead of a long-lived PAT
+zizmor --gh-token $(gh auth token) workflow.yml
+
 # online for the purpose of fetching the input (example/example),
 # but all audits themselves are offline
 zizmor --no-online-audits --gh-token ghp-... example/example
 ```
+
+> [!TIP]
+> For auditing Actions that are available publicly, `GH_TOKEN` can be either a classic or fine-grained token that needs no additional scopes (don't check any of the permissions boxes).  If you're trying to reference private actions, this token will need the ability to access those repositories.
 
 ## Output formats
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,8 +117,12 @@ zizmor --gh-token $(gh auth token) workflow.yml
 zizmor --no-online-audits --gh-token ghp-... example/example
 ```
 
-> [!TIP]
-> For auditing Actions that are available publicly, `GH_TOKEN` can be either a classic or fine-grained token that needs no additional scopes (don't check any of the permissions boxes).  If you're trying to reference private actions, this token will need the ability to access those repositories.
+!!! tip
+
+    For auditing Actions that are available publicly, `GH_TOKEN` can be either a
+    classic or fine-grained token that needs no additional scopes (don't check any
+    of the permissions boxes).  If you're trying to reference private Actions, this
+    token will need the ability to access those repositories.
 
 ## Output formats
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,13 +117,6 @@ zizmor --gh-token $(gh auth token) workflow.yml
 zizmor --no-online-audits --gh-token ghp-... example/example
 ```
 
-!!! tip
-
-    For auditing Actions that are available publicly, `GH_TOKEN` can be either a
-    classic or fine-grained token that needs no additional scopes (don't check any
-    of the permissions boxes).  If you're trying to reference private Actions, this
-    token will need the ability to access those repositories.
-
 ## Output formats
 
 `zizmor` always produces output on `stdout`.


### PR DESCRIPTION
Closes #855 

This creates two small changes to the docs on usage.  One explicitly states the permissions needed for `GH_TOKEN`.  The other adds an example of passing in the [GitHub CLI's](https://cli.github.com) token instead of using a long-lived personal access token.