### PR TITLE
chore(deps): bump http-cache-reqwest to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "http-cache-reqwest"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8c123449fb658bd3888da88030538dfa47febab2aff40c54f7ab61c2e75368"
+checksum = "8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ csv = "1.3.1"
 etcetera = "0.10.0"
 flate2 = "1.1.2"
 fst = "0.4.7"
-http-cache-reqwest = "0.15.2"
+http-cache-reqwest = "0.16"
 human-panic = "2.0.1"
 ignore = "0.4.23"
 indexmap = { version = "2.9.0", features = ["serde"] }


### PR DESCRIPTION
Follows #979, #980.