### PR TITLE
Introduce a rule which suggests that permissions are documented

### DIFF
--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod secrets_inherit;
 pub(crate) mod self_hosted_runner;
 pub(crate) mod stale_action_refs;
 pub(crate) mod template_injection;
+pub(crate) mod undocumented_permissions;
 pub(crate) mod unpinned_images;
 pub(crate) mod unpinned_uses;
 pub(crate) mod unredacted_secrets;

--- a/crates/zizmor/src/audit/undocumented_permissions.rs
+++ b/crates/zizmor/src/audit/undocumented_permissions.rs
@@ -1,0 +1,94 @@
+use github_actions_models::common::{Permission, Permissions};
+
+use super::{Audit, AuditLoadError, Job, audit_meta};
+use crate::finding::location::Locatable as _;
+use crate::{
+    AuditState,
+    finding::{Confidence, Persona, Severity, location::SymbolicLocation},
+};
+
+audit_meta!(
+    UndocumentedPermissions,
+    "undocumented-permissions",
+    "permissions without explanatory comments"
+);
+
+pub(crate) struct UndocumentedPermissions;
+
+impl Audit for UndocumentedPermissions {
+    fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    fn audit_workflow<'doc>(
+        &self,
+        workflow: &'doc crate::models::workflow::Workflow,
+        _config: &crate::config::Config,
+    ) -> anyhow::Result<Vec<crate::finding::Finding<'doc>>> {
+        let mut findings = vec![];
+
+        // Check workflow-level permissions
+        if let Some(finding) = self.check_permissions_documentation(
+            &workflow.permissions,
+            workflow.location(),
+            workflow,
+        )? {
+            findings.push(finding);
+        }
+
+        // Check job-level permissions
+        for job in workflow.jobs() {
+            let (permissions, job_location) = match job {
+                Job::NormalJob(job) => (&job.permissions, job.location()),
+                Job::ReusableWorkflowCallJob(job) => (&job.permissions, job.location()),
+            };
+
+            if let Some(finding) =
+                self.check_permissions_documentation(permissions, job_location, workflow)?
+            {
+                findings.push(finding);
+            }
+        }
+
+        Ok(findings)
+    }
+}
+
+impl UndocumentedPermissions {
+    fn check_permissions_documentation<'a>(
+        &self,
+        permissions: &Permissions,
+        location: SymbolicLocation<'a>,
+        workflow: &'a crate::models::workflow::Workflow,
+    ) -> anyhow::Result<Option<crate::finding::Finding<'a>>> {
+        // Only check explicit permissions blocks
+        match permissions {
+            Permissions::Explicit(perms) if !perms.is_empty() => {
+                // Check if this permissions block needs documentation
+                // Skip if it only contains "contents: read" which is common and self-explanatory
+                if perms.len() == 1
+                    && perms.get("contents").map_or(false, |p| *p == Permission::Read) {
+                    return Ok(None);
+                }
+
+                // For explicit permissions, recommend documenting each permission
+                let perm_location = location.primary().with_keys(["permissions".into()]);
+                Ok(Some(
+                    Self::finding()
+                        .severity(Severity::Low)
+                        .confidence(Confidence::High)
+                        .persona(Persona::Pedantic)
+                        .add_location(perm_location.annotated(
+                            "consider adding comments to document each permission's purpose",
+                        ))
+                        .build(workflow)?,
+                ))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -63,6 +63,7 @@ impl AuditRegistry {
         register_audit!(audit::self_hosted_runner::SelfHostedRunner);
         register_audit!(audit::known_vulnerable_actions::KnownVulnerableActions);
         register_audit!(audit::unpinned_uses::UnpinnedUses);
+        register_audit!(audit::undocumented_permissions::UndocumentedPermissions);
         register_audit!(audit::insecure_commands::InsecureCommands);
         register_audit!(audit::github_env::GitHubEnv);
         register_audit!(audit::cache_poisoning::CachePoisoning);

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__cache_poisoning-11.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__cache_poisoning-11.snap
@@ -60,4 +60,4 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    = note: audit confidence → Low
    = note: this finding has an auto-fix
 
-3 findings (3 fixable): 0 unknown, 0 informational, 0 low, 0 medium, 3 high
+4 findings (1 suppressed, 3 fixable): 0 unknown, 0 informational, 0 low, 0 medium, 3 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-2.snap
@@ -11,4 +11,13 @@ error[excessive-permissions]: overly broad permissions
   |
   = note: audit confidence → High
 
-1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high
+help[undocumented-permissions]: permissions without explanatory comments
+ --> @@INPUT@@:5:1
+  |
+5 | / permissions:
+6 | |   contents: write
+  | |_________________- help: consider adding comments to document each permission's purpose
+  |
+  = note: audit confidence → High
+
+2 findings: 0 unknown, 0 informational, 1 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-8.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-8.snap
@@ -27,4 +27,4 @@ note[excessive-permissions]: overly broad permissions
   |
   = note: audit confidence → High
 
-3 findings: 1 unknown, 0 informational, 0 low, 0 medium, 2 high
+5 findings (2 suppressed): 1 unknown, 0 informational, 0 low, 0 medium, 2 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-9.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions-9.snap
@@ -2,4 +2,4 @@
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-default-perms-all-jobs-explicit.yml\")).run()?"
 ---
-No findings to report. Good job! (1 suppressed)
+No findings to report. Good job! (3 suppressed)

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__excessive_permissions.snap
@@ -2,4 +2,4 @@
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"excessive-permissions/issue-336-repro.yml\")).run()?"
 ---
-No findings to report. Good job! (1 suppressed)
+No findings to report. Good job! (2 suppressed)

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions-2.snap
@@ -1,0 +1,69 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"undocumented-permissions.yml\")).run()?"
+---
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:18:9
+   |
+18 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:29:9
+   |
+29 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:36:9
+   |
+36 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:43:9
+   |
+43 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+error[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:32:3
+   |
+32 | /   test-job-3:
+33 | |     runs-on: ubuntu-latest
+34 | |     permissions: write-all  # Using write-all for convenience (bad practice)
+   | |     ^^^^^^^^^^^^^^^^^^^^^^ uses write-all permissions
+35 | |     steps:
+36 | |       - uses: actions/checkout@v4
+37 | |       - run: echo "Test"
+   | |________________________^ this job
+   |
+   = note: audit confidence → High
+
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:39:3
+   |
+39 | /   test-job-4:
+40 | |     runs-on: ubuntu-latest
+41 | |     permissions: read-all
+   | |     --------------------- uses read-all permissions
+42 | |     steps:
+43 | |       - uses: actions/checkout@v4
+44 | |       - run: echo "Test"
+   | |________________________- this job
+   |
+   = note: audit confidence → High
+
+14 findings (8 suppressed, 4 fixable): 0 unknown, 0 informational, 0 low, 5 medium, 1 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions-3.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions-3.snap
@@ -1,0 +1,124 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"undocumented-permissions/documented.yml\")).args([\"--persona=pedantic\"]).run()?"
+---
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:18:9
+   |
+18 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:25:9
+   |
+25 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:32:9
+   |
+32 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+error[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:8:3
+  |
+8 |   packages: write # Write access to publish packages
+  |   ^^^^^^^^^^^^^^^ packages: write is overly broad at the workflow level
+  |
+  = note: audit confidence → High
+
+error[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:21:3
+   |
+21 | /   test-job-2:
+22 | |     runs-on: ubuntu-latest
+23 | |     permissions: write-all  # Full write access needed for admin operations
+   | |     ^^^^^^^^^^^^^^^^^^^^^^ uses write-all permissions
+24 | |     steps:
+25 | |       - uses: actions/checkout@v4
+26 | |       - run: echo "Test"
+   | |________________________^ this job
+   |
+   = note: audit confidence → High
+
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:28:3
+   |
+28 | /   test-job-3:
+29 | |     runs-on: ubuntu-latest
+30 | |     permissions: read-all  # Read-only access for analysis job
+   | |     --------------------- uses read-all permissions
+31 | |     steps:
+32 | |       - uses: actions/checkout@v4
+33 | |       - run: echo "Test"
+   | |________________________- this job
+   |
+   = note: audit confidence → High
+
+help[undocumented-permissions]: permissions without explanatory comments
+ --> @@INPUT@@:6:1
+  |
+6 | / permissions:
+7 | |   contents: read  # Read access to fetch code
+8 | |   packages: write # Write access to publish packages
+  | |____________________________________________________- help: consider adding comments to document each permission's purpose
+  |
+  = note: audit confidence → High
+
+help[undocumented-permissions]: permissions without explanatory comments
+  --> @@INPUT@@:14:5
+   |
+14 | /     permissions:
+15 | |       contents: write  # Need write access to create releases
+16 | |       issues: write    # Need to create and update issues
+   | |_________________________________________________________- help: consider adding comments to document each permission's purpose
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:11:3
+   |
+11 | /   test-job-1:
+12 | |     runs-on: ubuntu-latest
+...  |
+18 | |       - uses: actions/checkout@v4
+19 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:21:3
+   |
+21 | /   test-job-2:
+22 | |     runs-on: ubuntu-latest
+...  |
+25 | |       - uses: actions/checkout@v4
+26 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:28:3
+   |
+28 | /   test-job-3:
+29 | |     runs-on: ubuntu-latest
+...  |
+32 | |       - uses: actions/checkout@v4
+33 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+11 findings (3 fixable): 0 unknown, 3 informational, 2 low, 4 medium, 2 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions-4.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions-4.snap
@@ -1,0 +1,26 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"undocumented-permissions/contents-read-only.yml\")).args([\"--persona=pedantic\"]).run()?"
+---
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:16:9
+   |
+16 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:10:3
+   |
+10 | /   test-job:
+11 | |     runs-on: ubuntu-latest
+...  |
+16 | |       - uses: actions/checkout@v4
+17 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+2 findings (1 fixable): 0 unknown, 1 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__undocumented_permissions.snap
@@ -1,0 +1,156 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"undocumented-permissions.yml\")).args([\"--persona=pedantic\"]).run()?"
+---
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:18:9
+   |
+18 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:29:9
+   |
+29 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:36:9
+   |
+36 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:43:9
+   |
+43 |       - uses: actions/checkout@v4
+   |         ------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+   = note: this finding has an auto-fix
+
+error[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:7:3
+  |
+7 |   contents: write
+  |   ^^^^^^^^^^^^^^^ contents: write is overly broad at the workflow level
+  |
+  = note: audit confidence → High
+
+error[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:32:3
+   |
+32 | /   test-job-3:
+33 | |     runs-on: ubuntu-latest
+34 | |     permissions: write-all  # Using write-all for convenience (bad practice)
+   | |     ^^^^^^^^^^^^^^^^^^^^^^ uses write-all permissions
+35 | |     steps:
+36 | |       - uses: actions/checkout@v4
+37 | |       - run: echo "Test"
+   | |________________________^ this job
+   |
+   = note: audit confidence → High
+
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:39:3
+   |
+39 | /   test-job-4:
+40 | |     runs-on: ubuntu-latest
+41 | |     permissions: read-all
+   | |     --------------------- uses read-all permissions
+42 | |     steps:
+43 | |       - uses: actions/checkout@v4
+44 | |       - run: echo "Test"
+   | |________________________- this job
+   |
+   = note: audit confidence → High
+
+help[undocumented-permissions]: permissions without explanatory comments
+ --> @@INPUT@@:6:1
+  |
+6 | / permissions:
+7 | |   contents: write
+8 | |   packages: read
+  | |________________- help: consider adding comments to document each permission's purpose
+  |
+  = note: audit confidence → High
+
+help[undocumented-permissions]: permissions without explanatory comments
+  --> @@INPUT@@:14:5
+   |
+14 | /     permissions:
+15 | |       contents: read  # Need to read repo contents
+16 | |       issues: write   # Need to write issue comments
+   | |____________________________________________________- help: consider adding comments to document each permission's purpose
+   |
+   = note: audit confidence → High
+
+help[undocumented-permissions]: permissions without explanatory comments
+  --> @@INPUT@@:24:5
+   |
+24 | /     permissions:
+25 | |       contents: write
+26 | |       packages: write
+27 | |       actions: write
+   | |____________________- help: consider adding comments to document each permission's purpose
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:11:3
+   |
+11 | /   test-job-1:
+12 | |     runs-on: ubuntu-latest
+...  |
+18 | |       - uses: actions/checkout@v4
+19 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:21:3
+   |
+21 | /   test-job-2:
+22 | |     runs-on: ubuntu-latest
+...  |
+29 | |       - uses: actions/checkout@v4
+30 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:32:3
+   |
+32 | /   test-job-3:
+33 | |     runs-on: ubuntu-latest
+...  |
+36 | |       - uses: actions/checkout@v4
+37 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+info[anonymous-definition]: workflow or action definition without a name
+  --> @@INPUT@@:39:3
+   |
+39 | /   test-job-4:
+40 | |     runs-on: ubuntu-latest
+...  |
+43 | |       - uses: actions/checkout@v4
+44 | |       - run: echo "Test"
+   | |________________________- info: this job
+   |
+   = note: audit confidence → High
+
+14 findings (4 fixable): 0 unknown, 4 informational, 3 low, 5 medium, 2 high

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__use_trusted_publishing.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__use_trusted_publishing.snap
@@ -91,4 +91,4 @@ info[use-trusted-publishing]: prefer trusted publishing for authentication
    |
    = note: audit confidence → High
 
-25 findings (16 ignored, 1 suppressed): 0 unknown, 8 informational, 0 low, 0 medium, 0 high
+26 findings (16 ignored, 2 suppressed): 0 unknown, 8 informational, 0 low, 0 medium, 0 high

--- a/crates/zizmor/tests/integration/test-data/undocumented-permissions.yml
+++ b/crates/zizmor/tests/integration/test-data/undocumented-permissions.yml
@@ -1,0 +1,44 @@
+name: Test Undocumented Permissions
+
+on: [push, pull_request]
+
+# This workflow-level permission block has no comment
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  test-job-1:
+    runs-on: ubuntu-latest
+    # This job's permissions block has a comment explaining why
+    permissions:
+      contents: read  # Need to read repo contents
+      issues: write   # Need to write issue comments
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"
+
+  test-job-2:
+    runs-on: ubuntu-latest
+    # Missing individual permission comments
+    permissions:
+      contents: write
+      packages: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"
+
+  test-job-3:
+    runs-on: ubuntu-latest
+    permissions: write-all  # Using write-all for convenience (bad practice)
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"
+
+  test-job-4:
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"

--- a/crates/zizmor/tests/integration/test-data/undocumented-permissions/contents-read-only.yml
+++ b/crates/zizmor/tests/integration/test-data/undocumented-permissions/contents-read-only.yml
@@ -1,0 +1,17 @@
+name: Contents Read Only Test
+
+on: [push]
+
+# This should NOT trigger the rule since contents: read is self-explanatory
+permissions:
+  contents: read
+
+jobs:
+  test-job:
+    runs-on: ubuntu-latest
+    # This should also NOT trigger the rule
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"

--- a/crates/zizmor/tests/integration/test-data/undocumented-permissions/contents-read-with-other.yml
+++ b/crates/zizmor/tests/integration/test-data/undocumented-permissions/contents-read-with-other.yml
@@ -1,0 +1,15 @@
+name: Contents Read With Other Permissions Test
+
+on: [push]
+
+# This SHOULD trigger the rule since it has more than just contents: read
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  test-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"

--- a/crates/zizmor/tests/integration/test-data/undocumented-permissions/documented.yml
+++ b/crates/zizmor/tests/integration/test-data/undocumented-permissions/documented.yml
@@ -1,0 +1,33 @@
+name: Test Documented Permissions
+
+on: [push, pull_request]
+
+# GitHub token permissions for all jobs in this workflow
+permissions:
+  contents: read  # Read access to fetch code
+  packages: write # Write access to publish packages
+
+jobs:
+  test-job-1:
+    runs-on: ubuntu-latest
+    # Override workflow permissions for this specific job
+    permissions:
+      contents: write  # Need write access to create releases
+      issues: write    # Need to create and update issues
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"
+
+  test-job-2:
+    runs-on: ubuntu-latest
+    permissions: write-all  # Full write access needed for admin operations
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"
+
+  test-job-3:
+    runs-on: ubuntu-latest
+    permissions: read-all  # Read-only access for analysis job
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"

--- a/crates/zizmor/tests/integration/test-data/undocumented-permissions/empty-permissions.yml
+++ b/crates/zizmor/tests/integration/test-data/undocumented-permissions/empty-permissions.yml
@@ -1,0 +1,15 @@
+name: Empty Permissions Test
+
+on: [push]
+
+# This should NOT trigger the rule since there are no permissions to document
+permissions: {}
+
+jobs:
+  test-job:
+    runs-on: ubuntu-latest
+    # This should also NOT trigger the rule
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Test"

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1092,6 +1092,51 @@ shell quoting/expansion rules.
             ISSUE_TITLE: ${{ github.event.issue.title }}
         ```
 
+## `undocumented-permissions`
+
+| Type     | Examples         | Introduced in | Works offline  | Enabled by default | Configurable |
+|----------|------------------|---------------|----------------|--------------------|--------------|
+| Workflow | [undocumented-permissions.yml] | vx.y.z        | ✅             | ❌                 | ❌            |
+
+[undocumented-permissions.yml]: https://github.com/zizmorcore/zizmor/blob/main/crates/zizmor/tests/integration/test-data/undocumented-permissions.yml
+
+Detects explicit permissions blocks that lack explanatory comments.
+
+This audit recommends adding comments to document the purpose of each permission
+in explicit permissions blocks. Well-documented permissions help prevent
+over-scoping and make workflows more maintainable by explaining why specific
+permissions are needed.
+
+The audit skips permissions blocks that only contain `contents: read`, as this
+is a common, self-explanatory permission.
+
+!!! note
+
+    This is a `--pedantic` only audit, as it focuses on code quality and
+    maintainability rather than security vulnerabilities.
+
+### Remediation
+
+Add inline comments explaining why each permission is needed:
+
+=== "Before :warning:"
+
+    ```yaml title="undocumented-permissions.yml" hl_lines="2-4"
+    permissions:
+      contents: write
+      packages: read
+      issues: write
+    ```
+
+=== "After :white_check_mark:"
+
+    ```yaml title="undocumented-permissions.yml" hl_lines="2-4"
+    permissions:
+      contents: write  # Needed to create releases and update files
+      packages: read   # Needed to read existing package metadata
+      issues: write    # Needed to create and update issue comments
+    ```
+
 ## `unpinned-images`
 
 | Type     | Examples                | Introduced in | Works offline  | Enabled by default | Configurable |


### PR DESCRIPTION
Fixes #1127

This introduces a pedantic `undocumented-permissions` rule which suggests that all the permissions directives at the root level and the job level are documented with a trailing comment. The `contents: read` permission is excluded because it's self-explanatory and very common. I don't think it makes sense to require that be documented everywhere.

I've added full test coverage and updated the docs.

AI disclaimer: I've never written a line of Rust in my life. This was almost entirely produced by an AI-powered coding agent following my guidance. I'd love to know whether the code that it produced for the new rule is any good.