### PR TITLE
fix: broken links in documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ Disables the audit entirely if `true`.
     alternatives:
 
     1. Ignoring specific findings via [`rules.<id>.ignore`](#rulesidignore).
-    1. Changing your [persona](./usage.md/#using-personas) to a less sensitive
+    1. Changing your [persona](./usage.md#using-personas) to a less sensitive
        one. For example, consider removing `--persona=pedantic`
        or `--persona=auditor` if you're using one of those.
 
@@ -144,7 +144,7 @@ entire file or entire line.
 !!! important
 
     Composite action findings cannot be ignored via `zizmor.yml` currently,
-    They can be ignored inline [with comments](./usage.md/#ignoring-results).
+    They can be ignored inline [with comments](./usage.md#ignoring-results).
 
 For example, here is a configuration file with two different audit ignore
 rule groups:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -125,7 +125,7 @@ GitHub Actions setup:
     !!! important
 
         When using `--format=sarif`, `zizmor` does not use its
-        [exit codes](usage.md/#exit-codes) to signal the presence of findings. As a result,
+        [exit codes](usage.md#exit-codes) to signal the presence of findings. As a result,
         `zizmor` will always exit with code `0` even if findings are present,
         **unless** an internal error occurs during the audit.
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes #1492

The syntax `{file}.md/#{tag}` in the final HTML generates the link `{file}.md/#{tag}`, not `{file}/#{tag}`, which results in a 404 error in the documentation.
In this MR, I am fixing all incorrect links.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->
