### PR TITLE
feat: new audit: anonymous-definition

### DIFF
--- a/crates/zizmor/src/audit/anonymous_definition.rs
+++ b/crates/zizmor/src/audit/anonymous_definition.rs
@@ -15,7 +15,7 @@ const ANONYMOUS_DEFINITION_JOB_SEVERITY: Severity = Severity::Informational;
 audit_meta!(
     AnonymousDefinition,
     "anonymous-definition",
-    "workflow or action definitions without a name"
+    "workflow or action definition without a name"
 );
 
 impl Audit for AnonymousDefinition {
@@ -34,7 +34,7 @@ impl Audit for AnonymousDefinition {
                 Self::finding()
                     .severity(ANONYMOUS_DEFINITION_WORKFLOW_SEVERITY)
                     .confidence(Confidence::High)
-                    .persona(Persona::default())
+                    .persona(Persona::Pedantic)
                     .add_location(workflow.location().primary())
                     .build(workflow)?,
             );
@@ -56,10 +56,7 @@ impl Audit for AnonymousDefinition {
                         );
                     }
                 }
-                Job::ReusableWorkflowCallJob(_) => {
-                    // No finding for reusable workflow calls without a name.
-                    // This is because they are not defined in the workflow itself.
-                }
+                _ => continue,
             }
         }
 

--- a/crates/zizmor/src/audit/anonymous_definition.rs
+++ b/crates/zizmor/src/audit/anonymous_definition.rs
@@ -1,0 +1,68 @@
+pub(crate) struct AnonymousDefinition;
+
+use crate::{
+    finding::{Confidence, Persona, Severity, location::Locatable as _},
+    state::AuditState,
+};
+
+use super::{Audit, AuditLoadError, Job, audit_meta};
+
+// Workflows without a name can be hard to find in the GitHub UI, so
+// severity is set higher than for Job.
+const ANONYMOUS_DEFINITION_WORKFLOW_SEVERITY: Severity = Severity::Low;
+const ANONYMOUS_DEFINITION_JOB_SEVERITY: Severity = Severity::Informational;
+
+audit_meta!(
+    AnonymousDefinition,
+    "anonymous-definition",
+    "workflow or action definitions without a name"
+);
+
+impl Audit for AnonymousDefinition {
+    fn new(_state: &AuditState<'_>) -> Result<Self, AuditLoadError> {
+        Ok(Self)
+    }
+
+    fn audit_workflow<'doc>(
+        &self,
+        workflow: &'doc crate::models::workflow::Workflow,
+    ) -> anyhow::Result<Vec<crate::finding::Finding<'doc>>> {
+        let mut findings = vec![];
+
+        if workflow.name.is_none() {
+            findings.push(
+                Self::finding()
+                    .severity(ANONYMOUS_DEFINITION_WORKFLOW_SEVERITY)
+                    .confidence(Confidence::High)
+                    .persona(Persona::default())
+                    .add_location(workflow.location().primary())
+                    .build(workflow)?,
+            );
+        }
+
+        for job in workflow.jobs() {
+            match job {
+                Job::NormalJob(normal) => {
+                    if normal.name.is_none() {
+                        let location = normal.location().primary();
+
+                        findings.push(
+                            Self::finding()
+                                .severity(ANONYMOUS_DEFINITION_JOB_SEVERITY)
+                                .confidence(Confidence::High)
+                                .persona(Persona::Pedantic)
+                                .add_location(location)
+                                .build(workflow)?,
+                        );
+                    }
+                }
+                Job::ReusableWorkflowCallJob(_) => {
+                    // No finding for reusable workflow calls without a name.
+                    // This is because they are not defined in the workflow itself.
+                }
+            }
+        }
+
+        Ok(findings)
+    }
+}

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     state::AuditState,
 };
 
+pub(crate) mod anonymous_definition;
 pub(crate) mod artipacked;
 pub(crate) mod bot_conditions;
 pub(crate) mod cache_poisoning;

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -605,7 +605,6 @@ fn run() -> Result<ExitCode> {
         }};
     }
 
-    register_audit!(audit::anonymous_definition::AnonymousDefinition);
     register_audit!(audit::artipacked::Artipacked);
     register_audit!(audit::unsound_contains::UnsoundContains);
     register_audit!(audit::excessive_permissions::ExcessivePermissions);
