### PR TITLE
docs: trigger only if there are changes to the workflow files

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -17,9 +17,12 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["main"]
+    branches: main
+    paths:
+      - ".github/workflows/**"
   pull_request:
-    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
 
 permissions: {}
 
@@ -79,8 +82,11 @@ GitHub Actions setup:
     on:
       push:
         branches: ["main"]
+        paths:
+          - ".github/workflows/**"
       pull_request:
-        branches: ["**"]
+        paths:
+          - ".github/workflows/**"
 
     permissions: {}
 


### PR DESCRIPTION
Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

This is my first contribution to the project. It is unclear if documentation changes also need an issue, but I'd be happy to create if it is mandatory for every change regardless of type.

Also, if this change is accepted, I'd be happy to send a similar change to https://github.com/zizmorcore/zizmor-action/blob/main/README.md

Thank you for reviewing my change!  

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

## Summary

Updates the GitHub Action workflow example so that it only triggers if there are changes to the workflow files. 

## Test Plan

`paths` is a known GitHub action feature: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore