### PR TITLE
chore: bump github-actions-models to 0.42.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "github-actions-models"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "indexmap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.88.0"
 [workspace.dependencies]
 anyhow = "1.0.100"
 github-actions-expressions = { path = "crates/github-actions-expressions", version = "0.0.11" }
-github-actions-models = { path = "crates/github-actions-models", version = "0.41.0" }
+github-actions-models = { path = "crates/github-actions-models", version = "0.42.0" }
 itertools = "0.14.0"
 pest = "2.8.4"
 pest_derive = "2.8.4"

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-actions-models"
-version = "0.41.0"
+version = "0.42.0"
 description = "Unofficial, high-quality data models for GitHub Actions workflows, actions, and related components"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/github-actions-models"
 keywords = ["github", "ci"]


### PR DESCRIPTION
Signed-off-by: William Woodruff <william@yossarian.net>
