### PR TITLE
Detect `shell` before applying template expression fixes

### DIFF
--- a/crates/zizmor/src/audit/github_env.rs
+++ b/crates/zizmor/src/audit/github_env.rs
@@ -300,7 +300,8 @@ impl GitHubEnv {
         let normalized = utils::normalize_shell(shell);
 
         match normalized {
-            "bash" | "sh" => self.bash_uses_github_env(run_step_body),
+            // NOTE(ww): zsh is probably close enough in syntax to slide here. Hopefully.
+            "bash" | "sh" | "zsh" => self.bash_uses_github_env(run_step_body),
             "cmd" => Ok(self.cmd_uses_github_env(run_step_body)),
             "pwsh" | "powershell" => self.pwsh_uses_github_env(run_step_body),
             // TODO: handle python.

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -180,7 +180,7 @@ impl TemplateInjection {
         }
 
         // Get the effective shell, which includes defaults and fallbacks
-        let shell = step.effective_shell()?;
+        let shell = step.shell()?;
 
         match shell {
             // sh-style shells (bash, sh, zsh, etc.)

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -309,15 +309,16 @@ impl TemplateInjection {
         // index. In those kinds of cases, we don't produce a fix.
         let env_var = Self::context_to_env_var(ctx)?;
 
-        // Determine the shell type and generate appropriate variable syntax
-        let var_syntax = Self::variable_expansion_for_shell(&env_var, step)?;
+        // Express the variable's expansion according to the step's shell.
+        // For example, `VAR` becomes `${VAR}` in bash/sh/zsh,
+        let var_expansion = Self::variable_expansion_for_shell(&env_var, step)?;
 
         let mut patches = vec![];
         patches.push(Patch {
             route: step.route().with_key("run"),
             operation: Op::RewriteFragment {
                 from: subfeature::Subfeature::new(0, raw.as_raw()),
-                to: var_syntax.into(),
+                to: var_expansion.into(),
             },
         });
 

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -170,6 +170,32 @@ impl TemplateInjection {
         }
     }
 
+    /// Returns the appropriate shell variable syntax for the given environment variable
+    /// based on the step's shell type. Returns `None` if the shell type is unsupported
+    /// for auto-fixing.
+    fn shell_variable_syntax<'doc>(env_var: &str, step: &impl StepCommon<'doc>) -> Option<String> {
+        // Only provide fixes for run steps
+        if !matches!(step.body(), models::StepBodyCommon::Run { .. }) {
+            return None;
+        }
+
+        // Get the effective shell, which includes defaults and fallbacks
+        let shell = step.effective_shell()?;
+
+        match shell {
+            // sh-style shells (bash, sh, zsh, etc.)
+            "bash" | "sh" | "zsh" => Some(format!("${{{env_var}}}")),
+            // Windows Command Prompt
+            "cmd" => Some(format!("%{env_var}%")),
+            // PowerShell (both Windows PowerShell and PowerShell Core)
+            "pwsh" | "powershell" => Some(format!("$env:{env_var}")),
+            // Python shell (uses os.environ)
+            "python" => Some(format!("{{os.environ.get('{env_var}')}}")),
+            // For unknown shells, don't provide a fix to avoid incorrect syntax
+            _ => None,
+        }
+    }
+
     /// Converts a [`Context`] into an appropriate environment variable name,
     /// or `None` if conversion is not possible.
     fn context_to_env_var(ctx: &Context) -> Option<String> {
@@ -264,9 +290,6 @@ impl TemplateInjection {
             return None;
         }
 
-        // FIXME: We should only produce a fix if we're confident that
-        // the `run:` block has bash syntax.
-
         // If our expression isn't a single context, then we can't fix it yet.
         let Expr::Context(ctx) = parsed else {
             return None;
@@ -274,8 +297,9 @@ impl TemplateInjection {
 
         // From here, our fix consists of two patch operations:
         // 1. Replacing the expression in the script with an environment
-        //    variable of our generation. For example, `${{ foo.bar }}`
-        //    becomes `${FOO_BAR}`.
+        //    variable of our generation. The variable syntax depends on
+        //    the shell type: `${VAR}` for bash/sh, `%VAR%` for cmd,
+        //    `$env:VAR` for PowerShell.
         // 2. Inserting the new environment variable into the step's
         //    `env:` block, e.g. `FOO_BAR: ${{ foo.bar }}`.
         //
@@ -289,12 +313,15 @@ impl TemplateInjection {
         // index. In those kinds of cases, we don't produce a fix.
         let env_var = Self::context_to_env_var(ctx)?;
 
+        // Determine the shell type and generate appropriate variable syntax
+        let var_syntax = Self::shell_variable_syntax(&env_var, step)?;
+
         let mut patches = vec![];
         patches.push(Patch {
             route: step.route().with_key("run"),
             operation: Op::RewriteFragment {
                 from: subfeature::Subfeature::new(0, raw.as_raw()),
-                to: format!("${{{env_var}}}").into(),
+                to: var_syntax.into(),
             },
         });
 
@@ -1161,5 +1188,416 @@ jobs:
                 expected
             );
         }
+    }
+
+    #[test]
+    fn test_template_injection_fix_bash_shell() {
+        let workflow_content = r#"
+name: Test Template Injection - Bash
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Vulnerable step with bash shell
+        shell: bash
+        run: echo "User is ${{ github.actor }}"
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_bash_shell.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - Bash
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Vulnerable step with bash shell
+                            shell: bash
+                            run: echo "User is ${GITHUB_ACTOR}"
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_cmd_shell() {
+        let workflow_content = r#"
+name: Test Template Injection - CMD
+on: push
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Vulnerable step with cmd shell
+        shell: cmd
+        run: echo User is ${{ github.actor }}
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_cmd_shell.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - CMD
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: windows-latest
+                        steps:
+                          - name: Vulnerable step with cmd shell
+                            shell: cmd
+                            run: echo User is %GITHUB_ACTOR%
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_pwsh_shell() {
+        let workflow_content = r#"
+name: Test Template Injection - PowerShell
+on: push
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Vulnerable step with pwsh shell
+        shell: pwsh
+        run: Write-Host "User is ${{ github.actor }}"
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_pwsh_shell.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - PowerShell
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: windows-latest
+                        steps:
+                          - name: Vulnerable step with pwsh shell
+                            shell: pwsh
+                            run: Write-Host "User is $env:GITHUB_ACTOR"
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_default_shell_ubuntu() {
+        let workflow_content = r#"
+name: Test Template Injection - Default Shell Ubuntu
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Vulnerable step with default shell
+        run: echo "User is ${{ github.actor }}"
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_default_shell_ubuntu.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    // Ubuntu default shell is bash, so should use ${VAR} syntax
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - Default Shell Ubuntu
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Vulnerable step with default shell
+                            run: echo "User is ${GITHUB_ACTOR}"
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_default_shell_windows() {
+        let workflow_content = r#"
+name: Test Template Injection - Default Shell Windows
+on: push
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Vulnerable step with default shell
+        run: Write-Host "User is ${{ github.actor }}"
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_default_shell_windows.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    // Windows default shell is pwsh, so should use $env:VAR syntax
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - Default Shell Windows
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: windows-latest
+                        steps:
+                          - name: Vulnerable step with default shell
+                            run: Write-Host "User is $env:GITHUB_ACTOR"
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_cmd_shell_with_custom_env() {
+        let workflow_content = r#"
+name: Test Template Injection - CMD with Custom Env
+on: push
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Vulnerable step with custom context
+        shell: cmd
+        run: echo PR title is ${{ github.event.pull_request.title }}
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_cmd_shell_with_custom_env.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - CMD with Custom Env
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: windows-latest
+                        steps:
+                          - name: Vulnerable step with custom context
+                            shell: cmd
+                            run: echo PR title is %GITHUB_EVENT_PULL_REQUEST_TITLE%
+                            env:
+                              GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_python_shell() {
+        let workflow_content = r#"
+name: Test Template Injection - Python
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Python script with template injection
+        shell: python
+        run: |
+          import os
+          print(f"User is ${{ github.event.pull_request.title }}")
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_python_shell.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - Python
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Python script with template injection
+                            shell: python
+                            run: |
+                              import os
+                              print(f"User is {os.environ.get('GITHUB_EVENT_PULL_REQUEST_TITLE')}")
+                            env:
+                              GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_fix_python_shell_with_default_env() {
+        let workflow_content = r#"
+name: Test Template Injection - Python with Default Env
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Python script with default env variable
+        shell: python
+        run: |
+          import os
+          print(f"User is ${{ github.actor }}")
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_fix_python_shell_with_default_env.yml",
+            workflow_content,
+            |workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                assert!(!findings.is_empty());
+
+                let finding_with_fix = findings.iter().find(|f| !f.fixes.is_empty());
+                assert!(finding_with_fix.is_some());
+
+                if let Some(finding) = finding_with_fix {
+                    let fixed_content = apply_fix_by_title_for_snapshot(
+                        workflow.as_document(),
+                        finding,
+                        "replace expression with environment variable",
+                    );
+                    // GITHUB_ACTOR is a default env var, so no env block should be added
+                    insta::assert_snapshot!(fixed_content.source(), @r#"
+                    name: Test Template Injection - Python with Default Env
+                    on: push
+                    jobs:
+                      test:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Python script with default env variable
+                            shell: python
+                            run: |
+                              import os
+                              print(f"User is {os.environ.get('GITHUB_ACTOR')}")
+                    "#);
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_template_injection_no_fix_unknown_shell() {
+        let workflow_content = r#"
+name: Test Template Injection - Unknown Shell
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Vulnerable step with unknown shell
+        shell: fish
+        run: echo "User is ${{ github.actor }}"
+"#;
+
+        test_workflow_audit!(
+            TemplateInjection,
+            "test_template_injection_no_fix_unknown_shell.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<crate::finding::Finding>| {
+                // Should find the vulnerability but not provide a fix for unknown shell
+                assert!(!findings.is_empty());
+
+                let findings_with_fixes: Vec<_> =
+                    findings.iter().filter(|f| !f.fixes.is_empty()).collect();
+                assert!(
+                    findings_with_fixes.is_empty(),
+                    "Expected no fixes for unknown shell type"
+                );
+            }
+        );
     }
 }

--- a/crates/zizmor/src/audit/use_trusted_publishing.rs
+++ b/crates/zizmor/src/audit/use_trusted_publishing.rs
@@ -270,7 +270,7 @@ impl UseTrustedPublishing {
         let normalized = utils::normalize_shell(shell);
 
         match normalized {
-            "bash" | "sh" => self.bash_trusted_publishing_command_candidates(run),
+            "bash" | "sh" | "zsh" => self.bash_trusted_publishing_command_candidates(run),
             "pwsh" | "powershell" => self.pwsh_trusted_publishing_command_candidates(run),
             _ => self.raw_trusted_publishing_command_candidates(run),
         }

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -54,6 +54,11 @@ pub(crate) trait StepCommon<'doc>: Locatable<'doc> + HasInputs {
 
     /// Returns the document which contains this step.
     fn document(&self) -> &'doc yamlpath::Document;
+
+    /// Returns the effective shell for this step, if it can be determined.
+    /// This includes the step's explicit shell, job defaults, workflow defaults,
+    /// and runner defaults. Returns `None` if the shell cannot be statically determined.
+    fn effective_shell(&self) -> Option<&str>;
 }
 
 impl<'a, 'doc, T: StepCommon<'doc>> AsDocument<'a, 'doc> for T {

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -58,7 +58,7 @@ pub(crate) trait StepCommon<'doc>: Locatable<'doc> + HasInputs {
     /// Returns the effective shell for this step, if it can be determined.
     /// This includes the step's explicit shell, job defaults, workflow defaults,
     /// and runner defaults. Returns `None` if the shell cannot be statically determined.
-    fn effective_shell(&self) -> Option<&str>;
+    fn shell(&self) -> Option<&str>;
 }
 
 impl<'a, 'doc, T: StepCommon<'doc>> AsDocument<'a, 'doc> for T {

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -227,7 +227,7 @@ impl<'doc> StepCommon<'doc> for CompositeStep<'doc> {
         self.action().as_document()
     }
 
-    fn effective_shell(&self) -> Option<&str> {
+    fn shell(&self) -> Option<&str> {
         // For composite action steps, shell is always explicitly specified in the YAML
         if let action::StepBody::Run { shell, .. } = &self.inner.body {
             Some(shell)

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -226,6 +226,15 @@ impl<'doc> StepCommon<'doc> for CompositeStep<'doc> {
     fn document(&self) -> &'doc yamlpath::Document {
         self.action().as_document()
     }
+
+    fn effective_shell(&self) -> Option<&str> {
+        // For composite action steps, shell is always explicitly specified in the YAML
+        if let action::StepBody::Run { shell, .. } = &self.inner.body {
+            Some(shell)
+        } else {
+            None
+        }
+    }
 }
 
 impl<'a> CompositeStep<'a> {

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -672,6 +672,11 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
     fn document(&self) -> &'doc yamlpath::Document {
         self.workflow().as_document()
     }
+
+    fn effective_shell(&self) -> Option<&str> {
+        // For workflow steps, we can use the existing shell() method
+        self.shell()
+    }
 }
 
 impl<'doc> Step<'doc> {

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -673,7 +673,7 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
         self.workflow().as_document()
     }
 
-    fn effective_shell(&self) -> Option<&str> {
+    fn shell(&self) -> Option<&str> {
         // For workflow steps, we can use the existing shell() method
         self.shell()
     }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -37,6 +37,8 @@ of `zizmor`.
   with leading or trailing whitespace (#1027)
 * Fixed a bug where [template-injection] findings in `--fix` mode would be
   incorrectly patched when referencing an `env.*` context (#1052)
+* Fixed a bug where [template-injection] findings in `--fix` mode would be
+  patched with shell syntax that didn't match the step's actual shell (#1064)
 
 ## 1.11.0
 


### PR DESCRIPTION
This PR fixes #1049 by detecting all the supported shells except Python and applying the correct environment variable syntax for fixing the finding(s), according to [GitHub workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_iddefaultsrunshell).