### PR TITLE
refactor: isolate json-v1 output format

### DIFF
--- a/crates/zizmor/src/finding.rs
+++ b/crates/zizmor/src/finding.rs
@@ -94,7 +94,7 @@ pub(crate) enum Severity {
 }
 
 /// A finding's "determination," i.e. its various classifications.
-#[derive(Serialize)]
+#[derive(Copy, Clone, Serialize)]
 pub(crate) struct Determinations {
     pub(crate) confidence: Confidence,
     pub(crate) severity: Severity,
@@ -141,7 +141,6 @@ impl Fix<'_> {
     }
 }
 
-#[derive(Serialize)]
 pub(crate) struct Finding<'doc> {
     /// The audit ID for this finding, e.g. `template-injection`.
     pub(crate) ident: &'static str,
@@ -163,7 +162,6 @@ pub(crate) struct Finding<'doc> {
     /// One or more suggested fixes for this finding. Because a finding
     /// can span multiple inputs, each fix is associated with a specific
     /// input via [`Fix::key`].
-    #[serde(skip_serializing)]
     pub(crate) fixes: Vec<Fix<'doc>>,
 }
 

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -684,7 +684,7 @@ fn run() -> Result<ExitCode> {
     match app.format {
         OutputFormat::Plain => output::plain::render_findings(&app, &registry, &results),
         OutputFormat::Json | OutputFormat::JsonV1 => {
-            serde_json::to_writer_pretty(stdout(), &results.findings())?
+            output::json::v1::output(stdout(), results.findings())?
         }
         OutputFormat::Sarif => {
             serde_json::to_writer_pretty(stdout(), &output::sarif::build(results.findings()))?

--- a/crates/zizmor/src/output/json/mod.rs
+++ b/crates/zizmor/src/output/json/mod.rs
@@ -1,0 +1,3 @@
+//! zizmor's JSON output formats.
+
+pub(crate) mod v1;

--- a/crates/zizmor/src/output/json/v1.rs
+++ b/crates/zizmor/src/output/json/v1.rs
@@ -1,0 +1,48 @@
+//! zizmor's "v1" JSON output format.
+//!
+//! The "v1" format is a flat array of findings, each represented as an object.
+//!
+//! This was originally represented as an exact dump of zizmor's internal
+//! [`Finding`] type, leading to both development friction and unnecessary
+//! user disruption when the internal representation changed.
+
+use std::io;
+
+use crate::finding;
+
+// NOTE: Internally this format still uses a lot of zizmor's internal types.
+// As those change, this module will gain "frozen" copies with converters.
+
+#[derive(serde::Serialize)]
+struct V1Finding<'a> {
+    ident: &'a str,
+    desc: &'a str,
+    url: &'a str,
+    determinations: finding::Determinations,
+    locations: &'a [finding::location::Location<'a>],
+    ignored: bool,
+}
+
+impl<'a> From<&'a finding::Finding<'a>> for V1Finding<'a> {
+    fn from(finding: &'a finding::Finding<'a>) -> Self {
+        Self {
+            ident: finding.ident,
+            desc: finding.desc,
+            url: finding.url,
+            determinations: finding.determinations,
+            locations: &finding.locations,
+            ignored: finding.ignored,
+        }
+    }
+}
+
+pub(crate) fn output<'a>(
+    sink: impl io::Write,
+    findings: &[finding::Finding<'a>],
+) -> anyhow::Result<()> {
+    serde_json::to_writer_pretty(
+        sink,
+        &findings.iter().map(V1Finding::from).collect::<Vec<_>>(),
+    )?;
+    Ok(())
+}

--- a/crates/zizmor/src/output/mod.rs
+++ b/crates/zizmor/src/output/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod fix;
 pub(crate) mod github;
+pub(crate) mod json;
 pub(crate) mod plain;
 pub(crate) mod sarif;

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 
 use crate::common::{OutputMode, input_under_test, zizmor};
 
+mod json_v1;
+
 #[cfg_attr(not(feature = "gh-token-tests"), ignore)]
 #[test]
 fn gha_hazmat() -> Result<()> {

--- a/crates/zizmor/tests/integration/e2e/json_v1.rs
+++ b/crates/zizmor/tests/integration/e2e/json_v1.rs
@@ -1,0 +1,18 @@
+//! End-to-end integration tests for `--format=json-v1`.
+
+use insta::assert_snapshot;
+
+use crate::common::{input_under_test, zizmor};
+
+#[test]
+fn test_json_v1() {
+    let output = zizmor()
+        .args(["--format=json-v1"])
+        .input(input_under_test("template-injection.yml"))
+        .input(input_under_test("unpinned-uses.yml"))
+        .input(input_under_test("unsound-contains.yml"))
+        .run()
+        .expect("Failed to run zizmor with JSON v1 format");
+
+    assert_snapshot!(output);
+}

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__json_v1__json_v1.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__json_v1__json_v1.snap
@@ -1,0 +1,675 @@
+---
+source: crates/zizmor/tests/integration/e2e/json_v1.rs
+expression: output
+snapshot_kind: text
+---
+[
+  {
+    "ident": "template-injection",
+    "desc": "code injection via template expansion",
+    "url": "https://docs.zizmor.sh/audits/#template-injection",
+    "determinations": {
+      "confidence": "High",
+      "severity": "High",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "this step",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "inject-me"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 0
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Hidden"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 15,
+              "column": 8
+            },
+            "end_point": {
+              "row": 19,
+              "column": 0
+            },
+            "offset_span": {
+              "start": 241,
+              "end": 425
+            }
+          },
+          "feature": "uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # tag=v7.0.1\n        with:\n          script: |\n            return \"doing a thing: ${{ github.event.issue.title }}\"\n",
+          "comments": [
+            "# tag=v7.0.1"
+          ]
+        }
+      },
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "may expand into attacker-controllable code",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "inject-me"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 0
+              },
+              {
+                "Key": "with"
+              },
+              {
+                "Key": "script"
+              }
+            ]
+          },
+          "feature_kind": {
+            "Subfeature": {
+              "after": 24,
+              "fragment": {
+                "Raw": "github.event.issue.title"
+              }
+            }
+          },
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 18,
+              "column": 39
+            },
+            "end_point": {
+              "row": 18,
+              "column": 63
+            },
+            "offset_span": {
+              "start": 396,
+              "end": 420
+            }
+          },
+          "feature": "|\n            return \"doing a thing: ${{ github.event.issue.title }}\"\n",
+          "comments": []
+        }
+      },
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "action accepts arbitrary code",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "inject-me"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 0
+              },
+              {
+                "Key": "uses"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Related"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 15,
+              "column": 8
+            },
+            "end_point": {
+              "row": 15,
+              "column": 76
+            },
+            "offset_span": {
+              "start": 241,
+              "end": 309
+            }
+          },
+          "feature": "uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea",
+          "comments": [
+            "# tag=v7.0.1"
+          ]
+        }
+      },
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "via this input",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "inject-me"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 0
+              },
+              {
+                "Key": "with"
+              },
+              {
+                "Key": "script"
+              }
+            ]
+          },
+          "feature_kind": "KeyOnly",
+          "kind": "Related"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 17,
+              "column": 10
+            },
+            "end_point": {
+              "row": 17,
+              "column": 16
+            },
+            "offset_span": {
+              "start": 347,
+              "end": 353
+            }
+          },
+          "feature": "script",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unpinned-uses",
+    "desc": "unpinned action reference",
+    "url": "https://docs.zizmor.sh/audits/#unpinned-uses",
+    "determinations": {
+      "confidence": "High",
+      "severity": "Medium",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "action is not pinned to a tag, branch, or hash ref",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "unpinned-0"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 1
+              },
+              {
+                "Key": "uses"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 16,
+              "column": 8
+            },
+            "end_point": {
+              "row": 16,
+              "column": 29
+            },
+            "offset_span": {
+              "start": 279,
+              "end": 300
+            }
+          },
+          "feature": "uses: docker://ubuntu",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unpinned-uses",
+    "desc": "unpinned action reference",
+    "url": "https://docs.zizmor.sh/audits/#unpinned-uses",
+    "determinations": {
+      "confidence": "High",
+      "severity": "Medium",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "action is not pinned to a tag, branch, or hash ref",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "unpinned-0"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 2
+              },
+              {
+                "Key": "uses"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 22,
+              "column": 8
+            },
+            "end_point": {
+              "row": 22,
+              "column": 58
+            },
+            "offset_span": {
+              "start": 404,
+              "end": 454
+            }
+          },
+          "feature": "uses: docker://ghcr.io/pypa/gh-action-pypi-publish",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unsound-contains",
+    "desc": "unsound contains condition",
+    "url": "https://docs.zizmor.sh/audits/#unsound-contains",
+    "determinations": {
+      "confidence": "High",
+      "severity": "High",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "contains(..) condition can be bypassed if attacker can control 'github.ref'",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "hackme"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 0
+              },
+              {
+                "Key": "if"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 19,
+              "column": 8
+            },
+            "end_point": {
+              "row": 19,
+              "column": 77
+            },
+            "offset_span": {
+              "start": 274,
+              "end": 343
+            }
+          },
+          "feature": "        if: ${{ contains('refs/heads/main refs/heads/develop', github.ref) }}",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unsound-contains",
+    "desc": "unsound contains condition",
+    "url": "https://docs.zizmor.sh/audits/#unsound-contains",
+    "determinations": {
+      "confidence": "High",
+      "severity": "High",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "contains(..) condition can be bypassed if attacker can control 'env.GITHUB_REF_NAME'",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "hackme"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 1
+              },
+              {
+                "Key": "if"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 23,
+              "column": 8
+            },
+            "end_point": {
+              "row": 23,
+              "column": 64
+            },
+            "offset_span": {
+              "start": 404,
+              "end": 460
+            }
+          },
+          "feature": "        if: ${{ contains('main,develop', env.GITHUB_REF_NAME) }}",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unsound-contains",
+    "desc": "unsound contains condition",
+    "url": "https://docs.zizmor.sh/audits/#unsound-contains",
+    "determinations": {
+      "confidence": "High",
+      "severity": "High",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "contains(..) condition can be bypassed if attacker can control 'github.ref_name'",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "hackme"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 2
+              },
+              {
+                "Key": "if"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 27,
+              "column": 8
+            },
+            "end_point": {
+              "row": 27,
+              "column": 120
+            },
+            "offset_span": {
+              "start": 521,
+              "end": 633
+            }
+          },
+          "feature": "        if: contains('main,prod', github.ref_name) || contains('longusername anotherlongusername', github.actor) == true",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unsound-contains",
+    "desc": "unsound contains condition",
+    "url": "https://docs.zizmor.sh/audits/#unsound-contains",
+    "determinations": {
+      "confidence": "High",
+      "severity": "High",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "contains(..) condition can be bypassed if attacker can control 'github.actor'",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "hackme"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 2
+              },
+              {
+                "Key": "if"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 27,
+              "column": 8
+            },
+            "end_point": {
+              "row": 27,
+              "column": 120
+            },
+            "offset_span": {
+              "start": 521,
+              "end": 633
+            }
+          },
+          "feature": "        if: contains('main,prod', github.ref_name) || contains('longusername anotherlongusername', github.actor) == true",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  },
+  {
+    "ident": "unsound-contains",
+    "desc": "unsound contains condition",
+    "url": "https://docs.zizmor.sh/audits/#unsound-contains",
+    "determinations": {
+      "confidence": "High",
+      "severity": "Informational",
+      "persona": "Regular"
+    },
+    "locations": [
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "prefix": null,
+              "given_path": "@@INPUT@@"
+            }
+          },
+          "annotation": "contains(..) condition can be bypassed if attacker can control 'runner.name'",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "hackme"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 3
+              },
+              {
+                "Key": "if"
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Primary"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 31,
+              "column": 8
+            },
+            "end_point": {
+              "row": 31,
+              "column": 52
+            },
+            "offset_span": {
+              "start": 719,
+              "end": 763
+            }
+          },
+          "feature": "        if: contains('runner1,runner2', runner.name)",
+          "comments": []
+        }
+      }
+    ],
+    "ignored": false
+  }
+]


### PR DESCRIPTION
This is a non-breaking change, just in preparation for an eventual "v2" JSON format: "v1" now has an isolated module and top-level serialization type, making it easier for me to make backwards incompatible changes in `Finding` going forwards.