### PR TITLE
fix: don't fail on single-file inputs without parent dir

### DIFF
--- a/crates/zizmor/src/config.rs
+++ b/crates/zizmor/src/config.rs
@@ -486,11 +486,6 @@ impl Config {
                 }
             };
 
-            // let Some(parent) = path.parent() else {
-            //     tracing::debug!("no parent for {path:?}, cannot discover config");
-            //     return Ok(None);
-            // };
-
             Self::discover_in_dir(parent).map_err(|err| ConfigError {
                 path: path.to_string(),
                 source: err,

--- a/crates/zizmor/src/config.rs
+++ b/crates/zizmor/src/config.rs
@@ -473,10 +473,23 @@ impl Config {
                 source: err,
             })
         } else {
-            let Some(parent) = path.parent() else {
-                tracing::debug!("no parent for {path:?}, cannot discover config");
-                return Ok(None);
+            let parent = match path.parent().map(|p| p.as_str()) {
+                // NOTE(ww): Annoying: `parent()` returns `None` for root paths,
+                // but `Some("")` for paths like `action.yml` (i.e. no parent dir).
+                // We have to handle this sentinel case explicitly, since
+                // `canonicalize("")` isn't valid.
+                Some("") => Utf8Path::new("."),
+                Some(p) => p.into(),
+                None => {
+                    tracing::debug!("no parent for {path:?}, cannot discover config");
+                    return Ok(None);
+                }
             };
+
+            // let Some(parent) = path.parent() else {
+            //     tracing::debug!("no parent for {path:?}, cannot discover config");
+            //     return Ok(None);
+            // };
 
             Self::discover_in_dir(parent).map_err(|err| ConfigError {
                 path: path.to_string(),

--- a/crates/zizmor/tests/integration/common.rs
+++ b/crates/zizmor/tests/integration/common.rs
@@ -118,6 +118,11 @@ impl Zizmor {
         self
     }
 
+    pub fn working_dir(mut self, dir: impl Into<String>) -> Self {
+        self.cmd.current_dir(dir.into());
+        self
+    }
+
     pub fn run(mut self) -> Result<String> {
         if self.offline {
             self.cmd.arg("--offline");

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -344,3 +344,24 @@ fn warn_on_min_confidence_unknown() -> Result<()> {
     );
     Ok(())
 }
+
+/// Regression test for #1210.
+///
+/// Ensures that we correctly handle single-inputs that aren't given
+/// with an explicit parent path, e.g. `action.yml` instead of
+/// `./action.yml`.
+#[test]
+fn issue_1210() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .expects_failure(false)
+            .output(OutputMode::Both)
+            .working_dir(input_under_test("e2e-menagerie/dummy-action-1"))
+            // Input doesn't matter, as long as it's relative without a leading
+            // `./` or other path component.
+            .input("action.yaml")
+            .run()?
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_1210.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_1210.snap
@@ -1,0 +1,12 @@
+---
+source: crates/zizmor/tests/integration/e2e.rs
+expression: "zizmor().expects_failure(false).output(OutputMode::Both).working_dir(input_under_test(\"e2e-menagerie/dummy-action-1\")).input(\"action.yaml\").run()?"
+---
+🌈 zizmor v@@VERSION@@
+ INFO zizmor::registry: skipping impostor-commit: can't run without a GitHub API token
+ INFO zizmor::registry: skipping ref-confusion: can't run without a GitHub API token
+ INFO zizmor::registry: skipping known-vulnerable-actions: can't run without a GitHub API token
+ INFO zizmor::registry: skipping stale-action-refs: can't run without a GitHub API token
+ INFO zizmor::registry: skipping ref-version-mismatch: can't run without a GitHub API token
+ INFO audit: zizmor: 🌈 completed @@INPUT@@
+No findings to report. Good job!


### PR DESCRIPTION
This was a regression in 1.13.0 -- I hadn't considered that `path.parent()` would be `Some("")` when the path has no explicit parent component (I expected that to be `None`). Consequently we'd incorrectly exit with an error if the user attempted to run `zizmor action.yml` or similar instead of `zizmor ./action.yml`.

Fixes #1210.