### PR TITLE
Use older Ubuntu runners for Debian compatibility

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - runner: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
Debian stable's GCC is too far behind ubuntu-latest, which means the
binaries won't work on Debian.

Fixes #1017

Signed-off-by: Ben Cotton <ben@kusari.dev>