### PR TITLE
feat: model input capabilities in workflows and actions

### DIFF
--- a/crates/github-actions-models/src/workflow/event.rs
+++ b/crates/github-actions-models/src/workflow/event.rs
@@ -249,7 +249,16 @@ pub struct WorkflowCallInput {
     // TODO: model `default`?
     #[serde(default)]
     pub required: bool,
-    pub r#type: String,
+    pub r#type: WorkflowCallInputType,
+}
+
+/// The type of a `workflow_call` input, as specified in the `type` field.
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkflowCallInputType {
+    Boolean,
+    Number,
+    String,
 }
 
 /// A single output in a `workflow_call` event trigger body.
@@ -274,7 +283,7 @@ pub struct WorkflowCallSecret {
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowDispatch {
     #[serde(default)]
-    pub inputs: IndexMap<String, WorkflowDispatchInput>, // TODO: WorkflowDispatchInput
+    pub inputs: IndexMap<String, WorkflowDispatchInput>,
 }
 
 /// A single input in a `workflow_dispatch` event trigger body.
@@ -285,11 +294,23 @@ pub struct WorkflowDispatchInput {
     // TODO: model `default`?
     #[serde(default)]
     pub required: bool,
-    // TODO: Model as boolean, choice, number, environment, string; default is string.
-    pub r#type: Option<String>,
+    /// The type of this `workflow_dispatch` input.
+    #[serde(default)]
+    pub r#type: WorkflowDispatchInputType,
     // Only present when `type` is `choice`.
     #[serde(default)]
     pub options: Vec<EnvValue>,
+}
+
+#[derive(Default, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkflowDispatchInputType {
+    Boolean,
+    Choice,
+    Environment,
+    Number,
+    #[default]
+    String,
 }
 
 /// The body of a `workflow_run` event trigger.

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -35,7 +35,8 @@ use crate::{
         location::{Routable as _, SymbolicLocation},
     },
     models::{
-        self, StepCommon, action::CompositeStep, uses::RepositoryUsesPattern, workflow::Step,
+        self, StepCommon, action::CompositeStep, inputs::Capability, uses::RepositoryUsesPattern,
+        workflow::Step,
     },
     state::AuditState,
     utils::{DEFAULT_ENVIRONMENT_VARIABLES, extract_expressions},
@@ -74,12 +75,6 @@ static CONTEXT_CAPABILITIES_FST: LazyLock<Map<&[u8]>> = LazyLock::new(|| {
     fst::Map::new(include_bytes!(concat!(env!("OUT_DIR"), "/context-capabilities.fst")).as_slice())
         .expect("couldn't initialize context capabilities FST")
 });
