### PR TITLE
feat: allow audits to be disabled in config

### DIFF
--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -759,7 +759,9 @@ jobs:
         let audit = KnownVulnerableActions::new(&state).unwrap();
 
         let input = workflow.into();
-        let findings = audit.audit(&input, &Config::default()).unwrap();
+        let findings = audit
+            .audit(KnownVulnerableActions::ident(), &input, &Config::default())
+            .unwrap();
         assert_eq!(findings.len(), 1);
 
         let new_doc = findings[0].fixes[0].apply(input.as_document()).unwrap();
@@ -812,7 +814,9 @@ jobs:
         let audit = KnownVulnerableActions::new(&state).unwrap();
 
         let input = workflow.into();
-        let findings = audit.audit(&input, &Config::default()).unwrap();
+        let findings = audit
+            .audit(KnownVulnerableActions::ident(), &input, &Config::default())
+            .unwrap();
         assert_eq!(findings.len(), 1);
 
         let new_doc = findings[0].fixes[0].apply(input.as_document()).unwrap();

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -305,7 +305,7 @@ pub(crate) trait Audit: AuditCore {
     ) -> anyhow::Result<Vec<Finding<'doc>>> {
         if config.disables(ident) {
             tracing::debug!(
-                "skipping {ident} is disabled in config for group {group:?}",
+                "skipping: {ident} is disabled in config for group {group:?}",
                 group = input.key().group()
             );
             return Ok(vec![]);

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -288,12 +288,29 @@ pub(crate) trait Audit: AuditCore {
     ///
     /// Implementors **should not** override this blanket implementation,
     /// since it's marked with tracing instrumentation.
-    #[instrument(skip(self, config))]
+    ///
+    /// NOTE: This method takes the audit's own identifier as an argument,
+    /// so that we can check whether the audit is disabled in the config.
+    /// This is a little silly since the audit would ideally call Self::ident(),
+    /// but this gets invoked through a trait object where `Self` is not `Sized`.
+    ///
+    /// TODO: This also means we effectively run the disablement check on every
+    /// single input in a group, rather than just once per group.
+    #[instrument(skip(self, ident, config))]
     fn audit<'doc>(
         &self,
+        ident: &str,
         input: &'doc AuditInput,
         config: &Config,
     ) -> anyhow::Result<Vec<Finding<'doc>>> {
+        if config.disables(ident) {
+            tracing::debug!(
+                "skipping {ident} is disabled in config for group {group:?}",
+                group = input.key().group()
+            );
+            return Ok(vec![]);
+        }
+
         let mut results = match input {
             AuditInput::Workflow(workflow) => self.audit_workflow(workflow, config),
             AuditInput::Action(action) => self.audit_action(action, config),

--- a/crates/zizmor/src/config.rs
+++ b/crates/zizmor/src/config.rs
@@ -80,8 +80,13 @@ impl<'de> Deserialize<'de> for WorkflowRule {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AuditRuleConfig {
+    /// Disables the audit entirely if `true`.
+    #[serde(default)]
+    disable: bool,
+    /// A list of ignore rules for findings from this audit.
     #[serde(default)]
     ignore: Vec<WorkflowRule>,
+    /// Rule-specific configuration.
     #[serde(default)]
     config: Option<serde_yaml::Mapping>,
 }
@@ -480,6 +485,15 @@ impl Config {
         } else {
             Ok(None)
         }
+    }
+
+    /// Returns `true` if this [`Config`] disables the given audit rule.
+    pub(crate) fn disables(&self, ident: &str) -> bool {
+        self.raw
+            .rules
+            .get(ident)
+            .map(|rule_config| rule_config.disable)
+            .unwrap_or(false)
     }
 
     /// Returns `true` if this [`Config`] has an ignore rule for the

--- a/crates/zizmor/src/lsp.rs
+++ b/crates/zizmor/src/lsp.rs
@@ -190,8 +190,12 @@ impl Backend {
         let mut registry = FindingRegistry::new(&input_registry, None, None, Persona::Regular);
 
         for (input_key, input) in input_registry.iter_inputs() {
-            for (_, audit) in self.audit_registry.iter_audits() {
-                registry.extend(audit.audit(input, input_registry.get_config(input_key.group()))?);
+            for (ident, audit) in self.audit_registry.iter_audits() {
+                registry.extend(audit.audit(
+                    ident,
+                    input,
+                    input_registry.get_config(input_key.group()),
+                )?);
             }
         }
 

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -538,10 +538,10 @@ fn run() -> Result<ExitCode> {
         for (input_key, input) in registry.iter_inputs() {
             Span::current().pb_set_message(input.key().filename());
             let config = registry.get_config(input_key.group());
-            for (name, audit) in audit_registry.iter_audits() {
-                tracing::debug!("running {name} on {input}", input = input.key());
-                results.extend(audit.audit(input, config).with_context(|| {
-                    format!("{name} failed on {input}", input = input.key().filename())
+            for (ident, audit) in audit_registry.iter_audits() {
+                tracing::debug!("running {ident} on {input}", input = input.key());
+                results.extend(audit.audit(ident, input, config).with_context(|| {
+                    format!("{ident} failed on {input}", input = input.key().filename())
                 })?);
                 Span::current().pb_inc(1);
             }

--- a/crates/zizmor/tests/integration/config.rs
+++ b/crates/zizmor/tests/integration/config.rs
@@ -1,4 +1,4 @@
-//! Configuration discovery tests.
+//! Configuration discovery and functionality tests.
 
 use crate::common::{OutputMode, input_under_test, zizmor};
 
@@ -170,6 +170,20 @@ fn test_ignores_config_in_dotgithub_from_file_input() -> anyhow::Result<()> {
                 "config-scenarios/config-in-dotgithub/.github/workflows/hackme.yml"
             ))
             .setenv("RUST_LOG", "zizmor::config=debug")
+            .output(OutputMode::Both)
+            .run()?
+    );
+
+    Ok(())
+}
+
+/// Ensures we respect the `disable: true` configuration directive.
+#[test]
+fn test_disablement() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("config-scenarios/disablement"))
+            .setenv("RUST_LOG", "zizmor::audit=debug")
             .output(OutputMode::Both)
             .run()?
     );

--- a/crates/zizmor/tests/integration/snapshots/integration__config__disablement.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__config__disablement.snap
@@ -1,0 +1,6 @@
+---
+source: crates/zizmor/tests/integration/config.rs
+expression: "zizmor().input(input_under_test(\"config-scenarios/disablement\")).setenv(\"RUST_LOG\",\n\"zizmor::audit=debug\").output(OutputMode::Both).run()?"
+---
+DEBUG audit{input=Workflow(file://@@INPUT@@/.github/workflows/hackme.yml)}: zizmor::audit: skipping template-injection is disabled in config for group Group("@@INPUT@@")
+No findings to report. Good job!

--- a/crates/zizmor/tests/integration/snapshots/integration__config__disablement.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__config__disablement.snap
@@ -2,5 +2,5 @@
 source: crates/zizmor/tests/integration/config.rs
 expression: "zizmor().input(input_under_test(\"config-scenarios/disablement\")).setenv(\"RUST_LOG\",\n\"zizmor::audit=debug\").output(OutputMode::Both).run()?"
 ---
-DEBUG audit{input=Workflow(file://@@INPUT@@/.github/workflows/hackme.yml)}: zizmor::audit: skipping template-injection is disabled in config for group Group("@@INPUT@@")
+DEBUG audit{input=Workflow(file://@@INPUT@@/.github/workflows/hackme.yml)}: zizmor::audit: skipping: template-injection is disabled in config for group Group("@@INPUT@@")
 No findings to report. Good job!

--- a/crates/zizmor/tests/integration/test-data/config-scenarios/disablement/.github/workflows/hackme.yml
+++ b/crates/zizmor/tests/integration/test-data/config-scenarios/disablement/.github/workflows/hackme.yml
@@ -1,0 +1,16 @@
+name: hackme
+on:
+  issues:
+
+permissions: {}
+
+jobs:
+  inject-me:
+    name: inject-me
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # tag=v7.0.1
+        with:
+          script: |
+            return "doing a thing: ${{ github.event.issue.title }}"

--- a/crates/zizmor/tests/integration/test-data/config-scenarios/disablement/zizmor.yml
+++ b/crates/zizmor/tests/integration/test-data/config-scenarios/disablement/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  template-injection:
+    disable: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ typically named `zizmor.yml`.
 
 !!! note
 
-    Configuration is *always* optional, and can always be disabled with
+    Configuration is *always* optional, and can always be skipped with
     `--no-config`. If `--no-config` is passed, no configuration is ever loaded.
 
 !!! tip
@@ -62,16 +62,53 @@ requested with `--config` or `ZIZMOR_CONFIG`.
 
 ## Settings
 
-### `rules`
+### `rules.<id>.disable`
 
-#### `rules.<id>`
+_Type_: `boolean`
 
-##### `rules.<id>.ignore`
+Disables the audit entirely if `true`.
+
+!!! warning
+
+    For most users, disabling audits should be a **measure of last resort**.
+    Disabled rules don't show up in ignored or suppressed finding counts,
+    making it **very easy** to accidentally miss important new findings.
+
+    Before disabling an audit entirely, consider one of the following
+    alternatives:
+
+    1. Ignoring specific findings via [`rules.<id>.ignore`](#rulesidignore).
+    1. Changing your [persona](./usage.md/#using-personas) to a less sensitive
+       one. For example, consider removing `--persona=pedantic`
+       or `--persona=auditor` if you're using one of those.
+
+When set, inputs covered by this configuration file will not be
+analyzed by the given audit.
+
+For example, here is a configuration file that disables the
+[`template-injection`](./audits.md#template-injection) audit:
+
+```yaml title="zizmor.yml"
+rules:
+  template-injection:
+    disable: true
+```
+
+Multiple audits can be disabled as well:
+
+```yaml title="zizmor.yml"
+rules:
+  template-injection:
+    disable: true
+  unpinned-uses:
+    disable: true
+```
+
+### `rules.<id>.ignore`
 
 _Type_: `array`
 
-Per-audit ignore rules, where `id` is the audit's name, e.g.
-[`template-injection`](./audits.md#template-injection).
+Per-audit ignore rules.
 
 Each member of `rules.<id>.ignore` is a *workflow rule*, formatted as follows:
 
@@ -106,7 +143,7 @@ rules:
       - pypi.yml:12:10
 ```
 
-#### `rules.<id>.config`
+### `rules.<id>.config`
 
 _Type_: `object`
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -41,6 +41,10 @@ of `zizmor`.
     See [Configuration - Discovery](./configuration.md#discovery) for a
     detailed explanation of the new behavior.
 
+* Audit rules can now be disabled entirely in `zizmor`'s configuration.
+  See [`rules.<id>.disable`](./configuration.md#rulesiddisable)
+  for details (#1132)
+
 ### Bug Fixes 🐛
 
 * `zizmor` now correctly honors `--strict-collection` when collecting from


### PR DESCRIPTION
This adds `disable: <bool>` to per-audit configs, allowing audits to be disabled entirely on a per-group basis.

(I was previously uncomfortable with audit disablement and still am to some extent, but I'm convinced that there are legitimate engineering reasons why people want this. I've added some scary language to the docs emphasizing that most users shouldn't need this. I'm also more comfortable with this now that config is loaded on a per-group basis, since a user can't accidentally disable findings outside of a single group now.)

Closes #714. 

See also #1123.