### PR TITLE
fix: use-trusted-publishing: recognize crates.io Trusted Publishing for cargo publish

### DIFF
--- a/crates/zizmor/tests/integration/snapshot.rs
+++ b/crates/zizmor/tests/integration/snapshot.rs
@@ -306,6 +306,15 @@ fn use_trusted_publishing() -> Result<()> {
             .run()?
     );
 
+    // Trusted Publishing for crates.io should suppress findings for cargo publish
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "use-trusted-publishing/cargo-publish-trusted.yml"
+            ))
+            .run()?
+    );
+
     Ok(())
 }
 

--- a/crates/zizmor/tests/integration/snapshots/integration__snapshot__use_trusted_publishing-5.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__snapshot__use_trusted_publishing-5.snap
@@ -1,0 +1,7 @@
+---
+source: crates/zizmor/tests/integration/snapshot.rs
+assertion_line: 310
+expression: "zizmor().input(input_under_test(\"use-trusted-publishing/cargo-publish-trusted.yml\")).run()?"
+---
+No findings to report. Good job! (1 ignored, 2 suppressed)
+

--- a/crates/zizmor/tests/integration/test-data/use-trusted-publishing/cargo-publish-trusted.yml
+++ b/crates/zizmor/tests/integration/test-data/use-trusted-publishing/cargo-publish-trusted.yml
@@ -1,0 +1,20 @@
+on: [push]
+
+name: use-trusted-publishing
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: authenticate with crates.io (TP)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1 # zizmor: ignore[unpinned-uses]
+
+      # Should NOT be flagged: token comes from Trusted Publishing action outputs via env
+      - name: cargo publish with env token
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION

## Summary

Avoid false positives from the `use-trusted-publishing` audit when publishing Rust crates via crates.io Trusted Publishing.

This change recognizes workflows that use `rust-lang/crates-io-auth-action` and then run `cargo publish` with the action’s OIDC-derived token (either via `env.CARGO_REGISTRY_TOKEN` or inline `--token`). In these cases, we now treat authentication as Trusted Publishing and do not flag `cargo publish`.

Docs: https://crates.io/docs/trusted-publishing

## Context

Workflows like the following correctly use Trusted Publishing, but were previously flagged with an informational finding suggesting to "prefer trusted publishing":

```yaml
permissions:
  id-token: write
steps:
  - uses: rust-lang/crates-io-auth-action@v1
    id: auth
  - run: cargo publish
    env:
      CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
```

Because `cargo publish` appears in `run:`, the audit previously matched it as a generic publish command. This PR makes the audit aware of the crates.io TP pattern so it won’t produce a false positive in this case.

## Changes

- `use-trusted-publishing` audit:
  - If a prior step uses `rust-lang/crates-io-auth-action` (with an `id`) and the `cargo publish` step references `${{ steps.<id>.outputs.token }}` (either via `env.CARGO_REGISTRY_TOKEN` or inline `--token`), skip the finding (treat as Trusted Publishing).
  - Scope limited to `cargo publish` commands.

- Tests:
  - Added `use-trusted-publishing/cargo-publish-trusted.yml` input that exercises the crates.io Trusted Publishing flow.
  - Added a new integration snapshot asserting no findings for the TP case.

## Why this is safe

crates.io Trusted Publishing uses OIDC to issue a scoped token at runtime for the publishing workflow. Using the action’s output token (derived from OIDC) is materially different from using a long-lived secret and should not be flagged as "manual" credential usage.

Reference: https://crates.io/docs/trusted-publishing

## Example behavior

- Trusted (no finding):
  - Previous step: `uses: rust-lang/crates-io-auth-action@v1` with `id: auth`.
  - `run: cargo publish` with `env.CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}`.

- Not trusted (finding preserved):
  - `run: cargo publish` with `env.CARGO_REGISTRY_TOKEN: ${{ secrets.CRATESIO_PUBLISH_TOKEN }}` or similar manually configured credentials.
