### PR TITLE
chore: refactor fix input key handling

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -149,7 +149,7 @@ impl Artipacked {
                 When 'persist-credentials' is true (the default), the GITHUB_TOKEN persists in the local git config \
                 after checkout, which may be inadvertently leaked through subsequent actions like artifact uploads. \
                 Setting 'persist-credentials: false' ensures that credentials don't persist beyond the checkout step itself.".to_string(),
-            _key: step.location().key,
+            key: step.location().key,
             patches: vec![
                 Patch {
                     route: step.route(),

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -312,7 +312,7 @@ impl TemplateInjection {
         Some(Fix {
             title: "replace expression with environment variable".into(),
             description: "todo".into(),
-            _key: step.location().key,
+            key: step.location().key,
             patches,
         })
     }

--- a/crates/zizmor/src/finding.rs
+++ b/crates/zizmor/src/finding.rs
@@ -111,7 +111,8 @@ pub(crate) struct Fix<'doc> {
     /// A detailed description of the fix.
     #[allow(dead_code)]
     pub(crate) description: String,
-    pub(crate) _key: &'doc InputKey,
+    /// The key back into the input registry that this fix applies to.
+    pub(crate) key: &'doc InputKey,
     pub(crate) patches: Vec<Patch<'doc>>,
 }
 

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -59,7 +59,7 @@ pub(crate) struct LocalKey {
     /// The path's nondeterministic prefix, if any.
     prefix: Option<Utf8PathBuf>,
     /// The given path to the input. This can be absolute or relative.
-    given_path: Utf8PathBuf,
+    pub(crate) given_path: Utf8PathBuf,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, PartialOrd, Ord)]


### PR DESCRIPTION
This refactors `zizmor::fix` to use each `Fix::key` instead of trying to infer it from the parent `Finding`'s first location. In doing so we also save ourselves a handful of clones.