### PR TITLE
bugfix: eliminate a panic when auditing composite actions

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -179,7 +179,10 @@ impl Audit for Artipacked {
         &self,
         action: &'doc crate::models::action::Action,
     ) -> anyhow::Result<Vec<Finding<'doc>>> {
-        let steps = action.steps();
+        let Some(steps) = action.steps() else {
+            return Ok(vec![]);
+        };
+
         self.process_steps(steps)
     }
 

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -1,6 +1,5 @@
 //! Core namespace for zizmor's audits.
 
-use github_actions_models::action;
 use line_index::LineIndex;
 use thiserror::Error;
 use tracing::instrument;
@@ -247,8 +246,8 @@ pub(crate) trait Audit: AuditCore {
     fn audit_action<'doc>(&self, action: &'doc Action) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut results = vec![];
 
-        if matches!(action.runs, action::Runs::Composite(_)) {
-            for step in action.steps() {
+        if let Some(steps) = action.steps() {
+            for step in steps {
                 results.extend(self.audit_composite_step(&step)?);
             }
         }

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -661,6 +661,11 @@ fn run() -> Result<ExitCode> {
         for (_, input) in registry.iter_inputs() {
             Span::current().pb_set_message(input.key().filename());
             for (name, audit) in audit_registry.iter_audits() {
+                tracing::debug!(
+                    "running {name} on {input}",
+                    name = name,
+                    input = input.key()
+                );
                 results.extend(audit.audit(input).with_context(|| {
                     format!("{name} failed on {input}", input = input.key().filename())
                 })?);

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -83,8 +83,9 @@ impl Action {
         })
     }
 
-    /// A [`CompositeSteps`] iterator over this workflow's constituent [`CompositeStep`]s.
-    pub(crate) fn steps(&self) -> CompositeSteps<'_> {
+    /// Returns a [`CompositeSteps`] iterator over this actions's constituent
+    /// [`CompositeStep`]s, or `None` if the action is not a composite action.
+    pub(crate) fn steps(&self) -> Option<CompositeSteps<'_>> {
         CompositeSteps::new(self)
     }
 
@@ -111,16 +112,14 @@ pub(crate) struct CompositeSteps<'a> {
 }
 
 impl<'a> CompositeSteps<'a> {
-    /// Create a new [`CompositeSteps`].
-    ///
-    /// Invariant: panics if the given [`Action`] is not a composite action.
-    fn new(action: &'a Action) -> Self {
+    /// Create a new [`CompositeSteps`], or `None` if the action is not a composite action.
+    fn new(action: &'a Action) -> Option<Self> {
         match &action.inner.runs {
-            action::Runs::Composite(composite) => Self {
+            action::Runs::Composite(composite) => Some(Self {
                 inner: composite.steps.iter().enumerate(),
                 parent: action,
-            },
-            _ => panic!("API misuse: can't call steps() on a non-composite action"),
+            }),
+            _ => None,
         }
     }
 }

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -240,6 +240,7 @@ fn invalid_inputs() -> Result<()> {
 #[test]
 fn pr_960_backstop() -> Result<()> {
     // Backstop test for PR #960.
+    // See: https://github.com/zizmorcore/zizmor/pull/960
 
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -236,3 +236,17 @@ fn invalid_inputs() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn pr_960_backstop() -> Result<()> {
+    // Backstop test for PR #960.
+
+    insta::assert_snapshot!(
+        zizmor()
+            .output(OutputMode::Both)
+            .input(input_under_test("pr-960-backstop"))
+            .run()?
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__pr_960_backstop.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__pr_960_backstop.snap
@@ -1,0 +1,11 @@
+---
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().output(OutputMode::Both).input(input_under_test(\"pr-960-backstop\")).run()?"
+---
+ INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
+ INFO zizmor: skipping ref-confusion: can't run without a GitHub API token
+ INFO zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
+ INFO zizmor: skipping forbidden-uses: audit not configured
+ INFO zizmor: skipping stale-action-refs: can't run without a GitHub API token
+ INFO audit: zizmor: 🌈 completed @@INPUT@@/action.yml
+No findings to report. Good job!

--- a/crates/zizmor/tests/integration/test-data/pr-960-backstop/action.yml
+++ b/crates/zizmor/tests/integration/test-data/pr-960-backstop/action.yml
@@ -1,0 +1,10 @@
+name: "backstop for PR #960"
+
+description: |
+  a backstop for PR #960 to ensure we don't crash on non-composite actions
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - lol


### PR DESCRIPTION
I regressed this in a hard-to-notice way with #896.

Needs a good regression test; a non-composite test that doesn't cause a crash would probably be sufficient.