### PR TITLE
fix: update error message to handle enterprise servers

### DIFF
--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -395,12 +395,18 @@ fn collect_from_repo_slug(
         client.fetch_workflows(&slug, registry)?;
     } else {
         let before = registry.len();
+        let host = match &state.gh_hostname {
+            GitHubHost::Enterprise(address) => address.as_str(),
+            GitHubHost::Standard(_) => "github.com",
+        };
+
         client
             .fetch_audit_inputs(&slug, registry)
             .with_context(|| {
                 tips(
                     format!(
-                        "couldn't collect inputs from https://github.com/{owner}/{repo}",
+                        "couldn't collect inputs from https://{host}/{owner}/{repo}",
+                        host = host,
                         owner = slug.owner,
                         repo = slug.repo
                     ),

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,8 @@ of `zizmor`.
 * The [template-injection] audit now correctly emits pedantic findings
   in a blanket manner, rather than filtering them based on the presence
   of other findings (#745)
+* CLI: Fixed a misleading error message when `zizmor` is used with
+  a GitHub host other than `github.com` (#863)
 
 ## v1.8.0
 


### PR DESCRIPTION
While using zizmor at work today I noticed that when specifying `--gh-hostname` and failing to collect inputs from an on-prem GitHub Enterprise Server, zizmor would emit a message making it seem like it was trying to connect to github.com.