### PR TITLE
fix(pyproject): include readme in dynamic fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 # `uv run --only-group docs` from failing.
 [project]
 name = "zizmor"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 # Arbitrarily set to the oldest non-EOL Python.
 requires-python = ">=3.9"
 


### PR DESCRIPTION
This mirrors a change in maturin's handling of dynamic fields, i.e. fields it populates from `Cargo.toml`, via https://github.com/PyO3/maturin/pull/2672

Closes #1110.