### PR TITLE
refactor: generalize use-trusted-publishing audit

### DIFF
--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -34,7 +34,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/setup-java/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-java".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "cache",
+                ControlFieldType::FreeString,
+                false,
+            ),
         },
         // https://github.com/actions/setup-go/blob/main/action.yml
         ActionCoordinate::Configurable {
@@ -44,12 +49,22 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/setup-node/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-node".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "cache",
+                ControlFieldType::FreeString,
+                false,
+            ),
         },
         // https://github.com/actions/setup-python/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-python".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "cache",
+                ControlFieldType::FreeString,
+                false,
+            ),
         },
         // https://github.com/actions/setup-dotnet/blob/main/action.yml
         ActionCoordinate::Configurable {
@@ -62,7 +77,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
             control: ControlExpr::single(
                 Toggle::OptOut,
                 "enable-cache",
-                ControlFieldType::String,
+                ControlFieldType::Boolean,
                 true,
             ),
         },
@@ -129,7 +144,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/graalvm/setup-graalvm/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "graalvm/setup-graalvm".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "cache",
+                ControlFieldType::FreeString,
+                false,
+            ),
         },
         // https://github.com/gradle/actions/blob/main/setup-gradle/action.yml
         ActionCoordinate::Configurable {
@@ -151,7 +171,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                     ControlFieldType::Boolean,
                     true,
                 ),
-                ControlExpr::single(Toggle::OptIn, "version", ControlFieldType::String, false),
+                ControlExpr::single(
+                    Toggle::OptIn,
+                    "version",
+                    ControlFieldType::FreeString,
+                    false,
+                ),
             ]),
         },
         // https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml
@@ -337,8 +362,7 @@ impl CachePoisoning {
                     ),
                     // String control fields are action-specific and we can't reliably know
                     // what value disables caching (e.g., setup-node expects '' not 'false')
-                    (Toggle::OptIn, ControlFieldType::String)
-                    | (Toggle::OptOut, ControlFieldType::String) => {
+                    (Toggle::OptIn, _) | (Toggle::OptOut, _) => {
                         return None;
                     }
                 };
@@ -356,8 +380,8 @@ impl CachePoisoning {
                     }],
                 })
             }
-            // For complex control expressions (All/Any), don't provide automatic fixes for now
-            ControlExpr::All(_) | ControlExpr::Any(_) => None,
+            // For complex control expressions (All/Any/Not), don't provide automatic fixes for now
+            ControlExpr::All(_) | ControlExpr::Any(_) | ControlExpr::Not(_) => None,
         }
     }
 

--- a/crates/zizmor/src/audit/use_trusted_publishing.rs
+++ b/crates/zizmor/src/audit/use_trusted_publishing.rs
@@ -41,6 +41,11 @@ static KNOWN_TRUSTED_PUBLISHING_ACTIONS: LazyLock<Vec<(ActionCoordinate, &[&str]
                             ControlFieldType::FreeString,
                             false,
                         ),
