### PR TITLE
github-actions-models: remove token from vendored testcase

### DIFF
--- a/crates/github-actions-models/tests/sample-workflows/rnpgp-rnp-centos-and-fedora.yml
+++ b/crates/github-actions-models/tests/sample-workflows/rnpgp-rnp-centos-and-fedora.yml
@@ -44,7 +44,6 @@ concurrency:
 env:
   CORES: 2
   RNP_LOG_CONSOLE: 1
-  CODECOV_TOKEN: dbecf176-ea3f-4832-b743-295fd71d0fad
 
 jobs:
   tests:


### PR DESCRIPTION
This token was already breached upstream, but that's no reason for us to propagate it here.

I suspect it's also been copied into the crate packages for `github-actions-models`, since those include test cases.

Closes #1210.

