### PR TITLE
Add 'crater' tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           sudo apt install -y expect
 
       - name: Test
-        run: cargo test --features online-tests,tty-tests,schema
+        run: cargo test --features crater-tests,tty-tests,schema
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -25,6 +25,8 @@ schema = ["dep:schemars"]
 gh-token-tests = []
 # Test-only: enable all online audits.
 online-tests = ["gh-token-tests"]
+# Test-only: enable 'crater' tests.
+crater-tests = ["online-tests"]
 # Test-only: enable tests that require `unbuffer` for TTY behavior.
 tty-tests = []
 

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -6,6 +6,7 @@ use crate::common::{OutputMode, input_under_test, zizmor};
 
 mod anchors;
 mod collect;
+mod crater;
 mod json_v1;
 
 #[cfg_attr(not(feature = "gh-token-tests"), ignore)]

--- a/crates/zizmor/tests/integration/e2e/crater.rs
+++ b/crates/zizmor/tests/integration/e2e/crater.rs
@@ -1,0 +1,34 @@
+//! "Crater" runs of zizmor, i.e. over large external projects.
+//!
+//! The idea behind these tests is to detect (unintended) large changes
+//! between versions of zizmor.
+
+use crate::common::{OutputMode, zizmor};
+
+#[cfg_attr(not(feature = "crater-tests"), ignore)]
+#[test]
+fn curl() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(false)
+            .output(OutputMode::Both)
+            .args(["--persona=pedantic"])
+            .input("curl/curl@6c8956c1cbf5cffcd2fd4571cf277e2eec280578")
+            .run()?
+    );
+    Ok(())
+}
+
+#[cfg_attr(not(feature = "crater-tests"), ignore)]
+#[test]
+fn libssh2() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(false)
+            .output(OutputMode::Both)
+            .args(["--persona=pedantic"])
+            .input("libssh2/libssh2@cb252b5909630dd439d3f80ca9318a99da253dbe")
+            .run()?
+    );
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
@@ -1,0 +1,24 @@
+---
+source: crates/zizmor/tests/integration/e2e/crater.rs
+expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"curl/curl@6c8956c1cbf5cffcd2fd4571cf277e2eec280578\").run()?"
+---
+🌈 zizmor v@@VERSION@@
+ INFO collect_inputs: zizmor::registry::input: collected 17 inputs from curl/curl
+ INFO audit: zizmor: 🌈 completed .github/dependabot.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/appveyor-status.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/checkdocs.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/checksrc.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/checkurls.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/codeql.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/configure-vs-cmake.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/curl-for-win.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/distcheck.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/fuzz.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/http3-linux.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/label.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/linux-old.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/linux.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/macos.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/non-native.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/windows.yml
+No findings to report. Good job! (2 ignored, 44 suppressed)

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__libssh2.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__libssh2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/zizmor/tests/integration/e2e/crater.rs
+expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"libssh2/libssh2@cb252b5909630dd439d3f80ca9318a99da253dbe\").run()?"
+---
+🌈 zizmor v@@VERSION@@
+ INFO collect_inputs: zizmor::registry::input: collected 7 inputs from libssh2/libssh2
+ INFO audit: zizmor: 🌈 completed .github/dependabot.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/appveyor_docker.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/appveyor_status.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/ci.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/cifuzz.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/codeql.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/openssh_server.yml
+No findings to report. Good job! (2 ignored, 10 suppressed)


### PR DESCRIPTION
These are named after Rust's crater. At some point they should probably be broken out of the test suite itself, into their own thing. 

Closes #1531.
