### PR TITLE
refactor: dedupe route/query types

### DIFF
--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -449,14 +449,14 @@ pub fn route_to_feature_pretty<'a>(
     route: &yamlpath::Route<'_>,
     doc: &'a yamlpath::Document,
 ) -> Result<yamlpath::Feature<'a>, Error> {
-    doc.query_pretty(&route).map_err(Error::from)
+    doc.query_pretty(route).map_err(Error::from)
 }
 
 pub fn route_to_feature_exact<'a>(
     route: &yamlpath::Route<'_>,
     doc: &'a yamlpath::Document,
 ) -> Result<Option<yamlpath::Feature<'a>>, Error> {
-    doc.query_exact(&route).map_err(Error::from)
+    doc.query_exact(route).map_err(Error::from)
 }
 
 /// Serialize a serde_yaml::Value to a YAML string, handling different types appropriately

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -1,4 +1,5 @@
 use yamlpatch::*;
+use yamlpath::route;
 
 #[test]
 fn test_serialize_flow() {
@@ -916,11 +917,11 @@ jobs:
 
     // Test what yamlpath extracts for the checkout step
     let doc = yamlpath::Document::new(original).unwrap();
-    let checkout_query = route!("jobs", "test", "steps", 0).to_query().unwrap();
+    let checkout_query = route!("jobs", "test", "steps", 0);
     let checkout_feature = doc.query_pretty(&checkout_query).unwrap();
 
     // Test what yamlpath extracts for the test job
-    let job_query = route!("jobs", "test").to_query().unwrap();
+    let job_query = route!("jobs", "test");
     let job_feature = doc.query_pretty(&job_query).unwrap();
 
     // Assert that the checkout step extraction includes the expected content
@@ -1002,11 +1003,11 @@ fn test_comment_boundary_issue() {
 
     // See what yamlpath extracts for step 0
     let doc = yamlpath::Document::new(original).unwrap();
-    let step0_query = route!("steps", 0).to_query().unwrap();
+    let step0_query = route!("steps", 0);
     let step0_feature = doc.query_pretty(&step0_query).unwrap();
 
     // See what yamlpath extracts for step 1
-    let step1_query = route!("steps", 1).to_query().unwrap();
+    let step1_query = route!("steps", 1);
     let step1_feature = doc.query_pretty(&step1_query).unwrap();
 
     // Check for overlaps
@@ -1308,7 +1309,7 @@ fn test_debug_indentation_issue() {
 
     // Test yamlpath extraction
     let doc = yamlpath::Document::new(original).unwrap();
-    let step_query = route!("jobs", "build", "steps", 0).to_query().unwrap();
+    let step_query = route!("jobs", "build", "steps", 0);
     let step_feature = doc.query_pretty(&step_query).unwrap();
 
     // Test indentation calculation and content extraction
@@ -1410,9 +1411,7 @@ jobs:
 
     // Test yamlpath extraction of the env section
     let doc = yamlpath::Document::new(original).unwrap();
-    let env_query = route!("jobs", "test", "steps", 0, "env")
-        .to_query()
-        .unwrap();
+    let env_query = route!("jobs", "test", "steps", 0, "env");
 
     if let Ok(env_feature) = doc.query_pretty(&env_query) {
         let env_content = doc.extract(&env_feature);

--- a/crates/yamlpath/Cargo.toml
+++ b/crates/yamlpath/Cargo.toml
@@ -16,10 +16,10 @@ workspace = true
 
 [dependencies]
 line-index.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-yaml = { workspace = true }
 
 [dev-dependencies]
-serde.workspace = true
 serde_yaml.workspace = true

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -343,14 +343,6 @@ impl Document {
         &self.source
     }
 
-    /// Returns a `Feature` for this document's root node.
-    ///
-    /// This is typically useful as a "fallback" feature, e.g. for capturing
-    /// a span of the entire document.
-    pub fn root(&self) -> Feature {
-        self.tree.root_node().into()
-    }
-
     /// Returns a [`Feature`] for the topmost semantic object in this document.
     ///
     /// This is typically useful as a "fallback" feature, e.g. for positioning
@@ -875,6 +867,21 @@ baz:
             doc.extract_with_leading_whitespace(&doc.query_pretty(&route).unwrap()),
             "{d: e}"
         );
+    }
+
+    #[test]
+    fn test_top_feature() {
+        let doc = r#"
+foo: bar
+baz:
+  abc: def
+"#;
+
+        let doc = Document::new(doc).unwrap();
+        let feature = doc.top_feature().unwrap();
+
+        assert_eq!(doc.extract(&feature).trim(), doc.source().trim());
+        assert_eq!(feature.kind(), FeatureKind::BlockMapping);
     }
 
     #[test]

--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -148,7 +148,7 @@ impl Artipacked {
             key: step.location().key,
             disposition: Default::default(),
             patches: vec![Patch {
-                route: step.route().into(),
+                route: step.route(),
                 operation: Op::MergeInto {
                     key: "with".to_string(),
                     updates: indexmap::IndexMap::from_iter([(

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -13,7 +13,7 @@ use super::{Audit, AuditLoadError, AuditState, audit_meta};
 use crate::{
     finding::{
         Confidence, Fix, FixDisposition, Severity,
-        location::{Locatable as _, Route, Subfeature},
+        location::{Locatable as _, Subfeature},
     },
     models::workflow::{JobExt, Workflow},
     utils::ExtractedExpr,
@@ -77,7 +77,7 @@ impl Audit for BotConditions {
             conds.push((
                 expr,
                 job.location_with_name(),
-                job.location().with_keys(&["if".into()]),
+                job.location().with_keys(["if".into()]),
             ));
         }
 
@@ -87,7 +87,7 @@ impl Audit for BotConditions {
                 conds.push((
                     expr,
                     step.location_with_name(),
-                    step.location().with_keys(&["if".into()]),
+                    step.location().with_keys(["if".into()]),
                 ));
             }
         }
@@ -352,7 +352,7 @@ impl BotConditions {
     fn attempt_fix<'doc>(
         workflow: &'doc Workflow,
         spoofable_context: &SpannedExpr<'doc>,
-        if_route: Route<'doc>,
+        if_route: yamlpath::Route<'doc>,
     ) -> Option<Fix<'doc>> {
         // Get appropriate contexts based on workflow triggers
         let (safe_name_context, safe_id_context) = Self::get_user_contexts_for_triggers(workflow)?;

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -385,7 +385,7 @@ impl BotConditions {
             key: &workflow.key,
             disposition: FixDisposition::Safe,
             patches: vec![Patch {
-                route: if_route.into(),
+                route: if_route,
                 operation: Op::RewriteFragment {
                     from: spoofable_context_raw.into(),
                     to: safe_context.into(),

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -382,13 +382,13 @@ impl CachePoisoning {
                 .add_location(
                     step.workflow()
                         .location()
-                        .with_keys(&["on".into()])
+                        .with_keys(["on".into()])
                         .annotated("generally used when publishing artifacts generated at runtime"),
                 )
                 .add_location(
                     step.location()
                         .primary()
-                        .with_keys(&[yaml_key.into()])
+                        .with_keys([yaml_key.into()])
                         .annotated(annotation),
                 ),
             PublishingArtifactsScenario::UsingWellKnowPublisherAction(publisher) => Self::finding()
@@ -397,13 +397,13 @@ impl CachePoisoning {
                 .add_location(
                     publisher
                         .location()
-                        .with_keys(&["uses".into()])
+                        .with_keys(["uses".into()])
                         .annotated("runtime artifacts usually published here"),
                 )
                 .add_location(
                     step.location()
                         .primary()
-                        .with_keys(&[yaml_key.into()])
+                        .with_keys([yaml_key.into()])
                         .annotated(annotation),
                 ),
         };

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -348,7 +348,7 @@ impl CachePoisoning {
                     key: step.location().key,
                     disposition: FixDisposition::default(),
                     patches: vec![Patch {
-                        route: step.route().into(),
+                        route: step.route(),
                         operation: Op::MergeInto {
                             key: "with".to_string(),
                             updates: IndexMap::from([(field_name.to_string(), field_value)]),

--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -29,7 +29,7 @@ impl Audit for DangerousTriggers {
                         workflow
                             .location()
                             .primary()
-                            .with_keys(&["on".into()])
+                            .with_keys(["on".into()])
                             .annotated("pull_request_target is almost always used insecurely"),
                     )
                     .build(workflow)?,
@@ -44,7 +44,7 @@ impl Audit for DangerousTriggers {
                         workflow
                             .location()
                             .primary()
-                            .with_keys(&["on".into()])
+                            .with_keys(["on".into()])
                             .annotated("workflow_run is almost always used insecurely"),
                     )
                     .build(workflow)?,

--- a/crates/zizmor/src/audit/excessive_permissions.rs
+++ b/crates/zizmor/src/audit/excessive_permissions.rs
@@ -159,14 +159,14 @@ impl ExcessivePermissions {
                     Severity::Medium,
                     Confidence::High,
                     location
-                        .with_keys(&["permissions".into()])
+                        .with_keys(["permissions".into()])
                         .annotated("uses read-all permissions"),
                 )),
                 BasePermission::WriteAll => results.push((
                     Severity::High,
                     Confidence::High,
                     location
-                        .with_keys(&["permissions".into()])
+                        .with_keys(["permissions".into()])
                         .annotated("uses write-all permissions"),
                 )),
             },
@@ -186,7 +186,7 @@ impl ExcessivePermissions {
                         *severity,
                         Confidence::High,
                         location
-                            .with_keys(&["permissions".into(), name.as_str().into()])
+                            .with_keys(["permissions".into(), name.as_str().into()])
                             .annotated(format!(
                                 "{name}: write is overly broad at the workflow level"
                             )),
@@ -219,14 +219,14 @@ impl ExcessivePermissions {
                     Severity::Medium,
                     Confidence::High,
                     location
-                        .with_keys(&["permissions".into()])
+                        .with_keys(["permissions".into()])
                         .annotated("uses read-all permissions"),
                 )),
                 BasePermission::WriteAll => Some((
                     Severity::High,
                     Confidence::High,
                     location
-                        .with_keys(&["permissions".into()])
+                        .with_keys(["permissions".into()])
                         .annotated("uses write-all permissions"),
                 )),
             },

--- a/crates/zizmor/src/audit/forbidden_uses.rs
+++ b/crates/zizmor/src/audit/forbidden_uses.rs
@@ -55,7 +55,7 @@ impl ForbiddenUses {
                     .add_location(
                         step.location()
                             .primary()
-                            .with_keys(&["uses".into()])
+                            .with_keys(["uses".into()])
                             .annotated("use of this action is forbidden"),
                     )
                     .build(step)?,

--- a/crates/zizmor/src/audit/github_env.rs
+++ b/crates/zizmor/src/audit/github_env.rs
@@ -410,7 +410,7 @@ impl Audit for GitHubEnv {
                         .add_location(
                             step.location()
                                 .primary()
-                                .with_keys(&["run".into()])
+                                .with_keys(["run".into()])
                                 .annotated(format!("write to {dest} may allow code execution")),
                         )
                         .build(step.workflow())?,
@@ -440,7 +440,7 @@ impl Audit for GitHubEnv {
                     .add_location(
                         step.location()
                             .primary()
-                            .with_keys(&["run".into()])
+                            .with_keys(["run".into()])
                             .annotated(format!("write to {dest} may allow code execution")),
                     )
                     .build(step.action())?,

--- a/crates/zizmor/src/audit/hardcoded_container_credentials.rs
+++ b/crates/zizmor/src/audit/hardcoded_container_credentials.rs
@@ -55,7 +55,7 @@ impl Audit for HardcodedContainerCredentials {
                             .add_location(
                                 job.location()
                                     .primary()
-                                    .with_keys(&["container".into(), "credentials".into()])
+                                    .with_keys(["container".into(), "credentials".into()])
                                     .annotated("container registry password is hard-coded"),
                             )
                             .build(workflow)?,
@@ -82,7 +82,7 @@ impl Audit for HardcodedContainerCredentials {
                                 .add_location(
                                     job.location()
                                         .primary()
-                                        .with_keys(&[
+                                        .with_keys([
                                             "services".into(),
                                             service.as_str().into(),
                                             "credentials".into(),

--- a/crates/zizmor/src/audit/insecure_commands.rs
+++ b/crates/zizmor/src/audit/insecure_commands.rs
@@ -32,7 +32,7 @@ impl InsecureCommands {
             .severity(Severity::High)
             .persona(Persona::Auditor)
             .add_location(
-                location.primary().with_keys(&["env".into()]).annotated(
+                location.primary().with_keys(["env".into()]).annotated(
                     "non-static environment may contain ACTIONS_ALLOW_UNSECURE_COMMANDS",
                 ),
             )
@@ -50,7 +50,7 @@ impl InsecureCommands {
             .add_location(
                 location
                     .primary()
-                    .with_keys(&["env".into()])
+                    .with_keys(["env".into()])
                     .annotated("insecure commands enabled here"),
             )
             .build(doc)

--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -131,7 +131,7 @@ impl KnownVulnerableActions {
                     .add_location(
                         step.location()
                             .primary()
-                            .with_keys(&["uses".into()])
+                            .with_keys(["uses".into()])
                             .annotated(&id)
                             .with_url(format!("https://github.com/advisories/{id}")),
                     )

--- a/crates/zizmor/src/audit/obfuscation.rs
+++ b/crates/zizmor/src/audit/obfuscation.rs
@@ -110,7 +110,7 @@ impl Obfuscation {
                         .add_location(
                             step.location()
                                 .primary()
-                                .with_keys(&["uses".into()])
+                                .with_keys(["uses".into()])
                                 .annotated(annotation),
                         )
                         .build(step)?,

--- a/crates/zizmor/src/audit/ref_confusion.rs
+++ b/crates/zizmor/src/audit/ref_confusion.rs
@@ -90,7 +90,7 @@ impl Audit for RefConfusion {
                                     .add_location(
                                         step.location()
                                             .primary()
-                                            .with_keys(&["uses".into()])
+                                            .with_keys(["uses".into()])
                                             .annotated(REF_CONFUSION_ANNOTATION),
                                     )
                                     .build(workflow)?,
@@ -139,7 +139,7 @@ impl Audit for RefConfusion {
                     .add_location(
                         step.location()
                             .primary()
-                            .with_keys(&["uses".into()])
+                            .with_keys(["uses".into()])
                             .annotated(REF_CONFUSION_ANNOTATION),
                     )
                     .build(step.action())?,

--- a/crates/zizmor/src/audit/secrets_inherit.rs
+++ b/crates/zizmor/src/audit/secrets_inherit.rs
@@ -34,12 +34,12 @@ impl Audit for SecretsInherit {
                     .add_location(
                         job.location()
                             .primary()
-                            .with_keys(&["uses".into()])
+                            .with_keys(["uses".into()])
                             .annotated("this reusable workflow"),
                     )
                     .add_location(
                         job.location()
-                            .with_keys(&["secrets".into()])
+                            .with_keys(["secrets".into()])
                             .annotated("inherits all parent secrets"),
                     )
                     .confidence(Confidence::High)

--- a/crates/zizmor/src/audit/self_hosted_runner.rs
+++ b/crates/zizmor/src/audit/self_hosted_runner.rs
@@ -63,7 +63,7 @@ impl Audit for SelfHostedRunner {
                                     .add_location(
                                         job.location()
                                             .primary()
-                                            .with_keys(&["runs-on".into()])
+                                            .with_keys(["runs-on".into()])
                                             .annotated("self-hosted runner used here"),
                                     )
                                     .build(workflow)?,
@@ -81,7 +81,7 @@ impl Audit for SelfHostedRunner {
                                     .add_location(
                                         job.location()
                                             .primary()
-                                            .with_keys(&["runs-on".into()])
+                                            .with_keys(["runs-on".into()])
                                             .annotated(
                                                 "expression may expand into a self-hosted runner",
                                             ),
@@ -104,7 +104,7 @@ impl Audit for SelfHostedRunner {
                         .add_location(
                             job.location()
                                 .primary()
-                                .with_keys(&["runs-on".into()])
+                                .with_keys(["runs-on".into()])
                                 .annotated("runner group implies self-hosted runner"),
                         )
                         .build(workflow)?,
@@ -130,13 +130,13 @@ impl Audit for SelfHostedRunner {
                                 .persona(Persona::Auditor)
                                 .add_location(
                                     job.location()
-                                        .with_keys(&["strategy".into()])
+                                        .with_keys(["strategy".into()])
                                         .annotated("matrix declares self-hosted runner"),
                                 )
                                 .add_location(
                                     job.location()
                                         .primary()
-                                        .with_keys(&["runs-on".into()])
+                                        .with_keys(["runs-on".into()])
                                         .annotated(
                                             "expression may expand into a self-hosted runner",
                                         ),

--- a/crates/zizmor/src/audit/stale_action_refs.rs
+++ b/crates/zizmor/src/audit/stale_action_refs.rs
@@ -47,7 +47,7 @@ impl StaleActionRefs {
                     .confidence(Confidence::High)
                     .severity(Severity::Low)
                     .persona(Persona::Pedantic)
-                    .add_location(step.location().primary().with_keys(&["uses".into()]))
+                    .add_location(step.location().primary().with_keys(["uses".into()]))
                     .build(step)?,
             );
         }

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -284,7 +284,7 @@ impl TemplateInjection {
 
         let mut patches = vec![];
         patches.push(Patch {
-            route: step.route().with_keys(["run".into()]),
+            route: step.route().with_key("run"),
             operation: Op::RewriteFragment {
                 from: raw.as_raw().to_string().into(),
                 to: format!("${{{env_var}}}").into(),

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -130,16 +130,16 @@ impl TemplateInjection {
                         .map(|script| {
                             (
                                 script,
-                                step.location().with_keys(&["with".into(), input.into()]),
+                                step.location().with_keys(["with".into(), input.into()]),
                                 vec![
                                     // TODO: Plumb the step name/id as a related
                                     // location here and below; this will require us
                                     // to add it to StepCommon.
                                     step.location()
-                                        .with_keys(&["uses".into()])
+                                        .with_keys(["uses".into()])
                                         .annotated("action accepts arbitrary code"),
                                     step.location()
-                                        .with_keys(&["with".into(), input.into()])
+                                        .with_keys(["with".into(), input.into()])
                                         .annotated("via this input")
                                         .key_only(),
                                 ],
@@ -150,10 +150,10 @@ impl TemplateInjection {
             models::StepBodyCommon::Run { run, .. } => {
                 vec![(
                     run,
-                    step.location().with_keys(&["run".into()]),
+                    step.location().with_keys(["run".into()]),
                     vec![
                         step.location()
-                            .with_keys(&["run".into()])
+                            .with_keys(["run".into()])
                             .annotated("this run block")
                             .key_only(),
                     ],
@@ -284,7 +284,7 @@ impl TemplateInjection {
 
         let mut patches = vec![];
         patches.push(Patch {
-            route: step.route().with_keys(&["run".into()]).into(),
+            route: step.route().with_keys(["run".into()]).into(),
             operation: Op::RewriteFragment {
                 from: raw.as_raw().to_string().into(),
                 to: format!("${{{env_var}}}").into(),

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -284,7 +284,7 @@ impl TemplateInjection {
 
         let mut patches = vec![];
         patches.push(Patch {
-            route: step.route().with_keys(["run".into()]).into(),
+            route: step.route().with_keys(["run".into()]),
             operation: Op::RewriteFragment {
                 from: raw.as_raw().to_string().into(),
                 to: format!("${{{env_var}}}").into(),
@@ -300,7 +300,7 @@ impl TemplateInjection {
             .contains(&env_var.as_str())
         {
             patches.push(Patch {
-                route: step.route().into(),
+                route: step.route(),
                 operation: Op::MergeInto {
                     key: "env".to_string(),
                     updates: indexmap::IndexMap::from_iter([(

--- a/crates/zizmor/src/audit/unpinned_images.rs
+++ b/crates/zizmor/src/audit/unpinned_images.rs
@@ -58,7 +58,7 @@ impl Audit for UnpinnedImages {
                 image.parse().unwrap(),
                 job.location()
                     .primary()
-                    .with_keys(&["container".into(), "image".into()]),
+                    .with_keys(["container".into(), "image".into()]),
             ));
         }
 
@@ -66,7 +66,7 @@ impl Audit for UnpinnedImages {
             if let Container::Container { image, .. } = &config {
                 image_refs_with_locations.push((
                     image.parse().unwrap(),
-                    job.location().primary().with_keys(&[
+                    job.location().primary().with_keys([
                         "services".into(),
                         service.as_str().into(),
                         "image".into(),

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -106,7 +106,7 @@ impl UnpinnedUses {
                     .add_location(
                         step.location()
                             .primary()
-                            .with_keys(&["uses".into()])
+                            .with_keys(["uses".into()])
                             .annotated(annotation),
                     )
                     .build(step)?,

--- a/crates/zizmor/src/audit/unsound_contains.rs
+++ b/crates/zizmor/src/audit/unsound_contains.rs
@@ -67,7 +67,7 @@ impl Audit for UnsoundContains {
                         .severity(severity)
                         .confidence(Confidence::High)
                         .add_location(
-                            loc.with_keys(&["if".into()])
+                            loc.with_keys(["if".into()])
                                 .primary()
                                 .annotated(format!("contains(..) condition can be bypassed if attacker can control '{context}'")),
                         )

--- a/crates/zizmor/src/audit/use_trusted_publishing.rs
+++ b/crates/zizmor/src/audit/use_trusted_publishing.rs
@@ -45,7 +45,7 @@ impl UseTrustedPublishing {
             .add_location(
                 step.location()
                     .primary()
-                    .with_keys(&["uses".into()])
+                    .with_keys(["uses".into()])
                     .annotated("this step"),
             );
 
@@ -57,7 +57,7 @@ impl UseTrustedPublishing {
                     .add_location(
                         step.location()
                             .primary()
-                            .with_keys(&["with".into(), "password".into()])
+                            .with_keys(["with".into(), "password".into()])
                             .annotated(USES_MANUAL_CREDENTIAL),
                     )
                     .build(step)?,

--- a/crates/zizmor/src/finding/location.rs
+++ b/crates/zizmor/src/finding/location.rs
@@ -304,13 +304,7 @@ impl<'doc> SymbolicLocation<'doc> {
                 )
             }
             SymbolicFeature::KeyOnly => {
-                let feature = match self.route.is_empty() {
-                    false => document.query_key_only(&self.route)?,
-                    true => {
-                        // NOTE: Technically API misuse; maybe we should panic instead?
-                        anyhow::bail!("can't concretize a key-only route without a query");
-                    }
-                };
+                let feature = document.query_key_only(&self.route)?;
 
                 (
                     document.extract(&feature),

--- a/crates/zizmor/src/finding/location.rs
+++ b/crates/zizmor/src/finding/location.rs
@@ -266,19 +266,16 @@ impl<'doc> SymbolicLocation<'doc> {
             SymbolicFeature::Subfeature(subfeature) => {
                 // If we have a subfeature, we have to extract its exact
                 // parent feature.
-                let feature = match self.route.is_empty() {
-                    false => document.query_exact(&self.route)?.ok_or_else(|| {
-                        // This should never fail in practice, unless our
-                        // route is malformed or ends in a key-only feature
-                        // (e.g. `foo:`). The latter shouldn't really happen,
-                        // since there's no meaningful subfeature in that case.
-                        anyhow::anyhow!(
-                            "failed to extract exact feature for symbolic location: {}",
-                            self.annotation
-                        )
-                    })?,
-                    true => document.root(),
-                };
+                let feature = document.query_exact(&self.route)?.ok_or_else(|| {
+                    // This should never fail in practice, unless our
+                    // route is malformed or ends in a key-only feature
+                    // (e.g. `foo:`). The latter shouldn't really happen,
+                    // since there's no meaningful subfeature in that case.
+                    anyhow::anyhow!(
+                        "failed to extract exact feature for symbolic location: {}",
+                        self.annotation
+                    )
+                })?;
 
                 let extracted = document.extract(&feature);
 
@@ -298,10 +295,7 @@ impl<'doc> SymbolicLocation<'doc> {
                 )
             }
             SymbolicFeature::Normal => {
-                let feature = match self.route.is_empty() {
-                    false => document.query_pretty(&self.route)?,
-                    true => document.root(),
-                };
+                let feature = document.query_pretty(&self.route)?;
 
                 (
                     document.extract_with_leading_whitespace(&feature),

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -10,7 +10,7 @@ use terminal_link::Link;
 
 use crate::{
     InputKey,
-    finding::location::{Locatable, Route, SymbolicFeature, SymbolicLocation},
+    finding::location::{Locatable, SymbolicFeature, SymbolicLocation},
     models::{
         AsDocument, StepBodyCommon, StepCommon,
         inputs::{Capability, HasInputs},
@@ -97,7 +97,7 @@ impl Action {
             key: &self.key,
             annotation: "this action".to_string(),
             link: None,
-            route: Route::new(),
+            route: Default::default(),
             feature_kind: SymbolicFeature::Normal,
             kind: Default::default(),
         }
@@ -155,7 +155,7 @@ impl<'a> std::ops::Deref for CompositeStep<'a> {
 
 impl<'doc> Locatable<'doc> for CompositeStep<'doc> {
     fn location(&self) -> SymbolicLocation<'doc> {
-        self.parent.location().annotated("this step").with_keys(&[
+        self.parent.location().annotated("this step").with_keys([
             "runs".into(),
             "steps".into(),
             self.index.into(),
@@ -164,7 +164,7 @@ impl<'doc> Locatable<'doc> for CompositeStep<'doc> {
 
     fn location_with_name(&self) -> SymbolicLocation<'doc> {
         match self.inner.name {
-            Some(_) => self.location().with_keys(&["name".into()]),
+            Some(_) => self.location().with_keys(["name".into()]),
             None => self.location(),
         }
     }

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -20,7 +20,7 @@ use terminal_link::Link;
 
 use crate::{
     InputKey,
-    finding::location::{Locatable, Route, SymbolicFeature, SymbolicLocation},
+    finding::location::{Locatable, SymbolicFeature, SymbolicLocation},
     models::{
         AsDocument, StepBodyCommon, StepCommon,
         inputs::{Capability, HasInputs},
@@ -195,7 +195,7 @@ impl Workflow {
             key: &self.key,
             annotation: "this workflow".to_string(),
             link: None,
-            route: Route::new(),
+            route: Default::default(),
             feature_kind: SymbolicFeature::Normal,
             kind: Default::default(),
         }
@@ -337,12 +337,12 @@ impl<'doc, T: JobExt<'doc>> Locatable<'doc> for T {
         self.parent()
             .location()
             .annotated("this job")
-            .with_keys(&["jobs".into(), self.id().into()])
+            .with_keys(["jobs".into(), self.id().into()])
     }
 
     fn location_with_name(&self) -> SymbolicLocation<'doc> {
         match self.name() {
-            Some(_) => self.location().with_keys(&["name".into()]),
+            Some(_) => self.location().with_keys(["name".into()]),
             None => self.location(),
         }
     }
@@ -581,13 +581,13 @@ impl<'doc> Locatable<'doc> for Step<'doc> {
     fn location(&self) -> SymbolicLocation<'doc> {
         self.parent
             .location()
-            .with_keys(&["steps".into(), self.index.into()])
+            .with_keys(["steps".into(), self.index.into()])
             .annotated("this step")
     }
 
     fn location_with_name(&self) -> SymbolicLocation<'doc> {
         match self.inner.name {
-            Some(_) => self.location().with_keys(&["name".into()]),
+            Some(_) => self.location().with_keys(["name".into()]),
             None => self.location(),
         }
     }

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -84,10 +84,10 @@ error[artipacked]: credential persistence through GitHub Actions artifacts
    = note: this finding has an auto-fix
 
 warning[excessive-permissions]: overly broad permissions
-  --> .github/workflows/artipacked.yml:1:1
+  --> .github/workflows/artipacked.yml:21:1
    |
- 1 | / # artipacked.yml
- 2 | | #
+21 | / on:
+22 | |   push:
 ...  |
 84 | |           name: workspace
 85 | |           path: ${{ github.workspace }}
@@ -201,10 +201,10 @@ error[bot-conditions]: spoofable bot actor check
    = note: this finding has an auto-fix
 
 warning[excessive-permissions]: overly broad permissions
-  --> .github/workflows/cache-poisoning.yml:1:1
+  --> .github/workflows/cache-poisoning.yml:22:1
    |
- 1 | / # cache-poisoning.yml
- 2 | | #
+22 | / on: release
+23 | |
 ...  |
 57 | |       - name: Publish on crates.io
 58 | |         run: cargo publish --token ${{ secrets.CRATESIO_PUBLISH_TOKEN }}
@@ -702,10 +702,10 @@ error[unpinned-uses]: unpinned action reference
    = note: audit confidence → High
 
 warning[excessive-permissions]: overly broad permissions
-  --> .github/workflows/secrets-inherit.yml:1:1
+  --> .github/workflows/secrets-inherit.yml:12:1
    |
- 1 | / # secrets-inherit.yml
- 2 | | #
+12 | / on: push
+13 | |
 ...  |
 32 | |     # OK: no secrets forwarded
 33 | |     secrets: {}
@@ -796,10 +796,10 @@ warning[excessive-permissions]: overly broad permissions
    = note: audit confidence → Medium
 
 warning[excessive-permissions]: overly broad permissions
-   --> .github/workflows/template-injection.yml:1:1
+   --> .github/workflows/template-injection.yml:20:1
     |
-  1 | / # template-injection.yml
-  2 | | #
+ 20 | / name: example
+ 21 | | on:
 ...   |
 127 | |         run: |
 128 | |           ${{ some.context == 'success' }}

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__anonymous_definition.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"anonymous-definition.yml\")).args([\"--persona=pedantic\"]).run()?"
+snapshot_kind: text
 ---
 help[anonymous-definition]: workflow or action definition without a name
-  --> @@INPUT@@:1:1
+  --> @@INPUT@@:5:1
    |
- 1 | / # see https://github.com/zizmorcore/zizmor/issues/795
- 2 | |
+ 5 | / on:
+ 6 | |   issues:
 ...  |
 19 | |     steps:
 20 | |       - run: "echo this job will trigger"

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-3.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-3.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-default-perms.yml\")).args([\"--pedantic\"]).run()?"
+snapshot_kind: text
 ---
 warning[excessive-permissions]: overly broad permissions
-  --> @@INPUT@@:1:1
+  --> @@INPUT@@:5:1
    |
- 1 | / # two findings in pedantic mode: one for the entire workflow for having
- 2 | | # implicit permissions (pedantic), and one for the 'single' job for having
+ 5 | / on: push
+ 6 | |
 ...  |
 15 | |         with:
 16 | |           persist-credentials: false

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-5.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__unpinned_uses-5.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"unpinned-uses/issue-659-repro.yml\")).args([\"--pedantic\"]).run()?"
+snapshot_kind: text
 ---
 warning[excessive-permissions]: overly broad permissions
-  --> @@INPUT@@:1:1
+  --> @@INPUT@@:2:1
    |
- 1 | / # minimized from https://raw.githubusercontent.com/docker/actions-toolkit/59501e62b/.github/workflows/test.yml
- 2 | | name: issue-659-repro
+ 2 | / name: issue-659-repro
+ 3 | |
 ...  |
 19 | |         with:
 20 | |           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
This dedupes our various route/query types, centralizing on a single `yamlpath::Route`.