### PR TITLE
perf: use jemalloc as the global allocator on non-Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +3860,7 @@ dependencies = [
  "tar",
  "terminal-link",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tower-lsp",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tree-sitter-powershell = "0.25.9"
 yamlpath = { path = "crates/yamlpath", version = "0.25.0" }
 yamlpatch = { path = "crates/yamlpatch", version = "0.3.0" }
 tree-sitter-yaml = "0.7.1"
+tikv-jemallocator = "0.6"
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -71,6 +71,9 @@ tree-sitter-powershell.workspace = true
 yamlpath.workspace = true
 yamlpatch.workspace = true
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator.workspace = true
+
 [build-dependencies]
 csv.workspace = true
 fst.workspace = true

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -44,6 +44,10 @@ mod registry;
 mod state;
 mod utils;
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 // TODO: Dedupe this with the top-level `sponsors.json` used by the
 // README + docs site.
 const THANKS: &[(&str, &str)] = &[("Grafana Labs", "https://grafana.com")];

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,12 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Performance Improvements 🚄
+
+* zizmor now uses `jemalloc` as its default allocator on non-MSVC targets,
+  which should significantly improve performance for Linux and macOS users
+  (#1200)
+
 ### Enhancements 🌱
 
 * zizmor now unconditionally emits its version number to stderr on


### PR DESCRIPTION
I'm not sure how much of a boost this will be; we'll see.