### PR TITLE
feat: downgrade artipacked severity for checkout@v6+

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -81,6 +81,14 @@ including it in a publicly accessible artifact via @actions/upload-artifact.
 However, even without this, persisting the credential in the `.git/config`
 is non-ideal unless actually needed.
 
+!!! note "checkout@v6+ behavior change"
+
+    Starting with `actions/checkout@v6`, credentials are stored under `$RUNNER_TEMP`
+    instead of the local Git config. This significantly reduces the risk of accidentally
+    leaking credentials through workflow artifacts, Docker builds, or uploaded files.
+    As a result, `zizmor` reports lower severity findings for `checkout@v6+` compared
+    to earlier versions.
+
 Other resources:
 
 * [ArtiPACKED: Hacking Giants Through a Race Condition in GitHub Actions Artifacts]


### PR DESCRIPTION
<!--
    Thank you for opening a PR!

    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes #1334

This PR downgrades the severity of `artipacked` findings for `actions/checkout@v6+`.

Starting with `actions/checkout@v6`, credentials are stored in `$RUNNER_TEMP` instead of `.git/config`, significantly reducing the risk of credential leakage. This allows us to lower the severity of such findings.

## Changes

- Added version detection for `actions/checkout@v6+` and severity downgrade logic
- Severity changes: `Medium` → `Low` (no uploads) and `High` → `Medium` (with uploads) for v6+

## Test Plan

- Added unit tests for version detection and severity determination