@@ -629,6 +628,7 @@ fn run() -> Result<ExitCode> {
     register_audit!(audit::obfuscation::Obfuscation);
     register_audit!(audit::stale_action_refs::StaleActionRefs);
     register_audit!(audit::unpinned_images::UnpinnedImages);
+    register_audit!(audit::anonymous_definition::AnonymousDefinition);
 
     let mut results = FindingRegistry::new(&app, &config);
     {

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -605,6 +605,7 @@ fn run() -> Result<ExitCode> {
         }};
     }
 
+    register_audit!(audit::anonymous_definition::AnonymousDefinition);
     register_audit!(audit::artipacked::Artipacked);
     register_audit!(audit::unsound_contains::UnsoundContains);
     register_audit!(audit::excessive_permissions::ExcessivePermissions);

--- a/crates/zizmor/tests/integration/acceptance.rs
+++ b/crates/zizmor/tests/integration/acceptance.rs
@@ -40,6 +40,21 @@ fn catches_inlined_ignore() -> anyhow::Result<()> {
 }
 
 #[test]
+fn audit_anonymous_definition() -> anyhow::Result<()> {
+    let auditable = input_under_test("anonymous-definition.yml");
+
+    let cli_args = ["--persona=pedantic", &auditable];
+
+    let execution = zizmor().args(cli_args).output()?;
+    assert_eq!(execution.status.code(), Some(12));
+
+    let findings = serde_json::from_slice(&execution.stdout)?;
+    assert_value_match(&findings, "$[0].determinations.confidence", "High");
+
+    Ok(())
+}
+
+#[test]
 fn audit_artipacked() -> anyhow::Result<()> {
     let auditable = input_under_test("artipacked.yml");
     let cli_args = [&auditable];

--- a/crates/zizmor/tests/integration/snapshot.rs
+++ b/crates/zizmor/tests/integration/snapshot.rs
@@ -35,14 +35,6 @@ fn test_github_output() -> Result<()> {
 
 #[test]
 fn anonymous_definition() -> Result<()> {
-    // This should only produce a Workflow finding.
-    insta::assert_snapshot!(
-        zizmor()
-            .input(input_under_test("anonymous-definition.yml"))
-            .run()?
-    );
-
-    // This should produce both Workflow and Job findings.
     insta::assert_snapshot!(
         zizmor()
             .input(input_under_test("anonymous-definition.yml"))

--- a/crates/zizmor/tests/integration/snapshot.rs
+++ b/crates/zizmor/tests/integration/snapshot.rs
@@ -34,6 +34,26 @@ fn test_github_output() -> Result<()> {
 }
 
 #[test]
+fn anonymous_definition() -> Result<()> {
+    // This should only produce a Workflow finding.
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("anonymous-definition.yml"))
+            .run()?
+    );
+
+    // This should produce both Workflow and Job findings.
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("anonymous-definition.yml"))
+            .args(["--persona=pedantic"])
+            .run()?
+    );
+
+    Ok(())
+}
+
+#[test]
 fn artipacked() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/zizmor/tests/integration/e2e.rs
 expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\"]).input(\"woodruffw/gha-hazmat@33cd22cdd7823a5795768388aff977fe992b5aad\").run()?"
-snapshot_kind: text
 ---
  INFO collect_inputs: zizmor: collected 22 inputs from woodruffw/gha-hazmat
  INFO zizmor: skipping impostor-commit: offline audits only requested
@@ -1093,4 +1092,4 @@ error[dangerous-triggers]: use of fundamentally insecure workflow trigger
    |
    = note: audit confidence → Medium
 
-123 findings (28 suppressed): 0 unknown, 6 informational, 0 low, 37 medium, 52 high
+172 findings (77 suppressed): 0 unknown, 6 informational, 0 low, 37 medium, 52 high

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_569.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_569.snap
@@ -183,4 +183,4 @@ error[unpinned-uses]: unpinned action reference
    |
    = note: audit confidence → High
 
