### PR TITLE
feat: another template injection sink

### DIFF
--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -56,16 +56,22 @@ static ACTION_INJECTION_SINKS: LazyLock<Vec<(RepositoryUsesPattern, Vec<&str>)>>
         )
         .unwrap();
 
-        // These sinks are not tracked by CodeQL (yet)
-        sinks.push(("amadevus/pwsh-script".parse().unwrap(), vec!["script"]));
-        sinks.push((
-            "jannekem/run-python-script-action".parse().unwrap(),
-            vec!["script"],
-        ));
-        sinks.push((
-            "cardinalby/js-eval-action".parse().unwrap(),
-            vec!["expression"],
-        ));
+        sinks.extend([
+            // These sinks are not tracked by CodeQL (yet)
+            ("amadevus/pwsh-script".parse().unwrap(), vec!["script"]),
+            (
+                "jannekem/run-python-script-action".parse().unwrap(),
+                vec!["script"],
+            ),
+            (
+                "cardinalby/js-eval-action".parse().unwrap(),
+                vec!["expression"],
+            ),
+            (
+                "addnab/docker-run-action".parse().unwrap(),
+                vec!["options", "run"],
+            ),
+        ]);
         sinks
     });
 

--- a/crates/zizmor/tests/integration/test-data/template-injection/addnab-docker-run-action.yml
+++ b/crates/zizmor/tests/integration/test-data/template-injection/addnab-docker-run-action.yml
@@ -1,0 +1,27 @@
+# testcases for addnab/docker-run-action
+
+name: test-addnab-docker-run-action
+on: [push]
+
+permissions: {}
+
+jobs:
+  some-job:
+    name: some-job
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: injection-in-run
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
+        with:
+          image: ubuntu:latest
+          options: --rm
+          run: |
+            echo "The current branch is ${{ github.ref }}"
+
+      - name: injection-in-options
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
+        with:
+          image: ubuntu:latest
+          options: ${{ github.ref }}
+          run: echo "lol"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,7 @@ of `zizmor`.
   commands directly (#1042)
 * The [insecure-commands] audit now supports auto-fixes for many findings
   (#1045)
+* The [template-injection] audit now detects more action injection sinks (#1059)
 
 ### Bug Fixes 🐛
 
@@ -944,3 +945,4 @@ This is one of `zizmor`'s bigger recent releases! Key enhancements include:
 [use-trusted-publishing]: ./audits.md#use-trusted-publishing
 [anonymous-definition]: ./audits.md#anonymous-definition
 [unsound-condition]: ./audits.md#unsound-condition
+[known-vulnerable-actions]: ./audits.md#known-vulnerable-actions


### PR DESCRIPTION
`addnab/docker-run-action` has (at least) two relevant sinks: `run` obviously runs code, while `options` runs it less obviously (the flags aren't validated, so someone could inject a different image than expected).