### PR TITLE
refactor: break YamlPatchOperation into Op and Patch

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -17,7 +17,7 @@ use crate::{
     route,
     state::AuditState,
     utils::split_patterns,
-    yaml_patch::YamlPatchOperation,
+    yaml_patch::{Op, Patch},
 };
 
 pub(crate) struct Artipacked;
@@ -61,19 +61,22 @@ impl Artipacked {
                 after checkout, which may be inadvertently leaked through subsequent actions like artifact uploads. \
                 Setting 'persist-credentials: false' ensures that credentials don't persist beyond the checkout step itself.".to_string(),
             _key: step.location().key,
-            ops: vec![
-                YamlPatchOperation::MergeInto {
+            patches: vec![
+                Patch {
                     route: route!("jobs", job_id, "steps", checkout_index),
-                    key: "with".to_string(),
-                    value: {
-                        let mut with_map = serde_yaml::Mapping::new();
-                        with_map.insert(
-                            serde_yaml::Value::String("persist-credentials".to_string()),
-                            serde_yaml::Value::Bool(false),
-                        );
-                        serde_yaml::Value::Mapping(with_map)
+                    operation: Op::MergeInto {
+
+                        key: "with".to_string(),
+                        value: {
+                            let mut with_map = serde_yaml::Mapping::new();
+                            with_map.insert(
+                                serde_yaml::Value::String("persist-credentials".to_string()),
+                                serde_yaml::Value::Bool(false),
+                            );
+                            serde_yaml::Value::Mapping(with_map)
+                        },
                     },
-                },
+                }
             ],
         }
     }

--- a/crates/zizmor/src/finding.rs
+++ b/crates/zizmor/src/finding.rs
@@ -8,7 +8,7 @@ use self::location::{Location, SymbolicLocation};
 use crate::{
     InputKey,
     models::AsDocument,
-    yaml_patch::{self, YamlPatchOperation},
+    yaml_patch::{self, Patch},
 };
 
 pub(crate) mod location;
@@ -112,13 +112,13 @@ pub(crate) struct Fix<'doc> {
     #[allow(dead_code)]
     pub(crate) description: String,
     pub(crate) _key: &'doc InputKey,
-    pub(crate) ops: Vec<YamlPatchOperation<'doc>>,
+    pub(crate) patches: Vec<Patch<'doc>>,
 }
 
 impl Fix<'_> {
     /// Apply the fix to the given file content.
     pub(crate) fn apply_to_content(&self, old_content: &str) -> anyhow::Result<Option<String>> {
-        match yaml_patch::apply_yaml_patch(old_content, &self.ops) {
+        match yaml_patch::apply_yaml_patch(old_content, &self.patches) {
             Ok(new_content) => Ok(Some(new_content)),
             Err(e) => Err(anyhow!("YAML path failed: {e}")),
         }


### PR DESCRIPTION
The thinking behind this is to simplify/reduce the dev churn when adding new patch operations -- the `Patch` now contains the route and surrounds an underlying `Op`.