-
-enum Capability {
-    Arbitrary,
-    Structured,
-    Fixed,
-}
 
 impl Capability {
     fn from_context(context: &str) -> Option<Self> {

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -7,6 +7,7 @@ use github_actions_models::common::Env;
 use github_actions_models::workflow::job::Strategy;
 
 use crate::finding::location::Locatable;
+use crate::models::inputs::HasInputs;
 
 pub(crate) mod action;
 pub(crate) mod coordinate;
@@ -32,7 +33,7 @@ pub(crate) enum StepBodyCommon<'s> {
 }
 
 /// Common interfaces between workflow and action steps.
-pub(crate) trait StepCommon<'doc>: Locatable<'doc> {
+pub(crate) trait StepCommon<'doc>: Locatable<'doc> + HasInputs {
     /// Returns the step's index within its parent job or action.
     fn index(&self) -> usize;
 

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -10,6 +10,7 @@ use crate::finding::location::Locatable;
 
 pub(crate) mod action;
 pub(crate) mod coordinate;
+pub(crate) mod inputs;
 pub(crate) mod uses;
 pub(crate) mod workflow;
 

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -56,10 +56,7 @@ impl std::fmt::Debug for Action {
 impl HasInputs for Action {
     fn get_input(&self, name: &str) -> Option<Capability> {
         // Action inputs are always arbitrary strings.
-        match self.inputs.get(name) {
-            Some(_) => Some(Capability::Arbitrary),
-            None => None,
-        }
+        self.inputs.get(name).map(|_| Capability::Arbitrary)
     }
 }
 

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -12,7 +12,10 @@ use terminal_link::Link;
 use crate::{
     InputKey,
     finding::location::{Locatable, Route, SymbolicLocation},
-    models::{AsDocument, StepBodyCommon, StepCommon},
+    models::{
+        AsDocument, StepBodyCommon, StepCommon,
+        inputs::{Capability, HasInputs},
+    },
     registry::InputError,
     utils::{self, ACTION_VALIDATOR, from_str_with_validation},
 };
@@ -47,6 +50,16 @@ impl std::ops::Deref for Action {
 impl std::fmt::Debug for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{key}", key = self.key)
+    }
+}
+
+impl HasInputs for Action {
+    fn get_input(&self, name: &str) -> Option<Capability> {
+        // Action inputs are always arbitrary strings.
+        match self.inputs.get(name) {
+            Some(_) => Some(Capability::Arbitrary),
+            None => None,
+        }
     }
 }
 

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -178,6 +178,12 @@ impl<'doc> Locatable<'doc> for CompositeStep<'doc> {
     }
 }
 
+impl HasInputs for CompositeStep<'_> {
+    fn get_input(&self, name: &str) -> Option<Capability> {
+        self.parent.get_input(name)
+    }
+}
+
 impl<'doc> StepCommon<'doc> for CompositeStep<'doc> {
     fn index(&self) -> usize {
         self.index

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -332,6 +332,7 @@ mod tests {
         finding::location::{Locatable, SymbolicLocation},
         models::{
             coordinate::{ControlExpr, ControlFieldType, Toggle, Usage},
+            inputs::HasInputs,
             uses::RepositoryUsesPattern,
         },
     };
@@ -343,6 +344,12 @@ mod tests {
         }
 
         fn location_with_name(&self) -> crate::finding::location::SymbolicLocation<'doc> {
+            unreachable!()
+        }
+    }
+
+    impl HasInputs for Step {
+        fn get_input(&self, _name: &str) -> Option<crate::models::inputs::Capability> {
             unreachable!()
         }
     }

--- a/crates/zizmor/src/models/inputs.rs
+++ b/crates/zizmor/src/models/inputs.rs
@@ -1,0 +1,40 @@
+//! Common interfaces for modeling inputs across both workflows and actions.
+
+/// Represents the "capability" of an (input) value, i.e. how it expands.
+///
+/// This is shared by both inputs and contexts more generally, the latter
+/// in the setting of the `template-injection` audit.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum Capability {
+    /// The value's expansion is fully arbitrary, e.g. arbitrary code.
+    Arbitrary,
+    /// The value's expansion is structured, i.e. partially controlled
+    /// by the user, but fully controlled.
+    ///
+    /// An example of a structured value would be one with a fixed prefix:
+    /// the value might be `prefix-${{ foo }}`, where the user can control
+    /// the `${{ foo }}` part, but not the `prefix-` part.
+    Structured,
+    /// The value's expansion is fully fixed, i.e. not controlled by the user.
+    ///
+    /// The user might control the *choice* of the value, but not its
+    /// contents. For example, a choice-style input has multiple chooseable
+    /// values, but the user cannot control the contents of those values.
+    Fixed,
+}
+
+impl Capability {
+    /// Unify two capabilities in favor of the more permissive one.
+    pub(crate) fn unify(self, other: Self) -> Self {
+        match (self, other) {
+            (Capability::Arbitrary, _) | (_, Capability::Arbitrary) => Capability::Arbitrary,
+            (Capability::Structured, _) | (_, Capability::Structured) => Capability::Structured,
+            _ => self,
+        }
+    }
+}
+
+/// A trait for types that have inputs, such as workflows and actions.
+pub(crate) trait HasInputs {
+    fn get_input(&self, name: &str) -> Option<Capability>;
+}

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -22,7 +22,10 @@ use terminal_link::Link;
 use crate::{
     InputKey,
     finding::location::{Locatable, Route, SymbolicLocation},
-    models::{AsDocument, StepBodyCommon, StepCommon},
+    models::{
+        AsDocument, StepBodyCommon, StepCommon,
+        inputs::{Capability, HasInputs},
+    },
     registry::InputError,
     utils::{self, WORKFLOW_VALIDATOR, extract_expressions, from_str_with_validation},
 };
