### PR TITLE
chore: prep 1.18.0-rc1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "zizmor"
-version = "1.17.0"
+version = "1.18.0-rc1"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zizmor"
 description = "Static analysis for GitHub Actions"
-version = "1.17.0"
+version = "1.18.0-rc1"
 repository = "https://github.com/zizmorcore/zizmor"
 documentation = "https://docs.zizmor.sh"
 keywords = ["cli", "github-actions", "static-analysis", "security"]


### PR DESCRIPTION
So I can exercise the release changes before trying to cut 1.18.