### PR TITLE
docs: Unfix accidentally-fixed pinning example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -395,7 +395,7 @@ sensitive `zizmor`'s analyses are:
     as its pin instead of a hashed pin:
 
     ```yaml
-    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    uses: actions/checkout@v3
     ```
 
     produces:


### PR DESCRIPTION
This example in the docs was deliberately using a ref pin (`@v3`) for the sake of demonstrating `unpinned-uses`, but it got fixed accidentally by #817.

It unfortunately seems like this is likely to happen again if `pinact` is run again. I don't know what the right long-term solution is.