-72 findings (53 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 18 high
+78 findings (59 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 18 high

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_726.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_726.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/integration/e2e.rs
+source: crates/zizmor/tests/integration/e2e.rs
 expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\"]).input(\"woodruffw-experiments/zizmor-bug-726@a038d1a35\").run()?"
 ---
  INFO collect_inputs: zizmor: collected 6 inputs from woodruffw-experiments/zizmor-bug-726
@@ -14,4 +14,4 @@ expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-onlin
  INFO audit: zizmor: 🌈 completed .github/workflows/hello.yml
  INFO audit: zizmor: 🌈 completed arbitrary/subdir/.github/workflows/hello.yml
  INFO audit: zizmor: 🌈 completed arbitrary/subdir/custom-action/action.yml
-No findings to report. Good job!
+No findings to report. Good job! (2 suppressed)

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition-2.snap
@@ -1,0 +1,28 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"anonymous-definition.yml\")).args([\"--persona=pedantic\"]).run()?"
+---
+help[anonymous-definition]: workflow or action definitions without a name
+  --> @@INPUT@@:1:1
+   |
+ 1 | / # see https://github.com/zizmorcore/zizmor/issues/795
+ 2 | |
+...  |
+19 | |     steps:
+20 | |       - run: "echo this job will trigger"
+   | |__________________________________________- help: this workflow
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definitions without a name
+  --> @@INPUT@@:17:3
+   |
+17 | /   will-trigger:
+18 | |     runs-on: ubuntu-latest
+19 | |     steps:
+20 | |       - run: "echo this job will trigger"
+   | |__________________________________________- info: this job
+   |
+   = note: audit confidence → High
+
+2 findings: 0 unknown, 1 informational, 1 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition-2.snap
@@ -2,7 +2,7 @@
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"anonymous-definition.yml\")).args([\"--persona=pedantic\"]).run()?"
 ---
-help[anonymous-definition]: workflow or action definitions without a name
+help[anonymous-definition]: workflow or action definition without a name
   --> @@INPUT@@:1:1
    |
  1 | / # see https://github.com/zizmorcore/zizmor/issues/795
@@ -14,7 +14,7 @@ help[anonymous-definition]: workflow or action definitions without a name
    |
    = note: audit confidence → High
 
-info[anonymous-definition]: workflow or action definitions without a name
+info[anonymous-definition]: workflow or action definition without a name
   --> @@INPUT@@:17:3
    |
 17 | /   will-trigger:

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition.snap
@@ -1,0 +1,17 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"anonymous-definition.yml\")).run()?"
+---
+help[anonymous-definition]: workflow or action definitions without a name
+  --> @@INPUT@@:1:1
+   |
+ 1 | / # see https://github.com/zizmorcore/zizmor/issues/795
+ 2 | |
+...  |
+19 | |     steps:
+20 | |       - run: "echo this job will trigger"
+   | |__________________________________________- help: this workflow
+   |
+   = note: audit confidence → High
+
+2 findings (1 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
-expression: "zizmor().input(input_under_test(\"anonymous-definition.yml\")).run()?"
+expression: "zizmor().input(input_under_test(\"anonymous-definition.yml\")).args([\"--persona=pedantic\"]).run()?"
 ---
-help[anonymous-definition]: workflow or action definitions without a name
+help[anonymous-definition]: workflow or action definition without a name
   --> @@INPUT@@:1:1
    |
  1 | / # see https://github.com/zizmorcore/zizmor/issues/795
@@ -14,4 +14,15 @@ help[anonymous-definition]: workflow or action definitions without a name
    |
    = note: audit confidence → High
 
-2 findings (1 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 0 high
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:17:3
+   |
+17 | /   will-trigger:
+18 | |     runs-on: ubuntu-latest
+19 | |     steps:
+20 | |       - run: "echo this job will trigger"
+   | |__________________________________________- info: this job
+   |
+   = note: audit confidence → High
+
+2 findings: 0 unknown, 1 informational, 1 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__ref_confusion.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__ref_confusion.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"ref-confusion.yml\")).offline(false).run()?"
 ---
 warning[ref-confusion]: git ref for action with ambiguous ref type
@@ -18,4 +18,4 @@ error[unpinned-uses]: unpinned action reference
    |
    = note: audit confidence → High
 
-2 findings: 0 unknown, 0 informational, 0 low, 1 medium, 1 high
+3 findings (1 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 1 high

--- a/crates/zizmor/tests/integration/test-data/anonymous-definition.yml
+++ b/crates/zizmor/tests/integration/test-data/anonymous-definition.yml
@@ -1,0 +1,20 @@
+# see https://github.com/zizmorcore/zizmor/issues/795
+
+# Name of the workflow is purposefully left blank for this test.
+
+on:
+  issues:
+
+permissions: {}
+
+jobs:
+  no-trigger:
+    name: This is a test job that will not trigger 
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo this job will not trigger"
+
+  will-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo this job will trigger"

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -14,6 +14,52 @@ Legend:
 |----------|------------------|---------------|----------------|--------------------|--------------|
 | The kind of audit ("Workflow" or "Action") | Links to vulnerable examples | Added to `zizmor` in this version | The audit works with `--offline` | The audit needs to be explicitly enabled via configuration or an API token | The audit supports custom configuration |
 
+## `anonymous-definition`
+
+| Type            | Examples         | Introduced in | Works offline | Enabled by default | Configurable |
+|-----------------|------------------|---------------|----------------|--------------------|--------------|
+| Workflow, Action | N/A              | v1.10.0       | ✅             | ❌                 | ❌            |
+
+Detects workflows or action definitions that omit a `name:` field.
+
+GitHub explicitly allows workflows to omit the `name:` field, and (undocumented)
+permits the same for action definitions. When `name:` is omitted, the
+workflow or action is rendered anonymously in the GitHub Actions UI, making
+it harder to understand which definition is running.
+
+!!! note
+
+    This is a `--pedantic` only audit, due to a lack of security impact.
+
+### Remediation
+
+Add a `name:` field to your workflow or action.
+
+=== "Before :warning:"
+
+    ```yaml title="anonymous-definition.yml" hl_lines="7"
+    on: push
+
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo "Hello!"
+    ```
+
+=== "After :white_check_mark:"
+
+    ```yaml title="anonymous-definition.yml" hl_lines="7-9"
+    name: Echo Test
+    on: push
+
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo "Hello!"
+    ```
+
 ## `artipacked`
 
 | Type     | Examples         | Introduced in | Works offline  | Enabled by default | Configurable |

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -20,12 +20,12 @@ Legend:
 |-----------------|------------------|---------------|----------------|--------------------|--------------|
 | Workflow, Action | N/A              | v1.10.0       | ✅             | ❌                 | ❌            |
 
-Detects workflows or action definitions that omit a `name:` field.
+Detects workflows or action definitions that lack a `name:` field.
 
-GitHub explicitly allows workflows to omit the `name:` field, and (undocumented)
-permits the same for action definitions. When `name:` is omitted, the
-workflow or action is rendered anonymously in the GitHub Actions UI, making
-it harder to understand which definition is running.
+GitHub explicitly allows workflows to omit the `name:` field, and allows (but
+doesn't document) the same for action definitions. When `name:` is omitted, the
+workflow or action is rendered anonymously in the GitHub Actions UI, making it
+harder to understand which definition is running.
 
 !!! note
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,12 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### New Features 🌈
+
+* **New audit**: [anonymous-definition] detects unnamed workflows and actions.
+  Definitions without a `name:` field appear anonymously in the GitHub Actions
+  UI, making them harder to distinguish (#937)
+
 ### Enhancements 🌱
 
 * The [artipacked] audit now produces findings on composite action definitions,

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -860,3 +860,4 @@ This is one of `zizmor`'s bigger recent releases! Key enhancements include:
 [unpinned-images]: ./audits.md#unpinned-images
 [insecure-commands]: ./audits.md#insecure-commands
 [use-trusted-publishing]: ./audits.md#use-trusted-publishing
+[anonymous-definition]: ./audits.md#anonymous-definition


### PR DESCRIPTION
Notes:
* GitHub UI being impacted by unnamed Workflows make severity feel higher for that than jobs. That said, since it is not a security problem, I felt like "Low" was appropriate. Curious thoughts on this.
* I left out 'ReusableWorkflowCallJob' since as far as I could tell, they did not have any naming capabilities

Closes: https://github.com/zizmorcore/zizmor/issues/795