### PR TITLE
chore: bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 homepage = "https://docs.zizmor.sh"
 edition = "2024"
 license = "MIT"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -6,7 +6,6 @@ repository = "https://github.com/zizmorcore/zizmor"
 documentation = "https://docs.zizmor.sh"
 keywords = ["cli", "github-actions", "static-analysis", "security"]
 categories = ["command-line-utilities", "security"]
-rust-version = "1.85.0"
 
 homepage.workspace = true
 license.workspace = true


### PR DESCRIPTION
It'd be nice to detect this automatically.

This is also what's causing the release asset binary build failure.