### PR TITLE
tests: add a true negative test for NuGet Trusted Publishing

### DIFF
--- a/crates/zizmor/tests/integration/snapshot.rs
+++ b/crates/zizmor/tests/integration/snapshot.rs
@@ -652,7 +652,7 @@ fn use_trusted_publishing() -> Result<()> {
        |
        = note: audit confidence → High
 
-    5 findings (2 suppressed): 3 informational, 0 low, 0 medium, 0 high
+    7 findings (4 suppressed): 3 informational, 0 low, 0 medium, 0 high
     "
     );
 

--- a/crates/zizmor/tests/integration/test-data/use-trusted-publishing/nuget-push.yml
+++ b/crates/zizmor/tests/integration/test-data/use-trusted-publishing/nuget-push.yml
@@ -16,3 +16,23 @@ jobs:
 
       - name: vulnerable-3
         run: dotnet nuget push foo.nupkg
+
+  true-negatives:
+    name: true-negatives
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: NuGet Login
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544
+        with:
+          user: my-nuget-username
+
+      - name: Push package
+        run: |
+          dotnet nuget push mypkg.nupkg \
+            --api-key "${NUGET_API_KEY}" \
+            --source https://www.nuget.org/api/v2/package
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
Ensures that we correctly don't flag `nuget push` patterns where the encloding job/step has `id-token: write`.

(Note: This has the same basic imprecision as all of the other command-line matching TP checks, which is that we're looking for `id-token: write` but we can't actually assert (yet) that the user really _used_ that permission. I need to work on a proper output flow analysis for that, but that's a larger piece of work.)

See #1188.