### PR TITLE
feat: improve bot-conditions checks

### DIFF
--- a/crates/github-actions-expressions/src/lib.rs
+++ b/crates/github-actions-expressions/src/lib.rs
@@ -834,6 +834,18 @@ mod tests {
                     ],
                 ),
             ),
+            (
+                "github.actor_id == '49699333'",
+                Expr::BinOp {
+                    lhs: Expr::context(
+                        "github.actor_id",
+                        [Expr::ident("github"), Expr::ident("actor_id")],
+                    )
+                    .into(),
+                    op: BinOp::Eq,
+                    rhs: Box::new("49699333".into()),
+                },
+            ),
         ];
 
         for (case, expr) in cases {

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use github_actions_expressions::{
-    BinOp, Expr, Literal, UnOp,
+    BinOp, Expr, UnOp,
     context::{Context, ContextPattern},
 };
 use github_actions_models::common::{If, expr::ExplicitExpr};
@@ -34,14 +34,17 @@ static SPOOFABLE_ACTOR_ID_CONTEXTS: LazyLock<Vec<ContextPattern>> = LazyLock::ne
 // A list of known bot actor IDs; we need to hardcode these because they
 // have no equivalent `[bot]' suffix check.
 //
+// Stored as strings because every equality is stringly-typed
+// in GHA expressions anyways.
+//
 // NOTE: This list also contains non-user IDs like integration IDs.
 // The thinking there is that users will sometimes confuse the two,
 // so we should flag them as well.
-const BOT_ACTOR_IDS: &[u32] = &[
-    29110,    //dependabot[bot]'s integration ID
-    49699333, // dependabot[bot]
-    27856297, // dependabot-preview[bot]
-    29139614, // renovate[bot]
+const BOT_ACTOR_IDS: &[&str] = &[
+    "29110",    //dependabot[bot]'s integration ID
+    "49699333", // dependabot[bot]
+    "27856297", // dependabot-preview[bot]
+    "29139614", // renovate[bot]
 ];
 
 impl Audit for BotConditions {
@@ -67,26 +70,31 @@ impl Audit for BotConditions {
 
         let mut conds = vec![];
         if let Some(If::Expr(expr)) = &job.r#if {
-            conds.push((expr, job.location()));
+            conds.push((
+                expr,
+                job.location_with_name(),
+                job.location().with_keys(&["if".into()]),
+            ));
         }
 
         for step in job.steps() {
             if let Some(If::Expr(expr)) = &step.r#if {
-                conds.push((expr, step.location()));
+                conds.push((
+                    expr,
+                    step.location_with_name(),
+                    step.location().with_keys(&["if".into()]),
+                ));
             }
         }
 
-        for (expr, loc) in conds {
+        for (expr, parent, if_loc) in conds {
             if let Some(confidence) = Self::bot_condition(expr) {
                 findings.push(
                     Self::finding()
                         .severity(Severity::High)
                         .confidence(confidence)
-                        .add_location(
-                            loc.with_keys(&["if".into()])
-                                .primary()
-                                .annotated("actor context may be spoofable"),
-                        )
+                        .add_location(parent)
+                        .add_location(if_loc.primary().annotated("actor context may be spoofable"))
                         .build(job.parent())?,
                 );
             }
@@ -102,6 +110,7 @@ impl BotConditions {
             // We can't easily analyze the call's semantics, but we can
             // check to see if any of the call's arguments are
             // bot conditions. We treat a call as non-dominating always.
+            // TODO: Should probably check some variant of `contains` here.
             Expr::Call {
                 func: _,
                 args: exprs,
@@ -122,11 +131,14 @@ impl BotConditions {
                 }
                 // == is trivially dominating.
                 BinOp::Eq => match (lhs.as_ref(), rhs.as_ref()) {
-                    (Expr::Context(ctx), Expr::Literal(Literal::String(s)))
-                    | (Expr::Literal(Literal::String(s)), Expr::Context(ctx)) => {
-                        // NOTE: Can't use `contains` here because we our matching API.
+                    (Expr::Context(ctx), Expr::Literal(lit))
+                    | (Expr::Literal(lit), Expr::Context(ctx)) => {
                         if SPOOFABLE_ACTOR_NAME_CONTEXTS.iter().any(|x| x.matches(ctx))
-                            && s.ends_with("[bot]")
+                            && lit.as_str().ends_with("[bot]")
+                        {
+                            (true, true)
+                        } else if SPOOFABLE_ACTOR_ID_CONTEXTS.iter().any(|x| x.matches(ctx))
+                            && BOT_ACTOR_IDS.contains(&lit.as_str().as_ref())
                         {
                             (true, true)
                         } else {

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -133,12 +133,10 @@ impl BotConditions {
                 BinOp::Eq => match (lhs.as_ref(), rhs.as_ref()) {
                     (Expr::Context(ctx), Expr::Literal(lit))
                     | (Expr::Literal(lit), Expr::Context(ctx)) => {
-                        if SPOOFABLE_ACTOR_NAME_CONTEXTS.iter().any(|x| x.matches(ctx))
-                            && lit.as_str().ends_with("[bot]")
-                        {
-                            (true, true)
-                        } else if SPOOFABLE_ACTOR_ID_CONTEXTS.iter().any(|x| x.matches(ctx))
-                            && BOT_ACTOR_IDS.contains(&lit.as_str().as_ref())
+                        if (SPOOFABLE_ACTOR_NAME_CONTEXTS.iter().any(|x| x.matches(ctx))
+                            && lit.as_str().ends_with("[bot]"))
+                            || (SPOOFABLE_ACTOR_ID_CONTEXTS.iter().any(|x| x.matches(ctx))
+                                && BOT_ACTOR_IDS.contains(&lit.as_str().as_ref()))
                         {
                             (true, true)
                         } else {

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -145,32 +145,48 @@ error[dangerous-triggers]: use of fundamentally insecure workflow trigger
    = note: audit confidence → Medium
 
 error[bot-conditions]: spoofable bot actor check
-  --> .github/workflows/bot-conditions.yml:18:5
+  --> .github/workflows/bot-conditions.yml:16:3
    |
-18 |     if: github.actor == 'dependabot[bot]'
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+16 | /   hackme:
+17 | |     runs-on: ubuntu-latest
+18 | |     if: github.actor == 'dependabot[bot]'
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+19 | |     steps:
+...  |
+33 | |         run: echo hello
+34 | |         if: github.actor == 'notabot'
+   | |______________________________________^ this job
    |
    = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> .github/workflows/bot-conditions.yml:22:9
+  --> .github/workflows/bot-conditions.yml:20:9
    |
+20 |       - name: vulnerable-1
+   |         ^^^^^^^^^^^^^^^^^^ this step
+21 |         run: echo hello
 22 |         if: ${{ github.actor == 'dependabot[bot]' }}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> .github/workflows/bot-conditions.yml:26:9
+  --> .github/workflows/bot-conditions.yml:24:9
    |
+24 |       - name: vulnerable-2
+   |         ^^^^^^^^^^^^^^^^^^ this step
+25 |         run: echo hello
 26 |         if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'example/example' }}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → Medium
 
 error[bot-conditions]: spoofable bot actor check
-  --> .github/workflows/bot-conditions.yml:30:9
+  --> .github/workflows/bot-conditions.yml:28:9
    |
+28 |       - name: vulnerable-3
+   |         ^^^^^^^^^^^^^^^^^^ this step
+29 |         run: echo hello
 30 |         if: github.actor == 'renovate[bot]'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
@@ -11,59 +11,134 @@ error[dangerous-triggers]: use of fundamentally insecure workflow trigger
   = note: audit confidence → Medium
 
 error[bot-conditions]: spoofable bot actor check
- --> @@INPUT@@:8:5
-  |
-8 |     if: github.actor == 'dependabot[bot]'
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
-  |
-  = note: audit confidence → High
+  --> @@INPUT@@:6:3
+   |
+ 6 | /   hackme:
+ 7 | |     name: hackme
+ 8 | |     runs-on: ubuntu-latest
+ 9 | |     if: github.actor == 'dependabot[bot]'
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+10 | |     steps:
+...  |
+57 | |         run: echo hello
+58 | |         if: ${{ github.actor_id == '49699333' }}
+   | |_________________________________________________^ this job
+   |
+   = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:12:9
+  --> @@INPUT@@:11:9
    |
-12 |         if: ${{ github.actor == 'dependabot[bot]' }}
+11 |       - name: vulnerable-1
+   |         ^^^^^^^^^^^^^^^^^^ this step
+12 |         run: echo hello
+13 |         if: ${{ github.actor == 'dependabot[bot]' }}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:16:9
+  --> @@INPUT@@:15:9
    |
-16 |         if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'example/example' }}
+15 |       - name: vulnerable-2
+   |         ^^^^^^^^^^^^^^^^^^ this step
+16 |         run: echo hello
+17 |         if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'example/example' }}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → Medium
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:20:9
+  --> @@INPUT@@:19:9
    |
-20 |         if: github.actor == 'renovate[bot]'
+19 |       - name: vulnerable-3
+   |         ^^^^^^^^^^^^^^^^^^ this step
+20 |         run: echo hello
+21 |         if: github.actor == 'renovate[bot]'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:29:9
+  --> @@INPUT@@:27:9
    |
-29 |         if: github.ACTOR == 'dependabot[bot]'
+27 |       - name: vulnerable-5
+   |         ^^^^^^^^^^^^^^^^^^ this step
+28 |         run: echo hello
+29 |         # ensure we're case insensitive
+30 |         if: github.ACTOR == 'dependabot[bot]'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:34:9
+  --> @@INPUT@@:32:9
    |
-34 |         if: github.actor == 'mystery[bot]'
+32 |       - name: vulnerable-6
+   |         ^^^^^^^^^^^^^^^^^^ this step
+33 |         run: echo hello
+34 |         # ensure we detect unknown bots
+35 |         if: github.actor == 'mystery[bot]'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:39:9
+  --> @@INPUT@@:37:9
    |
-39 |         if: github['actor'] == 'dependabot[bot]'
+37 |       - name: vulnerable-7
+   |         ^^^^^^^^^^^^^^^^^^ this step
+38 |         run: echo hello
+39 |         # ensure we handle index-style contexts
+40 |         if: github['actor'] == 'dependabot[bot]'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
    |
    = note: audit confidence → High
 
-8 findings: 0 unknown, 0 informational, 0 low, 0 medium, 8 high
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:42:9
+   |
+42 |       - name: vulnerable-8
+   |         ^^^^^^^^^^^^^^^^^^ this step
+43 |         run: echo hello
+44 |         # ensure we handle index-style contexts with a different case
+45 |         if: github['ACTOR'] == 'dependabot[bot]'
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:47:9
+   |
+47 |       - name: vulnerable-9
+   |         ^^^^^^^^^^^^^^^^^^ this step
+48 |         run: echo hello
+49 |         # ensure we handle actor ID checks
+50 |         if: github.actor_id == 49699333
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:52:9
+   |
+52 |       - name: vulnerable-10
+   |         ^^^^^^^^^^^^^^^^^^^ this step
+53 |         run: echo hello
+54 |         if: github['ACTOR_ID'] == 49699333
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:56:9
+   |
+56 |       - name: vulnerable-11
+   |         ^^^^^^^^^^^^^^^^^^^ this step
+57 |         run: echo hello
+58 |         if: ${{ github.actor_id == '49699333' }}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+12 findings: 0 unknown, 0 informational, 0 low, 0 medium, 12 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
@@ -11,20 +11,15 @@ error[dangerous-triggers]: use of fundamentally insecure workflow trigger
   = note: audit confidence → Medium
 
 error[bot-conditions]: spoofable bot actor check
-  --> @@INPUT@@:6:3
-   |
- 6 | /   hackme:
- 7 | |     name: hackme
- 8 | |     runs-on: ubuntu-latest
- 9 | |     if: github.actor == 'dependabot[bot]'
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
-10 | |     steps:
-...  |
-57 | |         run: echo hello
-58 | |         if: ${{ github.actor_id == '49699333' }}
-   | |_________________________________________________^ this job
-   |
-   = note: audit confidence → High
+ --> @@INPUT@@:7:5
+  |
+7 |     name: hackme
+  |     ^^^^^^^^^^^^ this job
+8 |     runs-on: ubuntu-latest
+9 |     if: github.actor == 'dependabot[bot]'
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+  |
+  = note: audit confidence → High
 
 error[bot-conditions]: spoofable bot actor check
   --> @@INPUT@@:11:9

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"bot-conditions.yml\")).run()?"
 ---
 error[dangerous-triggers]: use of fundamentally insecure workflow trigger
@@ -42,4 +42,28 @@ error[bot-conditions]: spoofable bot actor check
    |
    = note: audit confidence → High
 
-5 findings: 0 unknown, 0 informational, 0 low, 0 medium, 5 high
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:29:9
+   |
+29 |         if: github.ACTOR == 'dependabot[bot]'
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:34:9
+   |
+34 |         if: github.actor == 'mystery[bot]'
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:39:9
+   |
+39 |         if: github['actor'] == 'dependabot[bot]'
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actor context may be spoofable
+   |
+   = note: audit confidence → High
+
+8 findings: 0 unknown, 0 informational, 0 low, 0 medium, 8 high

--- a/crates/zizmor/tests/integration/test-data/bot-conditions.yml
+++ b/crates/zizmor/tests/integration/test-data/bot-conditions.yml
@@ -22,3 +22,18 @@ jobs:
       - name: not-vulnerable-4
         run: echo hello
         if: github.actor == 'notabot'
+
+      - name: vulnerable-5
+        run: echo hello
+        # ensure we're case insensitive
+        if: github.ACTOR == 'dependabot[bot]'
+
+      - name: vulnerable-6
+        run: echo hello
+        # ensure we detect unknown bots
+        if: github.actor == 'mystery[bot]'
+
+      - name: vulnerable-7
+        run: echo hello
+        # ensure we handle index-style contexts
+        if: github['actor'] == 'dependabot[bot]'

--- a/crates/zizmor/tests/integration/test-data/bot-conditions.yml
+++ b/crates/zizmor/tests/integration/test-data/bot-conditions.yml
@@ -4,6 +4,7 @@ permissions: {}
 
 jobs:
   hackme:
+    name: hackme
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
@@ -37,3 +38,21 @@ jobs:
         run: echo hello
         # ensure we handle index-style contexts
         if: github['actor'] == 'dependabot[bot]'
+
+      - name: vulnerable-8
+        run: echo hello
+        # ensure we handle index-style contexts with a different case
+        if: github['ACTOR'] == 'dependabot[bot]'
+
+      - name: vulnerable-9
+        run: echo hello
+        # ensure we handle actor ID checks
+        if: github.actor_id == 49699333
+
+      - name: vulnerable-10
+        run: echo hello
+        if: github['ACTOR_ID'] == 49699333
+
+      - name: vulnerable-11
+        run: echo hello
+        if: ${{ github.actor_id == '49699333' }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,12 +15,16 @@ of `zizmor`.
   rather than just workflow definitions (#896)
 * The [use-trusted-publishing] audit now produces findings on composite
   action definitions, rather than just workflow definitions (#899)
+* The [bot-conditions] audit now detects more spoofable actor checks,
+  including checks against well-known user IDs for bot accounts (#905)
 
 ### Bug Fixes 🐛
 
 * The [template-injection] audit no longer crashes when attempting to
   evaluate the static-ness of an environment context within a
   composite action `uses:` step (#887)
+* The [bot-conditions] audit now correctly analyzes index-style contexts,
+  e.g. `github['actor']` (#905)
 
 ## 1.9.0
 


### PR DESCRIPTION
~~WIP.~~

https://boostsecurity.io/blog/weaponizing-dependabot-pwn-request-at-its-finest made me realize that there were a couple of contexts we weren't checking for properly. 

Separately, this also switches `bot-conditions` to use our context pattern APIs (so that we handle more varieties of contexts, like index-style contexts) and begins the work to ensure we handle numeric actor ID checks as well.