### PR TITLE
refactor: move literals to Expr::Literal

### DIFF
--- a/crates/github-actions-expressions/src/context.rs
+++ b/crates/github-actions-expressions/src/context.rs
@@ -1,6 +1,8 @@
 //! Parsing and matching APIs for GitHub Actions expressions
 //! contexts (e.g. `github.event.name`).
 
+use crate::Literal;
+
 use super::Expr;
 
 /// Represents a context in a GitHub Actions expression.
@@ -64,7 +66,7 @@ impl<'src> Context<'src> {
                 Expr::Star => pattern.push('*'),
                 Expr::Index(idx) => match idx.as_ref() {
                     // foo['bar'] -> foo.bar
-                    Expr::String(idx) => pattern.push_str(idx),
+                    Expr::Literal(Literal::String(idx)) => pattern.push_str(idx),
                     // any kind of numeric or computed index, e.g.:
                     // foo[0], foo[1 + 2], foo[bar]
                     _ => pattern.push('*'),
@@ -176,7 +178,7 @@ impl<'src> ContextPattern<'src> {
             match part {
                 Expr::Identifier(part) => pattern.eq_ignore_ascii_case(part.0),
                 Expr::Index(part) => match part.as_ref() {
-                    Expr::String(part) => pattern.eq_ignore_ascii_case(part),
+                    Expr::Literal(Literal::String(part)) => pattern.eq_ignore_ascii_case(part),
                     _ => false,
                 },
                 _ => false,

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -1,4 +1,4 @@
-use github_actions_expressions::{BinOp, Expr, UnOp, context::Context};
+use github_actions_expressions::{BinOp, Expr, Literal, UnOp, context::Context};
 use github_actions_models::common::{If, expr::ExplicitExpr};
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
@@ -91,8 +91,8 @@ impl BotConditions {
                 }
                 // == is trivially dominating.
                 BinOp::Eq => match (lhs.as_ref(), rhs.as_ref()) {
-                    (Expr::Context(ctx), Expr::String(s))
-                    | (Expr::String(s), Expr::Context(ctx)) => {
+                    (Expr::Context(ctx), Expr::Literal(Literal::String(s)))
+                    | (Expr::Literal(Literal::String(s)), Expr::Context(ctx)) => {
                         // NOTE: Can't use `contains` here because we need
                         // Context's `PartialEq` for case insensitive matching.
                         if SPOOFABLE_ACTOR_CONTEXTS.iter().any(|x| ctx == *x)

--- a/crates/zizmor/src/audit/overprovisioned_secrets.rs
+++ b/crates/zizmor/src/audit/overprovisioned_secrets.rs
@@ -84,9 +84,9 @@ impl OverprovisionedSecrets {
             Expr::Context(ctx) => {
                 match (ctx.parts.first(), ctx.parts.get(1)) {
                     // Look for `secrets[...]` accesses where the index component
-                    // is not a string literal.
+                    // is not a literal.
                     (Some(Expr::Identifier(ident)), Some(Expr::Index(idx)))
-                        if ident == "secrets" && !matches!(idx.as_ref(), Expr::String(_)) =>
+                        if ident == "secrets" && !matches!(idx.as_ref(), Expr::Literal(_)) =>
                     {
                         results.push(())
                     }

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -18,7 +18,7 @@
 use std::{collections::HashMap, env, sync::LazyLock};
 
 use fst::Map;
-use github_actions_expressions::{Expr, context::Context};
+use github_actions_expressions::{Expr, Literal, context::Context};
 use github_actions_models::{
     common::{
         RepositoryUses, Uses,
@@ -168,8 +168,10 @@ impl TemplateInjection {
                         // The right thing to do here is to parse these literals
                         // and refuse to convert them if we can't make them
                         // into valid identifiers.
-                        Expr::String(lit) => env_parts.push(lit.replace('-', "_")),
-                        Expr::Number(idx) => {
+                        Expr::Literal(Literal::String(lit)) => {
+                            env_parts.push(lit.replace('-', "_"))
+                        }
+                        Expr::Literal(Literal::Number(idx)) => {
                             let name = match *idx as i64 {
                                 0 => "FIRST".into(),
                                 1 => "SECOND".into(),

--- a/crates/zizmor/src/audit/unsound_contains.rs
+++ b/crates/zizmor/src/audit/unsound_contains.rs
@@ -1,4 +1,4 @@
-use github_actions_expressions::{Expr, context::Context};
+use github_actions_expressions::{Expr, Literal, context::Context};
 use github_actions_models::common::{If, expr::ExplicitExpr};
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
@@ -81,7 +81,9 @@ impl UnsoundContains {
     ) -> Box<dyn Iterator<Item = (&'a str, &'a Context<'a>)> + 'a> {
         match expr {
             Expr::Call { func, args: exprs } if func == "contains" => match exprs.as_slice() {
-                [Expr::String(s), Expr::Context(c)] => Box::new(std::iter::once((s.as_str(), c))),
+                [Expr::Literal(Literal::String(s)), Expr::Context(c)] => {
+                    Box::new(std::iter::once((s.as_ref(), c)))
+                }
                 args => Box::new(args.iter().flat_map(Self::walk_tree_for_unsound_contains)),
             },
             Expr::Call {


### PR DESCRIPTION
This makes it easier to work with literals in expressions, since literals are typically stringified as part of comparisons, etc.

It also adds a small optimization where we avoid a clone when parsing string literals that don't need to be unescaped.