### PR TITLE
crates: use `[lints]` table to inherit from workspace

### DIFF
--- a/crates/github-actions-expressions/Cargo.toml
+++ b/crates/github-actions-expressions/Cargo.toml
@@ -9,7 +9,9 @@ homepage.workspace = true
 license.workspace = true
 authors.workspace = true
 edition.workspace = true
-lints.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -11,7 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 edition.workspace = true
 license.workspace = true
-lints.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 indexmap.workspace = true

--- a/crates/yamlpath/Cargo.toml
+++ b/crates/yamlpath/Cargo.toml
@@ -10,7 +10,9 @@ authors.workspace = true
 homepage.workspace = true
 edition.workspace = true
 license.workspace = true
-lints.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -13,7 +13,9 @@ license.workspace = true
 readme.workspace = true
 authors.workspace = true
 edition.workspace = true
-lints.workspace = true
+
+[lints]
+workspace = true
 
 [features]
 # Test-only: enable online audits that make use of a GitHub token via GH_TOKEN.


### PR DESCRIPTION
Small follow-on to #879 -- `lints.workspace` doesn't work since it implicitly scopes below `[package]`, so we need to explicitly use a `[lints]` table instead.

CC @langston-barrett for viz 