@@ -58,6 +61,58 @@ impl std::ops::Deref for Workflow {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl HasInputs for workflow::event::WorkflowCall {
+    fn get_input(&self, name: &str) -> Option<Capability> {
+        let input = self.inputs.get(name)?;
+
+        Some(match input.r#type {
+            workflow::event::WorkflowCallInputType::Boolean => Capability::Fixed,
+            workflow::event::WorkflowCallInputType::Number => Capability::Fixed,
+            workflow::event::WorkflowCallInputType::String => Capability::Arbitrary,
+        })
+    }
+}
+
+impl HasInputs for workflow::event::WorkflowDispatch {
+    fn get_input(&self, name: &str) -> Option<Capability> {
+        let input = self.inputs.get(name)?;
+
+        Some(match input.r#type {
+            workflow::event::WorkflowDispatchInputType::Boolean => Capability::Fixed,
+            workflow::event::WorkflowDispatchInputType::Choice => Capability::Fixed,
+            workflow::event::WorkflowDispatchInputType::Environment => Capability::Fixed,
+            workflow::event::WorkflowDispatchInputType::Number => Capability::Fixed,
+            workflow::event::WorkflowDispatchInputType::String => Capability::Arbitrary,
+        })
+    }
+}
+
+impl HasInputs for Workflow {
+    fn get_input(&self, name: &str) -> Option<Capability> {
+        let workflow::Trigger::Events(events) = &self.on else {
+            return None;
+        };
+
+        let wc_cap = {
+            let workflow::event::OptionalBody::Body(wc) = &events.workflow_call else {
+                return None;
+            };
+
+            wc.get_input(name)?
+        };
+
+        let wd_cap = {
+            let workflow::event::OptionalBody::Body(wd) = &events.workflow_dispatch else {
+                return None;
+            };
+
+            wd.get_input(name)?
+        };
+
+        Some(wc_cap.unify(wd_cap))
     }
 }
 
@@ -659,5 +714,59 @@ impl<'doc> Iterator for Steps<'doc> {
             Some((idx, step)) => Some(Step::new(idx, step, self.parent.clone())),
             None => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::{
+        inputs::{Capability, HasInputs as _},
+        workflow::Workflow,
+    };
+
+    #[test]
+    fn test_workflow_has_inputs() -> anyhow::Result<()> {
+        let workflow = r#"
+name: Test Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      foo:
+        type: string
+        required: true
+      bar:
+        type: boolean
+        required: false
+  workflow_call:
+    inputs:
+      foo:
+        type: number
+        required: true
+      bar:
+        type: boolean
+        required: false
+
+jobs:
+  test_job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+"#;
+
+        let workflow =
+            Workflow::from_string(workflow.into(), crate::InputKey::local("dummy", None)?)?;
+
+        // `foo` unifies in favor of the more permissive capability,
+        // which is `Capability::Arbitrary` from the `string` input type
+        // under `workflow_dispatch`.
+        let foo_cap = workflow.get_input("foo").unwrap();
+        assert_eq!(foo_cap, Capability::Arbitrary);
+
+        // `bar` unifies to `Capability::Fixed` since both
+        // `workflow_dispatch` and `workflow_call` define it as a boolean.
+        let bar_cap = workflow.get_input("bar").unwrap();
+        assert_eq!(bar_cap, Capability::Fixed);
+
+        Ok(())
     }
 }

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -881,7 +881,7 @@ error[template-injection]: code injection via template expansion
 53 | |           echo "doing a thing: ${{ inputs.hackme }}"
    | |____________________________________________________^ inputs.hackme may expand into attacker-controllable code
    |
-   = note: audit confidence → Low
+   = note: audit confidence → High
 
 error[template-injection]: code injection via template expansion
   --> .github/workflows/template-injection.yml:60:9
@@ -893,7 +893,7 @@ error[template-injection]: code injection via template expansion
 63 | |           echo "doing a thing: ${{ inputs.hackme-call }}"
    | |_________________________________________________________^ inputs.hackme-call may expand into attacker-controllable code
    |
