### PR TITLE
bugfix: put longer comp_op variants ahead

### DIFF
--- a/crates/github-actions-expressions/src/expr.pest
+++ b/crates/github-actions-expressions/src/expr.pest
@@ -33,7 +33,7 @@ comp_expr = {
     unary_expr ~ (comp_op ~ unary_expr)*
   | ("(" ~ or_expr ~ ")")
 }
-comp_op   = { ">" | ">=" | "<" | "<=" }
+comp_op   = { ">=" | ">" | "<=" | "<" }
 
 /// Unary operations, including the base case for expressions.
 // HACK: `unary_op ~ or_expr` ensures that we handle non-trivial

--- a/crates/github-actions-expressions/src/lib.rs
+++ b/crates/github-actions-expressions/src/lib.rs
@@ -677,6 +677,10 @@ mod tests {
             "github[format('{0}', 'event')]",
             "github['event']['inputs'][github.event.inputs.magic]",
             "github['event']['inputs'].*",
+            "1 == 1",
+            "1 > 1",
+            "1 >= 1",
+            "matrix.node_version >= 20",
         ];
 
         for case in cases {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,8 @@ of `zizmor`.
   composite action `uses:` step (#887)
 * The [bot-conditions] audit now correctly analyzes index-style contexts,
   e.g. `github['actor']` (#905)
+* Fixed a bug where `zizmor` would fail to parse expressions that
+  contained `>=` or `<=` (#916)
 
 ## 1.9.0
 


### PR DESCRIPTION
This prevents us from accidentally matching
shorter variants first, leading to parse errors.

Fixes #912.