### PR TITLE
chore: release github-actions-expressions 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-expressions"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
-github-actions-expressions = { path = "crates/github-actions-expressions", version = "0.0.3" }
+github-actions-expressions = { path = "crates/github-actions-expressions", version = "0.0.4" }
 github-actions-models = { path = "crates/github-actions-models", version = "0.29.0" }
 itertools = "0.14.0"
 pest = "2.8.0"

--- a/crates/github-actions-expressions/Cargo.toml
+++ b/crates/github-actions-expressions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "github-actions-expressions"
 description = "GitHub Actions expression parser and data types"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/github-actions-expressions"
-version = "0.0.3"
+version = "0.0.4"
 readme = "README.md"
 
 homepage.workspace = true


### PR DESCRIPTION
Revealed during a failed dry-run of #877.