### PR TITLE
fix: remove spurious panic in env handling

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,3 +21,7 @@ jobs:
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@2520132f44b3ed84916048d32e5c7153fc739fe7 # v0.0.3
+        with:
+          # intentionally not scanning the entire repository,
+          # since it contains integration tests.
+          inputs: ./.github/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "github-actions-models"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 [workspace.dependencies]
 anyhow = "1.0.98"
 github-actions-expressions = { path = "crates/github-actions-expressions", version = "0.0.4" }
-github-actions-models = { path = "crates/github-actions-models", version = "0.29.0" }
+github-actions-models = { path = "crates/github-actions-models", version = "0.30.0" }
 itertools = "0.14.0"
 pest = "2.8.0"
 pest_derive = "2.8.0"

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-actions-models"
-version = "0.29.0"
+version = "0.30.0"
 description = "Unofficial, high-quality data models for GitHub Actions workflows, actions, and related components"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/github-actions-models"
 keywords = ["github", "ci"]

--- a/crates/github-actions-models/src/action.rs
+++ b/crates/github-actions-models/src/action.rs
@@ -123,6 +123,10 @@ pub struct Step {
     #[serde(default)]
     pub continue_on_error: BoE,
 
+    /// An optional environment mapping for this step.
+    #[serde(default)]
+    pub env: LoE<Env>,
+
     /// The `run:` or `uses:` body for this composite step.
     #[serde(flatten)]
     pub body: StepBody,
@@ -149,10 +153,6 @@ pub enum StepBody {
 
         /// The shell to run in.
         shell: String,
-
-        /// An optional environment mapping for this step.
-        #[serde(default)]
-        env: LoE<Env>,
 
         /// An optional working directory to run [`RunShell::run`] from.
         working_directory: Option<String>,

--- a/crates/github-actions-models/src/workflow/job.rs
+++ b/crates/github-actions-models/src/workflow/job.rs
@@ -102,6 +102,10 @@ pub struct Step {
     #[serde(default)]
     pub continue_on_error: BoE,
 
+    /// An optional environment mapping for this step.
+    #[serde(default)]
+    pub env: LoE<Env>,
+
     /// The `run:` or `uses:` body for this step.
     #[serde(flatten)]
     pub body: StepBody,
@@ -130,10 +134,6 @@ pub enum StepBody {
         /// An optional shell to run in. Defaults to the job or workflow's
         /// default shell.
         shell: Option<String>,
-
-        /// An optional environment mapping for this step.
-        #[serde(default)]
-        env: LoE<Env>,
     },
 }
 

--- a/crates/github-actions-models/tests/test_workflow.rs
+++ b/crates/github-actions-models/tests/test_workflow.rs
@@ -71,7 +71,6 @@ fn test_pip_audit_ci() {
         run,
         working_directory,
         shell,
-        env: LoE::Literal(env),
     } = &test_job.steps[2].body
     else {
         panic!("expected run step");
@@ -79,7 +78,6 @@ fn test_pip_audit_ci() {
     assert_eq!(run, "make test PIP_AUDIT_EXTRA=test");
     assert!(working_directory.is_none());
     assert!(shell.is_none());
-    assert!(env.is_empty());
 }
 
 #[test]

--- a/crates/zizmor/src/audit/insecure_commands.rs
+++ b/crates/zizmor/src/audit/insecure_commands.rs
@@ -74,13 +74,12 @@ impl InsecureCommands {
                     run: _,
                     working_directory: _,
                     shell: _,
-                    env,
                 } = &step.deref().body
                 else {
                     return None;
                 };
 
-                match env {
+                match &step.env {
                     // The entire environment block is an expression, which we
                     // can't follow (for now). Emit an auditor-only finding.
                     LoE::Expr(_) => {
@@ -143,11 +142,11 @@ impl Audit for InsecureCommands {
     ) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
-        let action::StepBody::Run { env, .. } = &step.body else {
+        let action::StepBody::Run { .. } = &step.body else {
             return Ok(findings);
         };
 
-        match env {
+        match &step.env {
             LoE::Expr(_) => {
                 findings.push(self.insecure_commands_maybe_present(step.action(), step.location())?)
             }

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -556,15 +556,10 @@ impl<'doc> Deref for Step<'doc> {
 
 impl<'doc> StepCommon<'doc> for Step<'doc> {
     fn env_is_static(&self, name: &str) -> bool {
-        // Collect each of the step, job, and workflow-level `env` blocks
-        // and check each.
-        let mut envs = vec![];
-
-        envs.push(&self.env);
-        envs.push(&self.job().env);
-        envs.push(&self.workflow().env);
-
-        utils::env_is_static(name, &envs)
+        utils::env_is_static(
+            name,
+            &[&self.env, &self.job().env, &self.workflow().env],
+        )
     }
 
     fn uses(&self) -> Option<&common::Uses> {

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -556,10 +556,7 @@ impl<'doc> Deref for Step<'doc> {
 
 impl<'doc> StepCommon<'doc> for Step<'doc> {
     fn env_is_static(&self, name: &str) -> bool {
-        utils::env_is_static(
-            name,
-            &[&self.env, &self.job().env, &self.workflow().env],
-        )
+        utils::env_is_static(name, &[&self.env, &self.job().env, &self.workflow().env])
     }
 
     fn uses(&self) -> Option<&common::Uses> {

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -36,7 +36,6 @@ pub(crate) enum StepBodyCommon<'s> {
         run: &'s str,
         _working_directory: Option<&'s str>,
         _shell: Option<&'s str>,
-        _env: &'s LoE<Env>,
     },
 }
 
@@ -561,18 +560,7 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
         // and check each.
         let mut envs = vec![];
 
-        match &self.body {
-            // `uses:` does not have an `env:` but its parent
-            // job and workflow might, so we skip instead of failing.
-            workflow::job::StepBody::Uses { .. } => (),
-            workflow::job::StepBody::Run {
-                run: _,
-                working_directory: _,
-                shell: _,
-                env,
-            } => envs.push(env),
-        };
-
+        envs.push(&self.env);
         envs.push(&self.job().env);
         envs.push(&self.workflow().env);
 
@@ -598,12 +586,10 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
                 run,
                 working_directory,
                 shell,
-                env,
             } => StepBodyCommon::Run {
                 run,
                 _working_directory: working_directory.as_deref(),
                 _shell: shell.as_deref(),
-                _env: env,
             },
         }
     }
@@ -656,7 +642,6 @@ impl<'doc> Step<'doc> {
             run: _,
             working_directory: _,
             shell,
-            env: _,
         } = &self.inner.body
         else {
             panic!("API misuse: can't call shell() on a uses: step")
@@ -842,19 +827,7 @@ impl<'a> Deref for CompositeStep<'a> {
 
 impl<'s> StepCommon<'s> for CompositeStep<'s> {
     fn env_is_static(&self, name: &str) -> bool {
-        let env = match &self.body {
-            action::StepBody::Uses { .. } => {
-                panic!("API misuse: can't call env_is_static on a uses: step")
-            }
-            action::StepBody::Run {
-                run: _,
-                working_directory: _,
-                shell: _,
-                env,
-            } => env,
-        };
-
-        utils::env_is_static(name, &[env])
+        utils::env_is_static(name, &[&self.env])
     }
 
     fn uses(&self) -> Option<&common::Uses> {
@@ -876,12 +849,10 @@ impl<'s> StepCommon<'s> for CompositeStep<'s> {
                 run,
                 working_directory,
                 shell,
-                env,
             } => StepBodyCommon::Run {
                 run,
                 _working_directory: working_directory.as_deref(),
                 _shell: Some(shell),
-                _env: env,
             },
         }
     }

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -355,12 +355,10 @@ mod tests {
                     run,
                     working_directory,
                     shell,
-                    env,
                 } => super::StepBodyCommon::Run {
                     run,
                     _working_directory: working_directory.as_deref(),
                     _shell: shell.as_deref(),
-                    _env: env,
                 },
             }
         }

--- a/crates/zizmor/tests/integration/snapshot.rs
+++ b/crates/zizmor/tests/integration/snapshot.rs
@@ -358,6 +358,14 @@ fn template_injection() -> Result<()> {
             .run()?
     );
 
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "template-injection/issue-883-repro/action.yml"
+            ))
+            .run()?
+    );
+
     Ok(())
 }
 

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-13.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-13.snap
@@ -1,0 +1,124 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"template-injection/issue-883-repro/action.yml\")).run()?"
+---
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:32:7
+   |
+32 |       - name: Create chango fragment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+33 |         id: create-chango-fragment
+...
+38 |         with:
+39 | /         script: |
+40 | |           import base64
+...  |
+92 | |             set_output("change_note_content", "")
+93 | |             set_output("change_note_path", "")
+   | |______________________________________________^ inputs.pyproject-toml may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+help[template-injection]: code injection via template expansion
+  --> @@INPUT@@:32:7
+   |
+32 |       - name: Create chango fragment
+   |         ---------------------------- help: this step
+33 |         id: create-chango-fragment
+...
+38 |         with:
+39 | /         script: |
+40 | |           import base64
+...  |
+92 | |             set_output("change_note_content", "")
+93 | |             set_output("change_note_path", "")
+   | |______________________________________________- help: env.CUSTOM_OUTPUT may expand into attacker-controllable code
+   |
+   = note: audit confidence → High
+
+help[template-injection]: code injection via template expansion
+  --> @@INPUT@@:32:7
+   |
+32 |       - name: Create chango fragment
+   |         ---------------------------- help: this step
+33 |         id: create-chango-fragment
+...
+38 |         with:
+39 | /         script: |
+40 | |           import base64
+...  |
+92 | |             set_output("change_note_content", "")
+93 | |             set_output("change_note_path", "")
+   | |______________________________________________- help: env.DEFAULT_OUTPUT may expand into attacker-controllable code
+   |
+   = note: audit confidence → High
+
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:32:7
+   |
+32 |       - name: Create chango fragment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+33 |         id: create-chango-fragment
+...
+38 |         with:
+39 | /         script: |
+40 | |           import base64
+...  |
+92 | |             set_output("change_note_content", "")
+93 | |             set_output("change_note_path", "")
+   | |______________________________________________^ inputs.data may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:32:7
+   |
+32 |       - name: Create chango fragment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+33 |         id: create-chango-fragment
+...
+38 |         with:
+39 | /         script: |
+40 | |           import base64
+...  |
+92 | |             set_output("change_note_content", "")
+93 | |             set_output("change_note_path", "")
+   | |______________________________________________^ github.event may expand into attacker-controllable code
+   |
+   = note: audit confidence → High
+
+help[template-injection]: code injection via template expansion
+   --> @@INPUT@@:95:7
+    |
+ 95 |       - name: Set Job Summary
+    |         --------------------- help: this step
+ 96 |         id: job-summary
+...
+105 |         with:
+106 | /         script: |
+107 | |           import base64
+...   |
+122 | |           set_summary(text)
+123 | |           error("Chango fragment should be updated. See the job summary for details.")
+    | |_______________________________________________________________________________________- help: env.CHANGE_NOTE_PATH may expand into attacker-controllable code
+    |
+    = note: audit confidence → High
+
+help[template-injection]: code injection via template expansion
+   --> @@INPUT@@:95:7
+    |
+ 95 |       - name: Set Job Summary
+    |         --------------------- help: this step
+ 96 |         id: job-summary
+...
+105 |         with:
+106 | /         script: |
+107 | |           import base64
+...   |
+122 | |           set_summary(text)
+123 | |           error("Chango fragment should be updated. See the job summary for details.")
+    | |_______________________________________________________________________________________- help: env.CHANGE_NOTE_CONTENT may expand into attacker-controllable code
+    |
+    = note: audit confidence → High
+
+14 findings (7 suppressed): 0 unknown, 0 informational, 4 low, 0 medium, 3 high

--- a/crates/zizmor/tests/integration/test-data/template-injection/issue-883-repro/action.yml
+++ b/crates/zizmor/tests/integration/test-data/template-injection/issue-883-repro/action.yml
@@ -1,0 +1,123 @@
+# minimized reproducer for zizmor#883
+# see: https://github.com/zizmorcore/zizmor/issues/883
+
+# minimized from: https://github.com/Bibo-Joshi/chango/blob/3b587df3226c5/action.yml
+
+# Copyright (c) 2024-present Hinrich Mahler <chango@mahlerhome.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: issue-883-repro
+description: issue 883 repro
+
+runs:
+  using: composite
+  steps:
+    - name: Create chango fragment
+      id: create-chango-fragment
+      uses: jannekem/run-python-script-action@bbfca66c612a28f3eeca0ae40e1f810265e2ea68 # v1.7
+      env:
+        CUSTOM_OUTPUT: ${{ steps.fetch-linked-issues-custom-token.outputs.data }}
+        DEFAULT_OUTPUT: ${{ steps.fetch-linked-issues-default-token.outputs.data }}
+      with:
+        script: |
+          import base64
+          import subprocess
+          import os
+          from chango.config import get_chango_instance
+          from chango.action import ChanGoActionData
+
+          os.chdir('./target-repo')
+
+          chango_instance = get_chango_instance(${{ inputs.pyproject-toml }})
+
+          null = None
+          false = False
+          true = True
+
+          # Merge additionally fetched data into the data passed by the user
+          output = (
+              ${{ toJson(env.CUSTOM_OUTPUT) }}
+              or ${{ toJson(env.DEFAULT_OUTPUT) }}
+          )
+          data = (
+              ${{ inputs.data }}
+              or ChanGoActionData.model_validate_json(output)
+          )
+
+          change_note = chango_instance.build_github_event_change_note(
+              event=${{ toJson(github.event) }},
+              data=data
+          )
+
+          should_commit = False
+          if change_note is not None:
+            path = chango_instance.write_change_note(change_note, version=None)
+
+            last_commiter = subprocess.run(
+              ["git", "log", "-1", "--format=%ce", "--", path],
+              capture_output=True,
+              text=True,
+              check=True
+            ).stdout.strip()
+
+            # Do not override manual changes
+            if last_commiter in ("github-actions[bot]", ""):
+              should_commit = True
+
+          set_output("should_commit", "true" if should_commit else "false")
+
+          if should_commit:
+            # b64 encoding avoits problems with new lines in the output
+            encoded_content = base64.b64encode(change_note.to_string().encode()).decode()
+            set_output("change_note_content", encoded_content)
+            set_output("change_note_path", path.relative_to(os.getcwd()).as_posix())
+          else:
+            set_output("change_note_content", "")
+            set_output("change_note_path", "")
+
+    - name: Set Job Summary
+      id: job-summary
+      # Run only if the commit & push step failed.
+      # We use this for PRs coming from forks. Here we can't easily push back to the PR branch or
+      # create PR reviews, so we fail the job and set the job summary
+      if: ${{ failure() && steps.create-chango-fragment.outputs.should_commit == 'true' }}
+      env:
+        CHANGE_NOTE_PATH: ${{ steps.create-chango-fragment.outputs.change_note_path }}
+        CHANGE_NOTE_CONTENT: ${{ steps.create-chango-fragment.outputs.change_note_content }}
+      uses: jannekem/run-python-script-action@bbfca66c612a28f3eeca0ae40e1f810265e2ea68 # v1.7
+      with:
+        script: |
+          import base64
+          from pathlib import Path
+
+          file_path = Path("${{ env.CHANGE_NOTE_PATH }}")
+          encoded_content = "${{ env.CHANGE_NOTE_CONTENT }}"
+          decoded_content = base64.b64decode(encoded_content).decode()
+
+          text = f"""
+          Please create a [chango](https://chango.readthedocs.io/stable/) fragment for this PR.
+          I suggest adding the following content to `{file_path}` in the repository:
+
+          ```{file_path.suffix[1:]}
+          {decoded_content}
+          ```
+          """
+          set_summary(text)
+          error("Chango fragment should be updated. See the job summary for details.")

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,12 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* The [template-injection] audit no longer crashes when attempting to
+  evaluate the static-ness of an environment context within a
+  composite action `uses:` step (#887)
+
 ## 1.9.0
 
 ### New Features 🌈


### PR DESCRIPTION
This fixes #883 by removing the `panic!` case entirely -- it's not actually needed, since `uses:` steps can contain `env:` blocks.

Fixes #883.