### PR TITLE
feat: better error messages for invalid inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_yaml",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -19,5 +19,6 @@ workspace = true
 indexmap.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/github-actions-models/src/workflow/job.rs
+++ b/crates/github-actions-models/src/workflow/job.rs
@@ -1,11 +1,11 @@
 //! Workflow jobs.
 
 use indexmap::IndexMap;
-use serde::{Deserialize, de};
+use serde::Deserialize;
 use serde_yaml::Value;
 
 use crate::common::expr::{BoE, LoE};
-use crate::common::{Env, If, Permissions, Uses};
+use crate::common::{Env, If, Permissions, Uses, custom_error};
 
 use super::{Concurrency, Defaults};
 
@@ -65,7 +65,7 @@ impl<'de> Deserialize<'de> for RunsOn {
         // has either a `group` or at least one label here.
         if let RunsOn::Group { group, labels } = &runs_on {
             if group.is_none() && labels.is_empty() {
-                return Err(de::Error::custom(
+                return Err(custom_error::<D>(
                     "runs-on must provide either `group` or one or more `labels`",
                 ));
             }

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -471,7 +471,6 @@ fn collect_inputs(
             registry.register(kind, contents, key)?;
         } else if input_path.is_dir() {
             collect_from_dir(input_path, mode, &mut registry)?;
-            // collect_from_repo_dir(input_path, input_path, mode, &mut registry)?;
         } else {
             // If this input isn't a file or directory, it's probably an
             // `owner/repo(@ref)?` slug.

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -3,7 +3,7 @@
 //! These models enrich the models under [`github_actions_models::action`],
 //! providing higher-level APIs for zizmor to use.
 
-use anyhow::Context as _;
+use anyhow::Context;
 use github_actions_expressions::context;
 use github_actions_models::{action, common, workflow::job::Strategy};
 use terminal_link::Link;
@@ -61,7 +61,8 @@ impl HasInputs for Action {
 impl Action {
     /// Load an action from a buffer, with an assigned name.
     pub(crate) fn from_string(contents: String, key: InputKey) -> Result<Self, InputError> {
-        let inner = from_str_with_validation(&contents, &ACTION_VALIDATOR)?;
+        let inner = from_str_with_validation(&contents, &ACTION_VALIDATOR)
+            .with_context(|| format!("failed to load action from {key}"))?;
 
         let document = yamlpath::Document::new(&contents)
             .context("failed to load internal pathing document")?;

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::Context as _;
+use anyhow::Context;
 use github_actions_expressions::context;
 use github_actions_models::{
     common::{self, expr::LoE},
@@ -121,7 +121,8 @@ impl HasInputs for Workflow {
 impl Workflow {
     /// Load a workflow from a buffer, with an assigned name.
     pub(crate) fn from_string(contents: String, key: InputKey) -> Result<Self, InputError> {
-        let inner = from_str_with_validation(&contents, &WORKFLOW_VALIDATOR)?;
+        let inner = from_str_with_validation(&contents, &WORKFLOW_VALIDATOR)
+            .with_context(|| format!("failed to load workflow from {key}"))?;
 
         let document = yamlpath::Document::new(&contents)
             .context("failed to load internal pathing document")?;

--- a/crates/zizmor/src/utils.rs
+++ b/crates/zizmor/src/utils.rs
@@ -355,7 +355,7 @@ where
                 // We the JSON schema `validator` to separate these.
                 Ok(raw_value) => match validator.apply(&raw_value).basic() {
                     Valid(_) => Err(e)
-                        .context("this strongly suggests a bug in zizmor; please report it!")
+                        .context("this suggests a bug in zizmor; please report it!")
                         .map_err(InputError::Model),
                     Invalid(errors) => Err(InputError::Schema(parse_validation_errors(errors))),
                 },

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-10.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-10.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Action
 
 Caused by:
-    0: input does not match expected validation schema
-    1: null is not of type "object"
+    0: failed to load action from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: null is not of type "object"

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-2.snap
@@ -1,12 +1,12 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: input does not match expected validation schema
-    1: on.workflow_call.inputs.input: "type" is a required property
+    0: failed to load workflow from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: on.workflow_call.inputs.input: "type" is a required property
        Additional properties are not allowed ('boom' was unexpected)

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-3.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-3.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: input does not match expected validation schema
-    1: null is not of type "object"
+    0: failed to load workflow from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: null is not of type "object"

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-4.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-4.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: input does not match expected validation schema
-    1: "lol" is not of type "object"
+    0: failed to load workflow from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: "lol" is not of type "object"

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-5.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-5.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: invalid YAML syntax: mapping values are not allowed in this context at line 3 column 8
-    1: mapping values are not allowed in this context at line 3 column 8
+    0: failed to load workflow from file://@@INPUT@@
+    1: invalid YAML syntax: mapping values are not allowed in this context at line 3 column 8
+    2: mapping values are not allowed in this context at line 3 column 8

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-6.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-6.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: input does not match expected validation schema
-    1: null is not of type "object"
+    0: failed to load workflow from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: null is not of type "object"

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-7.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-7.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: input does not match expected validation schema
-    1: null is not of type "object"
+    0: failed to load workflow from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: null is not of type "object"

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-8.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-8.snap
@@ -6,8 +6,9 @@ fatal: no audit was performed
 failed to load input as Action
 
 Caused by:
-    0: input does not match expected validation schema
-    1: runs: Additional properties are not allowed ('image' was unexpected)
+    0: failed to load action from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: runs: Additional properties are not allowed ('image' was unexpected)
        runs: "using" is a required property
        runs: "main" is a required property
        runs: Additional properties are not allowed ('image' was unexpected)

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-9.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs-9.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/e2e.rs
-expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-inputs\"]).run()?"
-snapshot_kind: text
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(true).input(input_under_test(&format!(\"invalid/{workflow_tc}.yml\"))).args([\"--strict-collection\"]).run()?"
 ---
 fatal: no audit was performed
 failed to load input as Action
 
 Caused by:
-    0: invalid YAML syntax: mapping values are not allowed in this context at line 3 column 8
-    1: mapping values are not allowed in this context at line 3 column 8
+    0: failed to load action from file://@@INPUT@@
+    1: invalid YAML syntax: mapping values are not allowed in this context at line 3 column 8
+    2: mapping values are not allowed in this context at line 3 column 8

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_inputs.snap
@@ -6,7 +6,8 @@ fatal: no audit was performed
 failed to load input as Workflow
 
 Caused by:
-    0: input does not match expected validation schema
-    1: jobs.invalid: "runs-on" is a required property
+    0: failed to load workflow from file://@@INPUT@@
+    1: input does not match expected validation schema
+    2: jobs.invalid: "runs-on" is a required property
        jobs.invalid: Additional properties are not allowed ('steps' was unexpected)
        jobs.invalid: "uses" is a required property

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__menagerie-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__menagerie-2.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/integration/e2e.rs
+source: crates/zizmor/tests/integration/e2e.rs
 expression: "zizmor().output(OutputMode::Both).args([\"--collect=all\"]).input(input_under_test(\"e2e-menagerie\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__menagerie.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__menagerie.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/integration/e2e.rs
+source: crates/zizmor/tests/integration/e2e.rs
 expression: "zizmor().output(OutputMode::Both).input(input_under_test(\"e2e-menagerie\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-10.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-10.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-11.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-11.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-12.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-12.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-6.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-6.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-7.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-7.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-8.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-8.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-9.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-9.snap
@@ -1,7 +1,6 @@
 ---
-source: tests/integration/snapshot.rs
+source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,8 @@ of `zizmor`.
   findings when analyzing `env` context accesses for static-ness (#911)
 * The [template-injection] audit now produces more precise findings
   when analyzing `inputs` context accesses (#919)
+* zizmor now produces more descriptive error messages when it fails to
+  parse a workflow or action definition (#956)
 
 ### Bug Fixes 🐛
 


### PR DESCRIPTION
The error in #952 now looks like this:

```
ERROR collect_inputs: github_actions_models::common: msg="repo action must have `@<ref>` in reusable workflow"
fatal: no audit was performed
failed to load input as Workflow

Caused by:
    0: failed to load workflow from file://tmp.yml
    1: couldn't turn input into a an appropriate model
    2: this suggests a bug in zizmor; please report it!
    3: jobs: data did not match any variant of untagged enum Job at line 23 column 3
```

Closes #952.