### PR TITLE
tests: remove a duped config test

### DIFF
--- a/crates/zizmor/tests/integration/config.rs
+++ b/crates/zizmor/tests/integration/config.rs
@@ -279,27 +279,5 @@ fn test_invalid_configs() -> anyhow::Result<()> {
     "
     );
 
-    // unpinned-uses audit config is invalid.
-    insta::assert_snapshot!(
-        zizmor()
-            .expects_failure(true)
-            .input(input_under_test("neutral.yml"))
-            .config(input_under_test(
-                "config-scenarios/zizmor.invalid-schema-3.yml"
-            ))
-            .output(OutputMode::Stderr)
-            .run()?,
-        @r"
-    🌈 zizmor v@@VERSION@@
-    fatal: no audit was performed
-    error: configuration error in @@CONFIG@@
-
-    Caused by:
-        0: configuration error in @@CONFIG@@
-        1: invalid `unpinned-uses` config
-        2: cannot use exact ref patterns here: `actions/checkout@v3`
-    "
-    );
-
     Ok(())
 }

--- a/crates/zizmor/tests/integration/test-data/config-scenarios/zizmor.invalid-schema-3.yml
+++ b/crates/zizmor/tests/integration/test-data/config-scenarios/zizmor.invalid-schema-3.yml
@@ -1,8 +1,0 @@
-# zizmor.yml config file with an invalid schema
-
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # invalid uses pattern in this context
-        actions/checkout@v3: hash-pin


### PR DESCRIPTION
This "generic" config test was already covered by the `unpinned-uses` invalid config tests. Specifically, `test_invalid_policy_syntax_6`.