### PR TITLE
docs: add trophy for rust-lang/this-week-in-rust

### DIFF
--- a/docs/snippets/trophies.md
+++ b/docs/snippets/trophies.md
@@ -997,6 +997,7 @@
         - rust-lang/crates.io#10176
         - rust-lang/crates.io#11203
         - rust-lang/rust-clippy#13933
+        - rust-lang/this-week-in-rust#6721
 
 
 -   ![](https://github.com/rustls.png?size=40){ width="40" loading=lazy align=left } rustls

--- a/docs/snippets/trophies.txt
+++ b/docs/snippets/trophies.txt
@@ -213,6 +213,7 @@ rubygems/rubygems#8702
 rust-lang/crates.io#10176
 rust-lang/crates.io#11203
 rust-lang/rust-clippy#13933
+rust-lang/this-week-in-rust#6721
 rustls/rustls#2261
 rustls/tokio-rustls#96
 rustls/webpki#299


### PR DESCRIPTION
We used zizmor to help catch some things on the TWiR repo! Added to trophy section.