+                        // TIP: On first glance you might think this should be
+                        // `any` instead, but observe that each of these control
+                        // expressions is marked with `enabled_by_default: true`.
+                        // If we used `any` we'd end up accidentally satisfying
+                        // when the user only sets one of the control fields.
                         ControlExpr::all([
                             ControlExpr::single(
                                 Toggle::OptIn,

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -13,10 +13,12 @@
 // able to express things like
 // "match foo/bar if foo: A and not bar: B and baz: /abcd/"
 
-use std::ops::{BitAnd, BitOr};
+use std::ops::{BitAnd, BitOr, Not};
 
-use github_actions_models::common::{EnvValue, Uses, expr::ExplicitExpr};
+use github_actions_models::common::{EnvValue, Uses};
 use indexmap::IndexMap;
+
+use crate::utils::ExtractedExpr;
 
 use super::{StepBodyCommon, StepCommon, uses::RepositoryUsesPattern};
 
@@ -89,8 +91,14 @@ pub(crate) enum Toggle {
 pub(crate) enum ControlFieldType {
     /// The behavior is controlled by a boolean field, e.g. `cache: true`.
     Boolean,
-    /// The behavior is controlled by a string field, e.g. `cache: "pip"`.
-    String,
+    /// The behavior is controlled by a "free" string field.
+    ///
+    /// This is effectively a "presence" check, i.e. is satisfied if
+    /// the field is present, regardless of its value.
+    FreeString,
+    /// The behavior is controlled by a "fixed" string field, i.e. only applies
+    /// when the field matches one of the given values.
+    Exact(&'static [&'static str]),
 }
 
 /// The result of evaluating a control expression.
@@ -105,6 +113,19 @@ pub(crate) enum ControlEvaluation {
     /// The control expression is conditionally satisfied,
     /// i.e. depends on an actions expression or similar.
     Conditional,
+}
+
+impl Not for ControlEvaluation {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            ControlEvaluation::DefaultSatisfied => ControlEvaluation::NotSatisfied,
+            ControlEvaluation::Satisfied => ControlEvaluation::NotSatisfied,
+            ControlEvaluation::NotSatisfied => ControlEvaluation::Satisfied,
+            ControlEvaluation::Conditional => ControlEvaluation::Conditional,
+        }
+    }
 }
 
 impl BitAnd for ControlEvaluation {
@@ -248,6 +269,8 @@ pub(crate) enum ControlExpr {
     /// Existential quantification: any of the fields must be satisfied.
     #[allow(dead_code)]
     Any(Vec<ControlExpr>),
+    /// Negation: the "opposite" of the expression's satisfaction.
+    Not(Box<ControlExpr>),
 }
 
 impl ControlExpr {
@@ -269,28 +292,64 @@ impl ControlExpr {
         Self::All(exprs.into_iter().collect())
     }
 
+    pub(crate) fn not(expr: ControlExpr) -> Self {
+        Self::Not(Box::new(expr))
+    }
+
     pub(crate) fn eval(&self, with: &IndexMap<String, EnvValue>) -> ControlEvaluation {
         match self {
             ControlExpr::Single {
                 toggle,
                 field_name,
-                field_type: _,
+                field_type,
                 satisfied_by_default: enabled_by_default,
             } => {
                 // If the controlling field is not present, the default dictates the semantics.
                 if let Some(field_value) = with.get(*field_name) {
-                    match field_value.to_string().as_str() {
-                        "false" => match toggle {
-                            Toggle::OptIn => ControlEvaluation::NotSatisfied,
-                            Toggle::OptOut => ControlEvaluation::Satisfied,
-                        },
-                        other => match ExplicitExpr::from_curly(other) {
-                            None => match toggle {
+                    match field_type {
+                        // We expect a boolean control.
+                        ControlFieldType::Boolean => match field_value.to_string().as_str() {
+                            "true" => match toggle {
                                 Toggle::OptIn => ControlEvaluation::Satisfied,
                                 Toggle::OptOut => ControlEvaluation::NotSatisfied,
                             },
-                            Some(_) => ControlEvaluation::Conditional,
+                            "false" => match toggle {
+                                Toggle::OptIn => ControlEvaluation::NotSatisfied,
+                                Toggle::OptOut => ControlEvaluation::Satisfied,
+                            },
+                            other => match ExtractedExpr::from_fenced(other) {
+                                // We have something like `foo: ${{ expr }}`,
+                                // which could evaluate either way.
+                                Some(_) => ControlEvaluation::Conditional,
+                                // We have something like `foo: bar`, but we
+                                // were expecting a boolean. Assume pessimistically
+                                // that the action coerces any non-`false` value to `true`.
+                                None => match toggle {
+                                    Toggle::OptIn => ControlEvaluation::Satisfied,
+                                    Toggle::OptOut => ControlEvaluation::NotSatisfied,
+                                },
+                            },
                         },
+                        // We expect a "free" string control, i.e. any value.
+                        // Evaluate just the toggle.
+                        ControlFieldType::FreeString => match toggle {
+                            Toggle::OptIn => ControlEvaluation::Satisfied,
+                            Toggle::OptOut => ControlEvaluation::NotSatisfied,
+                        },
+                        // We expect a "fixed" string control, i.e. one of a set of values.
+                        ControlFieldType::Exact(items) => {
+                            if items.contains(&field_value.to_string().as_str()) {
+                                match toggle {
+                                    Toggle::OptIn => ControlEvaluation::Satisfied,
+                                    Toggle::OptOut => ControlEvaluation::NotSatisfied,
+                                }
+                            } else {
+                                match toggle {
+                                    Toggle::OptIn => ControlEvaluation::NotSatisfied,
+                                    Toggle::OptOut => ControlEvaluation::Satisfied,
+                                }
+                            }
+                        }
                     }
                 } else if *enabled_by_default {
                     ControlEvaluation::DefaultSatisfied
@@ -306,6 +365,7 @@ impl ControlExpr {
                 .iter()
                 .map(|expr| expr.eval(with))
                 .fold(ControlEvaluation::NotSatisfied, |acc, expr| acc | expr),
+            ControlExpr::Not(expr) => !expr.eval(with),
         }
     }
 }

--- a/crates/zizmor/src/utils.rs
+++ b/crates/zizmor/src/utils.rs
@@ -412,7 +412,7 @@ impl<'a> ExtractedExpr<'a> {
     }
 
     /// Creates a new [`ExtractedExpr`] from a fenced expression.
-    fn from_fenced(expr: &'a str) -> Option<Self> {
+    pub(crate) fn from_fenced(expr: &'a str) -> Option<Self> {
         expr.strip_prefix("${{")
             .and_then(|e| e.strip_suffix("}}"))
             .map(|_| ExtractedExpr {

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__cache_poisoning-4.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__cache_poisoning-4.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"cache-poisoning/caching-opt-in-expression.yml\")).run()?"
+snapshot_kind: text
 ---
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1
@@ -16,5 +17,6 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    | |______________________________________________________________^ opt-in for caching might happen here
    |
    = note: audit confidence → Low
+   = note: this finding has an auto-fix
 
-1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high
+1 findings (1 fixable): 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__use_trusted_publishing.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__use_trusted_publishing.snap
@@ -1,16 +1,94 @@
 ---
 source: crates/zizmor/tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"use-trusted-publishing.yml\")).run()?"
+snapshot_kind: text
 ---
 info[use-trusted-publishing]: prefer trusted publishing for authentication
-  --> @@INPUT@@:16:9
+  --> @@INPUT@@:18:9
    |
-16 |         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+18 |         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
    |         -------------------------------------------- info: this step
-17 |         with:
-18 |           password: ${{ secrets.PYPI_TOKEN }}
+19 |         with:
+20 |           password: ${{ secrets.PYPI_TOKEN }}
    |           ----------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
    |
    = note: audit confidence → High
 
-3 findings (1 ignored, 1 suppressed): 0 unknown, 1 informational, 0 low, 0 medium, 0 high
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:25:9
+   |
+25 |         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+   |         -------------------------------------------- info: this step
+26 |         with:
+27 |           password: ${{ secrets.PYPI_TOKEN }}
+   |           ----------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:33:9
+   |
+33 |         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+   |         -------------------------------------------- info: this step
+34 |         with:
+35 |           password: ${{ secrets.PYPI_TOKEN }}
+   |           ----------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:51:9
+   |
+51 |         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+   |         -------------------------------------------- info: this step
+52 |         with:
+53 |           password: ${{ secrets.TEST_PYPI_TOKEN }}
+   |           ---------------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:58:9
+   |
+58 |         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+   |         -------------------------------------------- info: this step
+59 |         with:
+60 |           password: ${{ secrets.TEST_PYPI_TOKEN }}
+   |           ---------------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:65:9
+   |
+65 |         uses: rubygems/release-gem@v1 # zizmor: ignore[unpinned-uses]
+   |         ----------------------------- info: this step
+66 |         with:
+67 |           setup-trusted-publisher: false
+   |           ------------------------------ info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:82:9
+   |
+82 |         uses: rubygems/configure-rubygems-credentials@v1 # zizmor: ignore[unpinned-uses]
+   |         ------------------------------------------------ info: this step
+83 |         with:
+84 |           api-token: ${{ secrets.RUBYGEMS_API_TOKEN }}
+   |           -------------------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+info[use-trusted-publishing]: prefer trusted publishing for authentication
+  --> @@INPUT@@:95:9
+   |
+95 |         uses: rubygems/configure-rubygems-credentials@v1 # zizmor: ignore[unpinned-uses]
+   |         ------------------------------------------------ info: this step
+96 |         with:
+97 |           api-token: ${{ secrets.RUBYGEMS_API_TOKEN }}
+   |           -------------------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
+   |
+   = note: audit confidence → High
+
+25 findings (16 ignored, 1 suppressed): 0 unknown, 8 informational, 0 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/test-data/use-trusted-publishing.yml
+++ b/crates/zizmor/tests/integration/test-data/use-trusted-publishing.yml
@@ -12,7 +12,112 @@ jobs:
     permissions:
       id-token: write
     steps:
+      # NOT OK: password present and we know the default index supports
+      # trusted publishing.
+      - name: vulnerable-1
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+
+      # NOT OK: explicit repository-url, but for an index we know supports
+      # trusted publishing.
       - name: vulnerable-2
         uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+          repository-url: https://upload.pypi.org/legacy/
+
+      # NOT OK: explicit repository_url, but for an index we know supports
+      # trusted publishing.
+      - name: vulnerable-3
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          repository_url: https://upload.pypi.org/legacy/
+
+      # OK: no password, so we assume trusted publishing is used.
+      - name: not-vulnerable-4
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+
+      # OK: no passwords, so we assume trusted publishing is used,
+      # even with an explicit repository-url.
+      - name: not-vulnerable-5
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          repository-url: https://upload.pypi.org/legacy/
+
+      # NOT OK: like above, but with TestPyPI's repository-url.
+      - name: vulnerable-6
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      # NOT OK: like above, but with TestPyPI's repository_url.
+      - name: vulnerable-7
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      # NOT OK: rubygems/release-gem with setup-trusted-publisher: false
+      - name: vulnerable-8
+        uses: rubygems/release-gem@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          setup-trusted-publisher: false
+
+      # OK: rubygems/release-gem with setup-trusted-publisher: true
+      - name: not-vulnerable-9
+        uses: rubygems/release-gem@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          setup-trusted-publisher: true
+
+      # OK: rubygems/release-gem with setup-trusted-publisher not set
+      - name: not-vulnerable-10
+        uses: rubygems/release-gem@v1 # zizmor: ignore[unpinned-uses]
+
+      # NOT OK: rubygems/configure-rubygems-credentials with
+      # api-token set
+      - name: vulnerable-11
+        uses: rubygems/configure-rubygems-credentials@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          api-token: ${{ secrets.RUBYGEMS_API_TOKEN }}
+
+      # OK: rubygems/configure-rubygems-credentials with
+      # api-token not set
+      - name: not-vulnerable-12
+        uses: rubygems/configure-rubygems-credentials@v1 # zizmor: ignore[unpinned-uses]
+
+      # NOT OK: rubygems/configure-rubygems-credentials with
+      # api-token set, and with a gem-server that we know supports
+      # trusted publishing.
+      - name: vulnerable-13
+        uses: rubygems/configure-rubygems-credentials@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          api-token: ${{ secrets.RUBYGEMS_API_TOKEN }}
+          gem-server: https://rubygems.org
+
+      # OK: rubygems/configure-rubygems-credentials with
+      # api-token set, but with a server that we don't know
+      # anything about (and therefore can't recommend trusted publishing for).
+      - name: not-vulnerable-14
+        uses: rubygems/configure-rubygems-credentials@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          api-token: ${{ secrets.RUBYGEMS_API_TOKEN }}
+          gem-server: https://example.com
+
+      # OK: pypa/gh-action-pypi-publish with an explicit password,
+      # but with a repository-url that we don't know anything about
+      - name: not-vulnerable-15
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          repository-url: https://example.com/legacy/
+
+      # OK: pypa/gh-action-pypi-publish with an explicit password,
+      # but with a repository_url that we don't know anything about
+      - name: not-vulnerable-16
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          repository_url: https://example.com/legacy/


### PR DESCRIPTION
This generalizes the manual checks in `use-trusted-publishing` by lifting them into the `ActionCoordinate` pattern API. Doing this required some changes to how control fields are evaluated, plus a new `ControlExpr::Not` that allows us to write negative matches on fields.

Behaviorally, no breaking changes should come from this.