### PR TITLE
Fix a broken link to exit codes

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -125,7 +125,7 @@ GitHub Actions setup:
     !!! important
 
         When using `--format=sarif`, `zizmor` does not use its
-        [exit codes](#exit-codes) to signal the presence of findings. As a result,
+        [exit codes](usage.md/#exit-codes) to signal the presence of findings. As a result,
         `zizmor` will always exit with code `0` even if findings are present,
         **unless** an internal error occurs during the audit.
 


### PR DESCRIPTION
Reviewing #1105, I noticed a broken anchor in the docs build output:

`INFO    -  Doc file 'integrations.md' contains a link '#exit-codes', but there is no such anchor on this page.`

Turns out the exit code anchor is in `usage.md` so I fixed...the glitch.

There's a similar message that I chose not to address:

`INFO    -  Doc file 'release-notes.md' contains a link './installation.md#pypi', but the doc 'installation.md' does not contain an anchor '#pypi'.`

`installation.md` does actually have a `#pypi` anchor when it is rendered, but it doesn't appear in a way that MkDocs handles in the source. I considered explicitly adding anchors for each of the tabs on the Installation page, but that felt like busy work to appease software, not something actually useful to humans, so I opted to leave it out. If @woodruffw wants it in order to do things like "not have broken anchors in a pre-merge check" then I'd be happy to add it.


Signed-off-by: Ben Cotton <ben@kusari.dev>