### PR TITLE
chore: remove a root level special case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,7 +3448,7 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yamlpath"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "line-index",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = "0.3.19"
 tree-sitter = "0.25.6"
 tree-sitter-bash = "0.23.3"
 tree-sitter-powershell = "0.25.2"
-yamlpath = { path = "crates/yamlpath", version = "0.20.0" }
+yamlpath = { path = "crates/yamlpath", version = "0.21.0" }
 tree-sitter-yaml = "0.7.1"
 
 [workspace.lints.clippy]

--- a/crates/yamlpath/Cargo.toml
+++ b/crates/yamlpath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamlpath"
-version = "0.20.0"
+version = "0.21.0"
 description = "Format-preserving YAML feature extraction"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/yamlpath"
 readme = "README.md"

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -371,6 +371,17 @@ impl Document {
         self.range_spanned_by_comment(offset, offset)
     }
 
+    /// Perform a query on the current document, returning `true`
+    /// if the query succeeds (i.e. references an existing feature).
+    ///
+    /// All errors become `false`.
+    pub fn query_exists(&self, query: &Query) -> bool {
+        match self.query_node(query, QueryMode::Exact) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+
     /// Perform a query on the current document, returning a `Feature`
     /// if the query succeeds.
     ///

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -376,10 +376,7 @@ impl Document {
     ///
     /// All errors become `false`.
     pub fn query_exists(&self, query: &Query) -> bool {
-        match self.query_node(query, QueryMode::Exact) {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        self.query_node(query, QueryMode::Exact).is_ok()
     }
 
     /// Perform a query on the current document, returning a `Feature`

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -343,6 +343,15 @@ impl Document {
         self.tree.root_node().into()
     }
 
+    /// Returns a [`Feature`] for the topmost semantic object in this document.
+    ///
+    /// This is typically useful as a "fallback" feature, e.g. for positioning
+    /// relative to the "top" of the document.
+    pub fn top_feature(&self) -> Result<Feature, QueryError> {
+        let top_node = self.top_object()?;
+        Ok(top_node.into())
+    }
+
     /// Returns whether the given range is spanned by a comment node.
     ///
     /// The comment node must fully span the range; a range that ends
@@ -507,7 +516,9 @@ impl Document {
         )
     }
 
-    fn query_node(&self, query: &Query, mode: QueryMode) -> Result<Node, QueryError> {
+    /// Returns the topmost semantic object in the YAML document,
+    /// i.e. the node corresponding to the first block or flow feature.
+    fn top_object(&self) -> Result<Node, QueryError> {
         // All tree-sitter-yaml trees start with a `stream` node.
         let stream = self.tree.root_node();
 
@@ -528,7 +539,11 @@ impl Document {
             .find(|c| c.kind_id() == self.block_node_id || c.kind_id() == self.flow_node_id)
             .ok_or_else(|| QueryError::Other("document has no block_node or flow_node".into()))?;
 
-        let mut key_node = top_node;
+        Ok(top_node)
+    }
+
+    fn query_node(&self, query: &Query, mode: QueryMode) -> Result<Node, QueryError> {
+        let mut key_node = self.top_object()?;
         for component in &query.route {
             match self.descend(&key_node, component) {
                 Ok(next) => key_node = next,

--- a/crates/zizmor/src/yaml_patch/mod.rs
+++ b/crates/zizmor/src/yaml_patch/mod.rs
@@ -55,44 +55,38 @@ pub enum Style {
     SingleQuoted,
     /// Plain scalar style: value
     PlainScalar,
-    /// An empty feature, e.g. the value part of `foo:`
-    Empty,
 }
 
 impl Style {
-    /// Detect the YAML style of document feature.
-    pub fn detect(route: &Route, doc: &yamlpath::Document) -> Result<Self, Error> {
-        let Some(feature) = route_to_feature_exact(route, doc)? else {
-            return Ok(Style::Empty);
-        };
-
-        let content = doc.extract(&feature);
+    /// Given a feature and its document, determine the style of the feature.
+    pub fn from_feature(feature: &yamlpath::Feature, doc: &yamlpath::Document) -> Self {
+        let content = doc.extract(feature);
         let trimmed = content.trim().as_bytes();
         let multiline = trimmed.contains(&b'\n');
 
         match feature.kind() {
-            yamlpath::FeatureKind::BlockMapping => Ok(Style::BlockMapping),
-            yamlpath::FeatureKind::BlockSequence => Ok(Style::BlockSequence),
+            yamlpath::FeatureKind::BlockMapping => Style::BlockMapping,
+            yamlpath::FeatureKind::BlockSequence => Style::BlockSequence,
             yamlpath::FeatureKind::FlowMapping => {
                 if multiline {
-                    Ok(Style::MultilineFlowMapping)
+                    Style::MultilineFlowMapping
                 } else {
-                    Ok(Style::FlowMapping)
+                    Style::FlowMapping
                 }
             }
             yamlpath::FeatureKind::FlowSequence => {
                 if multiline {
-                    Ok(Style::MultilineFlowSequence)
+                    Style::MultilineFlowSequence
                 } else {
-                    Ok(Style::FlowSequence)
+                    Style::FlowSequence
                 }
             }
             yamlpath::FeatureKind::Scalar => match trimmed[0] {
-                b'|' => Ok(Style::MultilineLiteralScalar),
-                b'>' => Ok(Style::MultilineFoldedScalar),
-                b'"' => Ok(Style::DoubleQuoted),
-                b'\'' => Ok(Style::SingleQuoted),
-                _ => Ok(Style::PlainScalar),
+                b'|' => Style::MultilineLiteralScalar,
+                b'>' => Style::MultilineFoldedScalar,
+                b'"' => Style::DoubleQuoted,
+                b'\'' => Style::SingleQuoted,
+                _ => Style::PlainScalar,
             },
         }
     }
@@ -153,8 +147,15 @@ pub enum Op<'doc> {
     },
     /// Replace the value at the given path
     Replace(serde_yaml::Value),
-    /// Add a new key-value pair at the given path. The path should point to a mapping,
-    /// or use "/" for root-level additions. Maintains proper indentation and formatting.
+    /// Add a new key-value pair at the given path.
+    ///
+    /// The route should point to a mapping.
+    ///
+    /// Limitations:
+    ///
+    /// - The mapping must be a block mapping or single-line flow mapping.
+    ///   Multi-line flow mappings are not currently supported.
+    /// - The key must not already exist in the targeted mapping.
     Add {
         key: String,
         value: serde_yaml::Value,
@@ -296,20 +297,19 @@ fn apply_single_patch(content: &str, patch: &Patch) -> Result<String, Error> {
             result.replace_range(start_span..end_span, &replacement);
             Ok(result)
         }
-
         Op::Add { key, value } => {
-            if patch.route.is_root() {
-                // Handle root-level additions specially
-                return handle_root_level_addition(content, key, value);
-            }
-
-            let style = Style::detect(&patch.route, &doc)?;
-            let Some(feature) = route_to_feature_exact(&patch.route, &doc)? else {
-                return Err(Error::InvalidOperation(format!(
-                    "no existing mapping at {route:?}",
-                    route = patch.route
-                )));
+            let feature = if patch.route.is_root() {
+                doc.top_feature()?
+            } else {
+                route_to_feature_exact(&patch.route, &doc)?.ok_or_else(|| {
+                    Error::InvalidOperation(format!(
+                        "no existing mapping at {route:?}",
+                        route = patch.route
+                    ))
+                })?
             };
+
+            let style = Style::from_feature(&feature, &doc);
             let feature_content = doc.extract(&feature);
 
             let updated_feature = match style {
@@ -336,7 +336,6 @@ fn apply_single_patch(content: &str, patch: &Patch) -> Result<String, Error> {
             );
             Ok(result)
         }
-
         Op::MergeInto { key, value } => {
             if patch.route.is_root() {
                 // Handle root-level merges specially
@@ -411,7 +410,6 @@ fn apply_single_patch(content: &str, patch: &Patch) -> Result<String, Error> {
                 },
             )
         }
-
         Op::Remove => {
             if patch.route.is_root() {
                 return Err(Error::InvalidOperation(
@@ -1284,9 +1282,9 @@ empty:
                 route!("multiline-scalars", "folded-e"),
                 Style::MultilineFoldedScalar,
             ),
-            (route!("empty", "foo"), Style::Empty),
         ] {
-            let style = Style::detect(route, &doc).unwrap();
+            let feature = route_to_feature_exact(route, &doc).unwrap().unwrap();
+            let style = Style::from_feature(&feature, &doc);
             assert_eq!(style, *expected_style, "for route: {route:?}");
         }
     }


### PR DESCRIPTION
This renames some tests and removes the need for a `handle_root_level_addition` special-case in `Op::Add` by reusing the existing codepaths. It also adds a test to ensure that `Op::Add` fails when the key already exists in the targeted mapping.

Signed-off-by: William Woodruff <william@yossarian.net>