### PR TITLE
build: don't use jemalloc on any Windows-family targets

### DIFF
--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -71,7 +71,7 @@ tree-sitter-powershell.workspace = true
 yamlpath.workspace = true
 yamlpatch.workspace = true
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(target_family = "windows"))'.dependencies]
 tikv-jemallocator.workspace = true
 
 [build-dependencies]

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -46,7 +46,7 @@ mod state;
 mod utils;
 
 #[cfg(all(
-    not(target_env = "msvc"),
+    not(target_family = "windows"),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",


### PR DESCRIPTION
The previous jemalloc check treated `msvc` as a proxy for Windows, but there are non-MSVC Windows targets like MinGW. This ensures that we never use the jemalloc allocator on Windows targets, regardless of compiler toolchain.

See: https://github.com/zizmorcore/zizmor/pull/1200#issuecomment-3404150574

+CC @striezel to sanity check this, since non-MSVC targets aren't currently included in the official build platforms for zizmor.