-   = note: audit confidence → Low
+   = note: audit confidence → High
 
 warning[template-injection]: code injection via template expansion
   --> .github/workflows/template-injection.yml:82:9

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-13.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-13.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/issue-883-repro/action.yml\")).run()?"
+snapshot_kind: text
 ---
-error[template-injection]: code injection via template expansion
+note[template-injection]: code injection via template expansion
   --> @@INPUT@@:32:7
    |
 32 |       - name: Create chango fragment
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+   |         ---------------------------- note: this step
 33 |         id: create-chango-fragment
 ...
 38 |         with:
@@ -15,7 +16,7 @@ error[template-injection]: code injection via template expansion
 ...  |
 92 | |             set_output("change_note_content", "")
 93 | |             set_output("change_note_path", "")
-   | |______________________________________________^ inputs.pyproject-toml may expand into attacker-controllable code
+   | |______________________________________________- note: inputs.pyproject-toml may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
@@ -53,11 +54,11 @@ help[template-injection]: code injection via template expansion
    |
    = note: audit confidence → High
 
-error[template-injection]: code injection via template expansion
+note[template-injection]: code injection via template expansion
   --> @@INPUT@@:32:7
    |
 32 |       - name: Create chango fragment
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+   |         ---------------------------- note: this step
 33 |         id: create-chango-fragment
 ...
 38 |         with:
@@ -66,7 +67,7 @@ error[template-injection]: code injection via template expansion
 ...  |
 92 | |             set_output("change_note_content", "")
 93 | |             set_output("change_note_path", "")
-   | |______________________________________________^ inputs.data may expand into attacker-controllable code
+   | |______________________________________________- note: inputs.data may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 
@@ -121,4 +122,4 @@ help[template-injection]: code injection via template expansion
     |
     = note: audit confidence → High
 
-14 findings (7 suppressed): 0 unknown, 0 informational, 4 low, 0 medium, 3 high
+14 findings (7 suppressed): 2 unknown, 0 informational, 4 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-8.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__template_injection-8.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/pr-425-backstop/action.yml\")).run()?"
+snapshot_kind: text
 ---
 error[template-injection]: code injection via template expansion
   --> @@INPUT@@:12:7
@@ -11,7 +12,7 @@ error[template-injection]: code injection via template expansion
 14 | |         hello ${{ inputs.expandme }}
    | |____________________________________^ inputs.expandme may expand into attacker-controllable code
    |
-   = note: audit confidence → Low
+   = note: audit confidence → High
 
 error[template-injection]: code injection via template expansion
   --> @@INPUT@@:17:7
@@ -23,7 +24,7 @@ error[template-injection]: code injection via template expansion
 20 |         script: return "${{ inputs.expandme }}"
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.expandme may expand into attacker-controllable code
    |
-   = note: audit confidence → Low
+   = note: audit confidence → High
 
 error[template-injection]: code injection via template expansion
   --> @@INPUT@@:22:7
@@ -36,7 +37,7 @@ error[template-injection]: code injection via template expansion
 26 | |           echo "hello ${{ inputs.expandme }}"
    | |_____________________________________________^ inputs.expandme may expand into attacker-controllable code
    |
-   = note: audit confidence → Low
+   = note: audit confidence → High
 
 error[template-injection]: code injection via template expansion
   --> @@INPUT@@:28:7
@@ -48,7 +49,7 @@ error[template-injection]: code injection via template expansion
 31 |         inlineScript: Get-AzVM -ResourceGroupName "${{ inputs.expandme }}"
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.expandme may expand into attacker-controllable code
    |
-   = note: audit confidence → Low
+   = note: audit confidence → High
 
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:29:7

--- a/crates/zizmor/tests/integration/test-data/template-injection/input-caps.yml
+++ b/crates/zizmor/tests/integration/test-data/template-injection/input-caps.yml
@@ -1,0 +1,18 @@
+name: input-caps
+on:
+  workflow_call:
+    inputs:
+      test:
+        description: "Test"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  inject-me:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "doing a thing: ${{ inputs.test }}"


### PR DESCRIPTION
~~WIP.~~

This adds a `HasInputs` trait that allows workflow and action inputs to be queried for capability, similar to how other contexts can be queried for capabilities via the FST.

The ultimate idea here is to plug this into `template-injection` so that expansions of `input.*` contexts can be evaluated more accurately.