### PR TITLE
chore(ci): allow CI to run on undrafting of PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions: {}
 


### PR DESCRIPTION
Saves me a few clicks when the codegen automations open PRs.