### PR TITLE
fix(ref-version-mismatch): correct commit SHA in audit message

### DIFF
--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -93,6 +93,8 @@ impl RefVersionMismatch {
         };
 
         if commit_for_ref != commit_sha {
+            tracing::warn!("{commit_for_ref} != {commit_sha}");
+
             let subfeature = Subfeature::new(
                 uses_location.concrete.location.offset_span.end,
                 version_from_comment,
@@ -107,7 +109,7 @@ impl RefVersionMismatch {
                     // that avoids collisions in Linux-sized repositories.
                     uses_location.symbolic.clone().primary().annotated(format!(
                         "points to commit {short_commit}",
-                        short_commit = &commit_sha[..12]
+                        short_commit = &commit_for_ref[..12]
                     )),
                     Feature::from_subfeature(&subfeature, step),
                 ));

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__ref_version_mismatch.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__ref_version_mismatch.snap
@@ -6,7 +6,7 @@ warning[ref-version-mismatch]: detects commit SHAs that don't match their versio
   --> @@INPUT@@:21:77
    |
 21 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.1
-   |         -----------------------------------------------------------------   ^^^^^^ points to commit 1a4442cacd43
+   |         -----------------------------------------------------------------   ^^^^^^ points to commit 5e21ff4d9bc1
    |         |
    |         is pointed to by tag v3.8.2
    |


### PR DESCRIPTION
This fixes #1181 by showing the right short-SHA (the one underlying the tag, not the one we already know).

I unfortunately don't have a great way to regression-test this, since GitHub does floating tags like `# v3` that'll change too often in the snapshots. But the existing snapshot fix indirectly covers this by demonstrating that we now show the right hash.