### PR TITLE
bump github-actions-models to 0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "github-actions-models"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.88.0"
 [workspace.dependencies]
 anyhow = "1.0.100"
 github-actions-expressions = { path = "crates/github-actions-expressions", version = "0.0.10" }
-github-actions-models = { path = "crates/github-actions-models", version = "0.35.0" }
+github-actions-models = { path = "crates/github-actions-models", version = "0.36.0" }
 itertools = "0.14.0"
 pest = "2.8.3"
 pest_derive = "2.8.3"

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-actions-models"
-version = "0.35.0"
+version = "0.36.0"
 description = "Unofficial, high-quality data models for GitHub Actions workflows, actions, and related components"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/github-actions-models"
 keywords = ["github", "ci"]


### PR DESCRIPTION
Fat-fingered the last bump.