### PR TITLE
chore: add a debug message when registering inputs

### DIFF
--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -204,6 +204,8 @@ impl InputRegistry {
         contents: String,
         key: InputKey,
     ) -> anyhow::Result<()> {
+        tracing::debug!("registering {kind:?} input as with key {key}");
+
         let input: Result<AuditInput, InputError> = match kind {
             InputKind::Workflow => Workflow::from_string(contents, key).map(|wf| wf.into()),
             InputKind::Action => Action::from_string(contents, key).map(|a| a.into()),


### PR DESCRIPTION
This is a small QOL improvement for users attempting to debug `zizmor`'s behavior on one or more inputs.

xref #952, h/t @smillerdev