### PR TITLE
chore: remove descriptions from fixes

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -144,29 +144,23 @@ impl Artipacked {
     /// Create a Fix for setting persist-credentials: false
     fn create_persist_credentials_fix<'doc>(step: &impl StepCommon<'doc>) -> Fix<'doc> {
         Fix {
-            title: "Set persist-credentials: false".to_string(),
-            description: "To prevent credential persistence, set 'persist-credentials: false' in this checkout step. \
-                When 'persist-credentials' is true (the default), the GITHUB_TOKEN persists in the local git config \
-                after checkout, which may be inadvertently leaked through subsequent actions like artifact uploads. \
-                Setting 'persist-credentials: false' ensures that credentials don't persist beyond the checkout step itself.".to_string(),
+            title: "set persist-credentials: false".to_string(),
             key: step.location().key,
             disposition: Default::default(),
-            patches: vec![
-                Patch {
-                    route: step.route(),
-                    operation: Op::MergeInto {
-                        key: "with".to_string(),
-                        value: {
-                            let mut with_map = serde_yaml::Mapping::new();
-                            with_map.insert(
-                                serde_yaml::Value::String("persist-credentials".to_string()),
-                                serde_yaml::Value::Bool(false),
-                            );
-                            serde_yaml::Value::Mapping(with_map)
-                        },
+            patches: vec![Patch {
+                route: step.route(),
+                operation: Op::MergeInto {
+                    key: "with".to_string(),
+                    value: {
+                        let mut with_map = serde_yaml::Mapping::new();
+                        with_map.insert(
+                            serde_yaml::Value::String("persist-credentials".to_string()),
+                            serde_yaml::Value::Bool(false),
+                        );
+                        serde_yaml::Value::Mapping(with_map)
                     },
-                }
-            ],
+                },
+            }],
         }
     }
 }

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -382,7 +382,6 @@ impl BotConditions {
 
         Some(Fix {
             title: "replace spoofable actor context".into(),
-            description: "todo".into(),
             key: &workflow.key,
             disposition: FixDisposition::Safe,
             patches: vec![Patch {

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -311,7 +311,6 @@ impl TemplateInjection {
 
         Some(Fix {
             title: "replace expression with environment variable".into(),
-            description: "todo".into(),
             key: step.location().key,
             disposition: Default::default(),
             patches,

--- a/crates/zizmor/src/finding.rs
+++ b/crates/zizmor/src/finding.rs
@@ -123,9 +123,6 @@ pub(crate) struct Fix<'doc> {
     /// A short title describing the fix.
     #[allow(dead_code)]
     pub(crate) title: String,
-    /// A detailed description of the fix.
-    #[allow(dead_code)]
-    pub(crate) description: String,
     /// The key back into the input registry that this fix applies to.
     pub(crate) key: &'doc InputKey,
     /// The fix's disposition.


### PR DESCRIPTION
...for now. As-is these are not presented anywhere and are hard to template/enrich, so I want to take them out while thinking more about if/how to do long fix descriptions in the future.