### PR TITLE
feat(uses): add glob pattern support for repository matching

### DIFF
--- a/crates/zizmor/src/models/uses.rs
+++ b/crates/zizmor/src/models/uses.rs
@@ -1,6 +1,6 @@
 //! Extension traits for the `Uses` APIs.
 
-use std::{str::FromStr, sync::LazyLock};
+use std::{cmp::Ordering, str::FromStr, sync::LazyLock};
 
 use github_actions_models::common::{RepositoryUses, Uses};
 use regex::Regex;
@@ -14,20 +14,28 @@ static REPOSITORY_USES_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?xmi)                   # verbose, multi-line mode, case-insensitive
         ^                           # start of line
-        ([\w-]+)                    # (1) owner
+        ([\w-]+)                    # (1) owner (no wildcards allowed)
         /                           # /
-        ([\w\.-]+|\*)               # (2) repo or *
+        (                           # (2) repo: exact, glob, or *
+          [\w\.-]+                  # exact repo name (no wildcards)
+          |                         # OR
+          [\w\.-]*\*[\w\.-]*        # glob pattern with single * (e.g., foo-*, *-bar)
+          |                         # OR
+          \*                        # just * (matches any repo)
+        )
         (?:                         # non-capturing group for optional subpath
           /                         # /
-          (                         # (3) subpath
-            [[[:graph:]]&&[^@\*]]+  # any non-space, non-@, non-* characters
+          (                         # (3) subpath: exact, glob, or *
+            [[[:graph:]]&&[^@\*]]+  # exact subpath (no wildcards)
             |                       # OR
-            \*                      # *
+            [[[:graph:]]&&[^@\*]]*\*[[[:graph:]]&&[^@\*]]*  # glob pattern with single *
+            |                       # OR
+            \*                      # just * (matches any subpath)
           )                         # end of (3) subpath
         )?                          # end of non-capturing group for optional subpath
         (?:                         # non-capturing group for optional git ref
           @                         # @
-          ([[[:graph:]]&&[^\*]]+)   # (4) git ref (any non-space, non-* characters)
+          ([[[:graph:]]&&[^\*]]+)   # (4) git ref (no wildcards allowed)
         )?                          # end of non-capturing group for optional git ref
         $                           # end of line
         "#,
@@ -35,35 +43,179 @@ static REPOSITORY_USES_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// A segment that can be either an exact match or a glob pattern.
+///
+/// This is used for repo and subpath matching in [`RepositoryUsesPattern`].
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub(crate) enum Segment {
+    /// An exact literal match (e.g., "checkout", "foo/bar")
+    Exact(String),
+    /// A glob pattern with a single `*` (e.g., "foo-*", "*-bar")
+    Glob {
+        /// The literal text before the `*`
+        prefix: String,
+        /// The literal text after the `*`
+        suffix: String,
+    },
+}
+
+/// Result of parsing a segment string, including the special `*` case.
+///
+/// This is used during pattern parsing to distinguish between:
+/// - `Star`: the full wildcard `*` (used for `owner/*` or `owner/repo/*`)
+/// - `Segment`: an exact match or glob pattern
+/// - Parse failure (multiple wildcards)
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ParsedSegment {
+    /// Just `*` - matches anything in this position
+    Star,
+    /// A concrete segment (exact or glob)
+    Segment(Segment),
+}
+
+impl ParsedSegment {
+    /// Parse a string into a ParsedSegment.
+    ///
+    /// - `*` alone becomes `Star`
+    /// - A string with exactly one `*` becomes a `Glob` segment
+    /// - A string with no `*` becomes an `Exact` segment
+    /// - Multiple `*` characters returns `None` (invalid)
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        let star_count = s.matches('*').count();
+
+        match star_count {
+            0 => Some(ParsedSegment::Segment(Segment::Exact(s.to_string()))),
+            1 if s == "*" => Some(ParsedSegment::Star),
+            1 => {
+                let (prefix, suffix) = s.split_once('*')?;
+                Some(ParsedSegment::Segment(Segment::Glob {
+                    prefix: prefix.to_string(),
+                    suffix: suffix.to_string(),
+                }))
+            }
+            _ => None, // Multiple wildcards not supported
+        }
+    }
+}
+
+impl Segment {
+    /// Check if a value matches this segment (case-sensitive).
+    pub(crate) fn matches(&self, value: &str) -> bool {
+        match self {
+            Segment::Exact(s) => s == value,
+            Segment::Glob { prefix, suffix } => {
+                if value.len() < prefix.len() + suffix.len() {
+                    return false;
+                }
+                value.starts_with(prefix) && value.ends_with(suffix)
+            }
+        }
+    }
+
+    /// Check if a value matches this segment (case-insensitive for ASCII).
+    pub(crate) fn matches_ignore_ascii_case(&self, value: &str) -> bool {
+        match self {
+            Segment::Exact(s) => s.eq_ignore_ascii_case(value),
+            Segment::Glob { prefix, suffix } => {
+                if value.len() < prefix.len() + suffix.len() {
+                    return false;
+                }
+                // Compare prefix (case-insensitive) without allocating
+                let prefix_matches = value
+                    .as_bytes()
+                    .iter()
+                    .zip(prefix.as_bytes())
+                    .all(|(v, p)| v.eq_ignore_ascii_case(p));
+                if !prefix_matches {
+                    return false;
+                }
+                // Compare suffix (case-insensitive) without allocating
+                value
+                    .as_bytes()
+                    .iter()
+                    .rev()
+                    .zip(suffix.as_bytes().iter().rev())
+                    .all(|(v, s)| v.eq_ignore_ascii_case(s))
+            }
+        }
+    }
+
+    /// Returns the "specificity" of this segment for ordering purposes.
+    /// Lower values are more specific.
+    /// Exact matches are more specific than globs.
+    /// For globs, longer prefix+suffix means more specific.
+    fn specificity(&self) -> (u8, usize) {
+        match self {
+            // Exact is most specific (0), with no length consideration
+            Segment::Exact(_) => (0, 0),
+            // Glob is less specific (1), but longer literals are more specific (inverted)
+            Segment::Glob { prefix, suffix } => (1, usize::MAX - (prefix.len() + suffix.len())),
+        }
+    }
+}
+
+impl PartialOrd for Segment {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Segment {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.specificity().cmp(&other.specificity())
+    }
+}
+
+impl std::fmt::Display for Segment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Segment::Exact(s) => write!(f, "{s}"),
+            Segment::Glob { prefix, suffix } => write!(f, "{prefix}*{suffix}"),
+        }
+    }
+}
+
 /// # Represents a pattern for matching repository `uses` references.
 ///
 /// These patterns are ordered by specificity; more specific patterns
-/// should be listed first.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+/// should be listed first. The ordering is:
+///
+/// 1. `ExactWithRef` - most specific (matches owner/repo/subpath@ref exactly)
+/// 2. `ExactPath` - matches owner/repo/subpath (any ref)
+/// 3. `ExactRepo` - matches owner/repo with no subpath (any ref)
+/// 4. `InRepo` - matches owner/repo/* (any subpath, any ref)
+/// 5. `InOwner` - matches owner/* (any repo, any subpath, any ref)
+/// 6. `Any` - matches * (everything)
+///
+/// Within variants that have `Segment` fields, patterns with exact segments
+/// are more specific than patterns with glob segments.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "schema",
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
 pub(crate) enum RepositoryUsesPattern {
-    /// Matches exactly `owner/repo/subpath@ref`.
+    /// Matches `owner/repo/subpath@ref` where repo and subpath can be exact or globs.
     ExactWithRef {
         owner: String,
-        repo: String,
-        subpath: Option<String>,
+        repo: Segment,
+        subpath: Option<Segment>,
         git_ref: String,
     },
-    /// Matches exactly `owner/repo/subpath`.
+    /// Matches `owner/repo/subpath` where repo and subpath can be exact or globs.
+    /// Any ref is matched.
     ExactPath {
         owner: String,
-        repo: String,
-        subpath: String,
+        repo: Segment,
+        subpath: Segment,
     },
-    /// Matches exactly `owner/repo`.
-    ExactRepo { owner: String, repo: String },
-    /// Matches `owner/repo/*` (i.e. any subpath under the given repo, including
-    /// the empty subpath).
-    InRepo { owner: String, repo: String },
+    /// Matches `owner/repo` (no subpath allowed) where repo can be exact or a glob.
+    /// Any ref is matched.
+    ExactRepo { owner: String, repo: Segment },
+    /// Matches `owner/repo/*` where repo can be exact or a glob.
+    /// Any subpath (including none) is matched. Any ref is matched.
+    InRepo { owner: String, repo: Segment },
     /// Matches `owner/*` (i.e. any repo under the given owner).
     InOwner(String),
     /// Matches any `owner/repo`.
@@ -80,8 +232,11 @@ impl RepositoryUsesPattern {
                 git_ref,
             } => {
                 uses.owner().eq_ignore_ascii_case(owner)
-                    && uses.repo().eq_ignore_ascii_case(repo)
-                    && uses.subpath() == subpath.as_deref()
+                    && repo.matches_ignore_ascii_case(uses.repo())
+                    && match subpath {
+                        Some(sp) => uses.subpath().is_some_and(|s| sp.matches(s)),
+                        None => uses.subpath().is_none(),
+                    }
                     && uses.git_ref() == git_ref
             }
             RepositoryUsesPattern::ExactPath {
@@ -96,20 +251,54 @@ impl RepositoryUsesPattern {
                 // platform dependent (i.e. will do the wrong thing
                 // if the platform separator is not /).
                 uses.owner().eq_ignore_ascii_case(owner)
-                    && uses.repo().eq_ignore_ascii_case(repo)
-                    && uses.subpath().is_some_and(|s| s == subpath)
+                    && repo.matches_ignore_ascii_case(uses.repo())
+                    // Subpath matching is case-sensitive
+                    && uses.subpath().is_some_and(|s| subpath.matches(s))
             }
             RepositoryUsesPattern::ExactRepo { owner, repo } => {
                 uses.owner().eq_ignore_ascii_case(owner)
-                    && uses.repo().eq_ignore_ascii_case(repo)
+                    && repo.matches_ignore_ascii_case(uses.repo())
                     && uses.subpath().is_none()
             }
             RepositoryUsesPattern::InRepo { owner, repo } => {
-                uses.owner().eq_ignore_ascii_case(owner) && uses.repo().eq_ignore_ascii_case(repo)
+                uses.owner().eq_ignore_ascii_case(owner)
+                    && repo.matches_ignore_ascii_case(uses.repo())
             }
             RepositoryUsesPattern::InOwner(owner) => uses.owner().eq_ignore_ascii_case(owner),
             RepositoryUsesPattern::Any => true,
         }
+    }
+
+    /// Returns a tuple used for ordering patterns by specificity.
+    /// Lower values are more specific and should come first when sorted.
+    fn specificity(&self) -> (u8, Segment, Option<Segment>) {
+        // Create a dummy segment for comparison purposes
+        let no_segment = Segment::Exact(String::new());
+
+        match self {
+            RepositoryUsesPattern::ExactWithRef { repo, subpath, .. } => {
+                (0, repo.clone(), subpath.clone())
+            }
+            RepositoryUsesPattern::ExactPath { repo, subpath, .. } => {
+                (1, repo.clone(), Some(subpath.clone()))
+            }
+            RepositoryUsesPattern::ExactRepo { repo, .. } => (2, repo.clone(), None),
+            RepositoryUsesPattern::InRepo { repo, .. } => (3, repo.clone(), None),
+            RepositoryUsesPattern::InOwner(_) => (4, no_segment.clone(), None),
+            RepositoryUsesPattern::Any => (5, no_segment, None),
+        }
+    }
+}
+
+impl PartialOrd for RepositoryUsesPattern {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RepositoryUsesPattern {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.specificity().cmp(&other.specificity())
     }
 }
 
@@ -117,6 +306,7 @@ impl FromStr for RepositoryUsesPattern {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Special case: bare `*` matches everything
         if s == "*" {
             return Ok(RepositoryUsesPattern::Any);
         }
@@ -126,33 +316,88 @@ impl FromStr for RepositoryUsesPattern {
             .ok_or_else(|| anyhow::anyhow!("invalid pattern: {s}"))?;
 
         let owner = &caps[1];
-        let repo = &caps[2];
-        let subpath = caps.get(3).map(|m| m.as_str());
+        let repo_str = &caps[2];
+        let subpath_str = caps.get(3).map(|m| m.as_str());
         let git_ref = caps.get(4).map(|m| m.as_str());
 
-        match (owner, repo, subpath, git_ref) {
-            (owner, "*", None, None) => Ok(RepositoryUsesPattern::InOwner(owner.into())),
-            (owner, repo, None, None) => Ok(RepositoryUsesPattern::ExactRepo {
+        // Parse repo segment (handles validation of multiple wildcards)
+        let repo_parsed = ParsedSegment::parse(repo_str)
+            .ok_or_else(|| anyhow::anyhow!("invalid pattern: {s}"))?;
+
+        // Parse subpath segment if present
+        let subpath_parsed = subpath_str
+            .map(|sp| {
+                ParsedSegment::parse(sp).ok_or_else(|| anyhow::anyhow!("invalid pattern: {s}"))
+            })
+            .transpose()?;
+
+        // Build the appropriate pattern variant
+        match (&repo_parsed, &subpath_parsed, git_ref) {
+            // ================================================================
+            // owner/* - matches any repo under owner
+            // ================================================================
+            (ParsedSegment::Star, None, None) => Ok(RepositoryUsesPattern::InOwner(owner.into())),
+
+            // owner/*@ref is invalid (can't have ref with repo star)
+            (ParsedSegment::Star, None, Some(_)) => Err(anyhow::anyhow!("invalid pattern: {s}")),
+
+            // owner/*/... is invalid (can't have subpath after repo star)
+            (ParsedSegment::Star, Some(_), _) => Err(anyhow::anyhow!("invalid pattern: {s}")),
+
+            // ================================================================
+            // Patterns without subpath
+            // ================================================================
+            // owner/repo or owner/repo-* (no subpath, no ref)
+            (ParsedSegment::Segment(repo), None, None) => Ok(RepositoryUsesPattern::ExactRepo {
                 owner: owner.into(),
-                repo: repo.into(),
+                repo: repo.clone(),
             }),
-            (_, "*", Some(_), _) => Err(anyhow::anyhow!("invalid pattern: {s}")),
-            (owner, repo, Some("*"), None) => Ok(RepositoryUsesPattern::InRepo {
-                owner: owner.into(),
-                repo: repo.into(),
-            }),
-            (owner, repo, Some(subpath), None) => Ok(RepositoryUsesPattern::ExactPath {
-                owner: owner.into(),
-                repo: repo.into(),
-                subpath: subpath.into(),
-            }),
-            (_, _, Some("*"), Some(_)) => Err(anyhow::anyhow!("invalid pattern: {s}")),
-            (owner, repo, subpath, Some(git_ref)) => Ok(RepositoryUsesPattern::ExactWithRef {
-                owner: owner.into(),
-                repo: repo.into(),
-                subpath: subpath.map(|s| s.into()),
-                git_ref: git_ref.into(),
-            }),
+
+            // owner/repo@ref or owner/repo-*@ref (no subpath, with ref)
+            (ParsedSegment::Segment(repo), None, Some(r)) => {
+                Ok(RepositoryUsesPattern::ExactWithRef {
+                    owner: owner.into(),
+                    repo: repo.clone(),
+                    subpath: None,
+                    git_ref: r.into(),
+                })
+            }
+
+            // ================================================================
+            // Patterns with subpath = *
+            // ================================================================
+            // owner/repo/* or owner/repo-*/* (any subpath)
+            (ParsedSegment::Segment(repo), Some(ParsedSegment::Star), None) => {
+                Ok(RepositoryUsesPattern::InRepo {
+                    owner: owner.into(),
+                    repo: repo.clone(),
+                })
+            }
+
+            // owner/repo/*@ref is invalid (can't combine subpath star with ref)
+            (_, Some(ParsedSegment::Star), Some(_)) => Err(anyhow::anyhow!("invalid pattern: {s}")),
+
+            // ================================================================
+            // Patterns with exact or glob subpath
+            // ================================================================
+            // owner/repo/subpath or owner/repo-*/subpath or owner/repo/subpath-*
+            (ParsedSegment::Segment(repo), Some(ParsedSegment::Segment(subpath)), None) => {
+                Ok(RepositoryUsesPattern::ExactPath {
+                    owner: owner.into(),
+                    repo: repo.clone(),
+                    subpath: subpath.clone(),
+                })
+            }
+
+            // owner/repo/subpath@ref or owner/repo-*/subpath@ref or owner/repo/subpath-*@ref
+            (ParsedSegment::Segment(repo), Some(ParsedSegment::Segment(subpath)), Some(r)) => {
+                Ok(RepositoryUsesPattern::ExactWithRef {
+                    owner: owner.into(),
+                    repo: repo.clone(),
+                    subpath: Some(subpath.clone()),
+                    git_ref: r.into(),
+                })
+            }
         }
     }
 }
@@ -160,15 +405,6 @@ impl FromStr for RepositoryUsesPattern {
 impl std::fmt::Display for RepositoryUsesPattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RepositoryUsesPattern::Any => write!(f, "*"),
-            RepositoryUsesPattern::InOwner(owner) => write!(f, "{owner}/*"),
-            RepositoryUsesPattern::InRepo { owner, repo } => write!(f, "{owner}/{repo}/*"),
-            RepositoryUsesPattern::ExactRepo { owner, repo } => write!(f, "{owner}/{repo}"),
-            RepositoryUsesPattern::ExactPath {
-                owner,
-                repo,
-                subpath,
-            } => write!(f, "{owner}/{repo}/{subpath}"),
             RepositoryUsesPattern::ExactWithRef {
                 owner,
                 repo,
@@ -178,6 +414,15 @@ impl std::fmt::Display for RepositoryUsesPattern {
                 Some(subpath) => write!(f, "{owner}/{repo}/{subpath}@{git_ref}"),
                 None => write!(f, "{owner}/{repo}@{git_ref}"),
             },
+            RepositoryUsesPattern::ExactPath {
+                owner,
+                repo,
+                subpath,
+            } => write!(f, "{owner}/{repo}/{subpath}"),
+            RepositoryUsesPattern::ExactRepo { owner, repo } => write!(f, "{owner}/{repo}"),
+            RepositoryUsesPattern::InRepo { owner, repo } => write!(f, "{owner}/{repo}/*"),
+            RepositoryUsesPattern::InOwner(owner) => write!(f, "{owner}/*"),
+            RepositoryUsesPattern::Any => write!(f, "*"),
         }
     }
 }
@@ -283,7 +528,110 @@ mod tests {
     use anyhow::anyhow;
     use github_actions_models::common::Uses;
 
-    use super::RepositoryUsesPattern;
+    use super::{ParsedSegment, RepositoryUsesPattern, Segment};
+
+    #[test]
+    fn test_parsed_segment_parse() {
+        // Exact segments
+        assert_eq!(
+            ParsedSegment::parse("checkout"),
+            Some(ParsedSegment::Segment(Segment::Exact("checkout".into())))
+        );
+        assert_eq!(
+            ParsedSegment::parse("foo-bar"),
+            Some(ParsedSegment::Segment(Segment::Exact("foo-bar".into())))
+        );
+
+        // Star (full wildcard)
+        assert_eq!(ParsedSegment::parse("*"), Some(ParsedSegment::Star));
+
+        // Glob segments
+        assert_eq!(
+            ParsedSegment::parse("foo-*"),
+            Some(ParsedSegment::Segment(Segment::Glob {
+                prefix: "foo-".into(),
+                suffix: "".into()
+            }))
+        );
+        assert_eq!(
+            ParsedSegment::parse("*-bar"),
+            Some(ParsedSegment::Segment(Segment::Glob {
+                prefix: "".into(),
+                suffix: "-bar".into()
+            }))
+        );
+        assert_eq!(
+            ParsedSegment::parse("foo-*-bar"),
+            Some(ParsedSegment::Segment(Segment::Glob {
+                prefix: "foo-".into(),
+                suffix: "-bar".into()
+            }))
+        );
+
+        // Multiple wildcards - not supported
+        assert_eq!(ParsedSegment::parse("foo-*-*"), None);
+        assert_eq!(ParsedSegment::parse("**"), None);
+    }
+
+    #[test]
+    fn test_segment_matches() {
+        // Exact matching
+        let exact = Segment::Exact("checkout".into());
+        assert!(exact.matches("checkout"));
+        assert!(!exact.matches("Checkout")); // case-sensitive
+        assert!(!exact.matches("checkout-v2"));
+
+        // Case-insensitive exact matching
+        assert!(exact.matches_ignore_ascii_case("checkout"));
+        assert!(exact.matches_ignore_ascii_case("CHECKOUT"));
+        assert!(exact.matches_ignore_ascii_case("Checkout"));
+
+        // Glob matching - prefix
+        let prefix_glob = Segment::Glob {
+            prefix: "foo-".into(),
+            suffix: "".into(),
+        };
+        assert!(prefix_glob.matches("foo-bar"));
+        assert!(prefix_glob.matches("foo-"));
+        assert!(prefix_glob.matches("foo-baz-qux"));
+        assert!(!prefix_glob.matches("bar-foo"));
+        assert!(!prefix_glob.matches("foo"));
+
+        // Glob matching - suffix
+        let suffix_glob = Segment::Glob {
+            prefix: "".into(),
+            suffix: "-bar".into(),
+        };
+        assert!(suffix_glob.matches("foo-bar"));
+        assert!(suffix_glob.matches("-bar"));
+        assert!(suffix_glob.matches("baz-qux-bar"));
+        assert!(!suffix_glob.matches("bar-foo"));
+        assert!(!suffix_glob.matches("bar"));
+
+        // Glob matching - case insensitive
+        assert!(prefix_glob.matches_ignore_ascii_case("FOO-bar"));
+        assert!(prefix_glob.matches_ignore_ascii_case("Foo-BAZ"));
+    }
+
+    #[test]
+    fn test_segment_ordering() {
+        let exact = Segment::Exact("checkout".into());
+        let short_glob = Segment::Glob {
+            prefix: "foo-".into(),
+            suffix: "".into(),
+        };
+        let long_glob = Segment::Glob {
+            prefix: "foo-bar-".into(),
+            suffix: "-baz".into(),
+        };
+
+        // Exact is more specific than any glob
+        assert!(exact < short_glob);
+        assert!(exact < long_glob);
+
+        // Longer globs are more specific than shorter globs
+        assert!(long_glob < short_glob);
+    }
 
     #[test]
     fn test_repositoryusespattern_parse() {
@@ -292,7 +640,7 @@ mod tests {
             ("/", None),     // Invalid, not well formed
             ("//", None),    // Invalid, not well formed
             ("///", None),   // Invalid, not well formed
-            ("owner", None), // Invalid, sho,uld be owner/*
+            ("owner", None), // Invalid, should be owner/*
             ("**", None),    // Invalid, should be *
             ("*", Some(RepositoryUsesPattern::Any)),
             (
@@ -308,22 +656,22 @@ mod tests {
                 "owner/repo/*",
                 Some(RepositoryUsesPattern::InRepo {
                     owner: "owner".into(),
-                    repo: "repo".into(),
+                    repo: Segment::Exact("repo".into()),
                 }),
             ),
             (
                 "owner/repo",
                 Some(RepositoryUsesPattern::ExactRepo {
                     owner: "owner".into(),
-                    repo: "repo".into(),
+                    repo: Segment::Exact("repo".into()),
                 }),
             ),
             (
                 "owner/repo/subpath",
                 Some(RepositoryUsesPattern::ExactPath {
                     owner: "owner".into(),
-                    repo: "repo".into(),
-                    subpath: "subpath".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Segment::Exact("subpath".into()),
                 }),
             ),
             // We don't do any subpath normalization at construction time.
@@ -331,31 +679,31 @@ mod tests {
                 "owner/repo//",
                 Some(RepositoryUsesPattern::ExactPath {
                     owner: "owner".into(),
-                    repo: "repo".into(),
-                    subpath: "/".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Segment::Exact("/".into()),
                 }),
             ),
             (
                 "owner/repo/subpath/",
                 Some(RepositoryUsesPattern::ExactPath {
                     owner: "owner".into(),
-                    repo: "repo".into(),
-                    subpath: "subpath/".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Segment::Exact("subpath/".into()),
                 }),
             ),
             (
                 "owner/repo/subpath/very/nested////and/literal",
                 Some(RepositoryUsesPattern::ExactPath {
                     owner: "owner".into(),
-                    repo: "repo".into(),
-                    subpath: "subpath/very/nested////and/literal".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Segment::Exact("subpath/very/nested////and/literal".into()),
                 }),
             ),
             (
                 "owner/repo@v1",
                 Some(RepositoryUsesPattern::ExactWithRef {
                     owner: "owner".into(),
-                    repo: "repo".into(),
+                    repo: Segment::Exact("repo".into()),
                     subpath: None,
                     git_ref: "v1".into(),
                 }),
@@ -364,8 +712,8 @@ mod tests {
                 "owner/repo/subpath@v1",
                 Some(RepositoryUsesPattern::ExactWithRef {
                     owner: "owner".into(),
-                    repo: "repo".into(),
-                    subpath: Some("subpath".into()),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Some(Segment::Exact("subpath".into())),
                     git_ref: "v1".into(),
                 }),
             ),
@@ -373,7 +721,7 @@ mod tests {
                 "owner/repo@172239021f7ba04fe7327647b213799853a9eb89",
                 Some(RepositoryUsesPattern::ExactWithRef {
                     owner: "owner".into(),
-                    repo: "repo".into(),
+                    repo: Segment::Exact("repo".into()),
                     subpath: None,
                     git_ref: "172239021f7ba04fe7327647b213799853a9eb89".into(),
                 }),
@@ -382,16 +730,17 @@ mod tests {
                 "pypa/gh-action-pypi-publish@release/v1",
                 Some(RepositoryUsesPattern::ExactWithRef {
                     owner: "pypa".into(),
-                    repo: "gh-action-pypi-publish".into(),
+                    repo: Segment::Exact("gh-action-pypi-publish".into()),
                     subpath: None,
                     git_ref: "release/v1".into(),
                 }),
             ),
-            // Invalid: no wildcards allowed when refs are present.
+            // Invalid: no wildcards allowed when refs are present (subpath star only).
             ("owner/repo/*@v1", None),
-            ("owner/repo/*/subpath@v1", None),
-            ("owner/*/subpath@v1", None),
-            ("*/*/subpath@v1", None),
+            // Note: owner/repo/*/subpath@v1 is now VALID - it's a subpath glob matching "*" + "/subpath"
+            // See the glob patterns section below for the expected parse result.
+            ("owner/*/subpath@v1", None), // Invalid: can't have subpath after repo star
+            ("*/*/subpath@v1", None),     // Invalid: owner can't be wildcard
             // Ref also cannot be a wildcard.
             ("owner/repo@*", None),
             ("owner/repo@**", None),
@@ -399,9 +748,144 @@ mod tests {
             ("owner/repo/subpath@*", None),
             ("owner/*@*", None),
             ("*@*", None),
+            // ================================================================
+            // NEW: Glob patterns
+            // ================================================================
+            // Repo globs
+            (
+                "owner/foo-*",
+                Some(RepositoryUsesPattern::ExactRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                }),
+            ),
+            (
+                "owner/*-bar",
+                Some(RepositoryUsesPattern::ExactRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "".into(),
+                        suffix: "-bar".into(),
+                    },
+                }),
+            ),
+            // Glob with both prefix and suffix (single * with text on both sides)
+            (
+                "owner/foo-*-bar",
+                Some(RepositoryUsesPattern::ExactRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "-bar".into(),
+                    },
+                }),
+            ),
+            (
+                "owner/foo-*/*",
+                Some(RepositoryUsesPattern::InRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                }),
+            ),
+            (
+                "owner/foo-*/subpath",
+                Some(RepositoryUsesPattern::ExactPath {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                    subpath: Segment::Exact("subpath".into()),
+                }),
+            ),
+            (
+                "owner/foo-*/subpath@v1",
+                Some(RepositoryUsesPattern::ExactWithRef {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                    subpath: Some(Segment::Exact("subpath".into())),
+                    git_ref: "v1".into(),
+                }),
+            ),
+            (
+                "owner/foo-*@v1",
+                Some(RepositoryUsesPattern::ExactWithRef {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                    subpath: None,
+                    git_ref: "v1".into(),
+                }),
+            ),
+            // Subpath globs
+            (
+                "owner/repo/sub-*",
+                Some(RepositoryUsesPattern::ExactPath {
+                    owner: "owner".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Segment::Glob {
+                        prefix: "sub-".into(),
+                        suffix: "".into(),
+                    },
+                }),
+            ),
+            (
+                "owner/repo/sub-*@v1",
+                Some(RepositoryUsesPattern::ExactWithRef {
+                    owner: "owner".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Some(Segment::Glob {
+                        prefix: "sub-".into(),
+                        suffix: "".into(),
+                    }),
+                    git_ref: "v1".into(),
+                }),
+            ),
+            // Subpath glob with suffix (matches */subpath pattern)
+            (
+                "owner/repo/*/subpath@v1",
+                Some(RepositoryUsesPattern::ExactWithRef {
+                    owner: "owner".into(),
+                    repo: Segment::Exact("repo".into()),
+                    subpath: Some(Segment::Glob {
+                        prefix: "".into(),
+                        suffix: "/subpath".into(),
+                    }),
+                    git_ref: "v1".into(),
+                }),
+            ),
+            // Combined repo and subpath globs
+            (
+                "owner/foo-*/sub-*",
+                Some(RepositoryUsesPattern::ExactPath {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                    subpath: Segment::Glob {
+                        prefix: "sub-".into(),
+                        suffix: "".into(),
+                    },
+                }),
+            ),
+            // Invalid: multiple wildcards in segment
+            ("owner/foo-*-*", None),
+            ("owner/repo/sub-*-*", None),
         ] {
             let pattern = RepositoryUsesPattern::from_str(pattern).ok();
-            assert_eq!(pattern, expected);
+            assert_eq!(pattern, expected, "pattern: {pattern:?}");
         }
     }
 
@@ -411,7 +895,7 @@ mod tests {
             RepositoryUsesPattern::Any,
             RepositoryUsesPattern::ExactRepo {
                 owner: "owner".into(),
-                repo: "repo".into(),
+                repo: Segment::Exact("repo".into()),
             },
             RepositoryUsesPattern::InOwner("owner".into()),
         ];
@@ -423,10 +907,56 @@ mod tests {
             vec![
                 RepositoryUsesPattern::ExactRepo {
                     owner: "owner".into(),
-                    repo: "repo".into()
+                    repo: Segment::Exact("repo".into()),
                 },
                 RepositoryUsesPattern::InOwner("owner".into()),
                 RepositoryUsesPattern::Any,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_repositoryusespattern_ord_with_globs() {
+        let mut patterns = vec![
+            RepositoryUsesPattern::ExactRepo {
+                owner: "owner".into(),
+                repo: Segment::Glob {
+                    prefix: "foo-".into(),
+                    suffix: "".into(),
+                },
+            },
+            RepositoryUsesPattern::ExactRepo {
+                owner: "owner".into(),
+                repo: Segment::Exact("foo-bar".into()),
+            },
+            RepositoryUsesPattern::InRepo {
+                owner: "owner".into(),
+                repo: Segment::Exact("foo-bar".into()),
+            },
+        ];
+
+        patterns.sort();
+
+        // Exact repo should come before glob repo
+        // InRepo should come after both ExactRepo variants
+        assert_eq!(
+            patterns,
+            vec![
+                RepositoryUsesPattern::ExactRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Exact("foo-bar".into()),
+                },
+                RepositoryUsesPattern::ExactRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Glob {
+                        prefix: "foo-".into(),
+                        suffix: "".into(),
+                    },
+                },
+                RepositoryUsesPattern::InRepo {
+                    owner: "owner".into(),
+                    repo: Segment::Exact("foo-bar".into()),
+                },
             ]
         );
     }
@@ -484,6 +1014,56 @@ mod tests {
             ("actions/checkout@v3", "actions/checkout@v3", true),
             ("actions/checkout/foo@v3", "actions/checkout/foo@v3", true),
             ("actions/checkout/foo@v1", "actions/checkout/foo@v3", false),
+            // ================================================================
+            // NEW: Glob pattern matching
+            // ================================================================
+            // Repo globs - basic matching
+            ("org/foo-bar@v1", "org/foo-*", true),
+            ("org/foo-baz@v1", "org/foo-*", true),
+            ("org/foo-@v1", "org/foo-*", true), // edge case: just prefix
+            ("org/bar-foo@v1", "org/foo-*", false), // doesn't start with prefix
+            ("org/foo@v1", "org/foo-*", false), // missing hyphen
+            // Repo globs - suffix matching
+            ("org/bar-action@v1", "org/*-action", true),
+            ("org/foo-action@v1", "org/*-action", true),
+            ("org/action-bar@v1", "org/*-action", false),
+            // Repo globs - prefix AND suffix matching (single * with text on both sides)
+            ("org/foo-something-bar@v1", "org/foo-*-bar", true),
+            ("org/foo--bar@v1", "org/foo-*-bar", true), // empty middle is valid (matches "")
+            ("org/foo-x-bar@v1", "org/foo-*-bar", true),
+            ("org/foo-bar@v1", "org/foo-*-bar", false), // too short: prefix+suffix overlap
+            ("org/foo-something-baz@v1", "org/foo-*-bar", false), // wrong suffix
+            ("org/baz-something-bar@v1", "org/foo-*-bar", false), // wrong prefix
+            // Repo globs - case insensitivity (repo matching)
+            ("org/FOO-BAR@v1", "org/foo-*", true),
+            ("ORG/foo-bar@v1", "org/foo-*", true),
+            // Repo globs - no subpath allowed for ExactRepo variant
+            ("org/foo-bar@v1", "org/foo-*", true),
+            ("org/foo-bar/subpath@v1", "org/foo-*", false), // Has subpath, pattern doesn't allow
+            // Repo globs with InRepo (/*) - allows subpaths
+            ("org/foo-bar@v1", "org/foo-*/*", true),
+            ("org/foo-bar/subpath@v1", "org/foo-*/*", true),
+            ("org/foo-bar/deep/path@v1", "org/foo-*/*", true),
+            // Repo globs with specific subpath
+            ("org/foo-bar/init@v1", "org/foo-*/init", true),
+            ("org/foo-baz/init@v1", "org/foo-*/init", true),
+            ("org/foo-bar/other@v1", "org/foo-*/init", false),
+            // Repo globs with ref
+            ("org/foo-bar@v1", "org/foo-*@v1", true),
+            ("org/foo-bar@v2", "org/foo-*@v1", false),
+            ("org/foo-bar/sub@v1", "org/foo-*/sub@v1", true),
+            // Subpath globs
+            ("org/repo/sub-foo@v1", "org/repo/sub-*", true),
+            ("org/repo/sub-bar@v1", "org/repo/sub-*", true),
+            ("org/repo/other@v1", "org/repo/sub-*", false),
+            // Subpath globs - case sensitivity (subpath is case-sensitive)
+            ("org/repo/sub-foo@v1", "org/repo/sub-*", true),
+            ("org/repo/SUB-foo@v1", "org/repo/sub-*", false), // case mismatch
+            // Combined repo and subpath globs
+            ("org/foo-bar/sub-baz@v1", "org/foo-*/sub-*", true),
+            ("org/foo-qux/sub-quux@v1", "org/foo-*/sub-*", true),
+            ("org/bar-foo/sub-baz@v1", "org/foo-*/sub-*", false), // repo doesn't match
+            ("org/foo-bar/other@v1", "org/foo-*/sub-*", false),   // subpath doesn't match
         ] {
             let Ok(Uses::Repository(uses)) = Uses::parse(uses) else {
                 return Err(anyhow!("invalid uses: {uses}"));
@@ -494,10 +1074,34 @@ mod tests {
             assert_eq!(
                 pattern.matches(&uses),
                 matches,
-                "pattern: {pattern:?}, uses: {uses:?}, matches: {matches}"
+                "pattern: {pattern:?}, uses: {uses:?}, expected matches: {matches}"
             );
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_repositoryusespattern_display() {
+        // Test that Display roundtrips correctly for glob patterns
+        let patterns = [
+            "owner/foo-*",
+            "owner/*-bar",
+            "owner/foo-*/*",
+            "owner/foo-*/subpath",
+            "owner/foo-*@v1",
+            "owner/foo-*/subpath@v1",
+            "owner/repo/sub-*",
+            "owner/repo/sub-*@v1",
+        ];
+
+        for pattern_str in patterns {
+            let pattern = RepositoryUsesPattern::from_str(pattern_str).unwrap();
+            assert_eq!(
+                pattern.to_string(),
+                pattern_str,
+                "Display roundtrip failed for {pattern_str}"
+            );
+        }
     }
 }

--- a/crates/zizmor/src/models/uses.rs
+++ b/crates/zizmor/src/models/uses.rs
@@ -149,7 +149,6 @@ impl Segment {
             // Exact is most specific (0), with no length consideration
             Segment::Exact(_) => (0, Reverse(0)),
             // Wildcard is less specific (1), but longer literals are more specific
-            // Using Reverse so that longer lengths sort first (more specific)
             Segment::Wildcard { prefix, suffix } => (1, Reverse(prefix.len() + suffix.len())),
         }
     }
@@ -327,7 +326,6 @@ impl FromStr for RepositoryUsesPattern {
             })
             .transpose()?;
 
-        // Build the appropriate pattern variant
         match (&repo_parsed, &subpath_parsed, git_ref) {
             // owner/* matches any repo under owner
             (ParsedSegment::Star, None, None) => Ok(RepositoryUsesPattern::InOwner(owner.into())),
@@ -722,7 +720,6 @@ mod tests {
             ),
             // Invalid: no wildcards allowed when refs are present (subpath star only).
             ("owner/repo/*@v1", None),
-            // Note: owner/repo/*/subpath@v1 is now VALID - it's a subpath wildcard matching "*" + "/subpath"
             ("owner/*/subpath@v1", None), // Invalid: can't have subpath after repo star
             ("*/*/subpath@v1", None),     // Invalid: owner can't be wildcard
             // Ref also cannot be a wildcard.

--- a/crates/zizmor/tests/integration/audit/unpinned_uses.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_uses.rs
@@ -558,7 +558,7 @@ fn test_invalid_policy_syntax_4() -> Result<()> {
     Caused by:
         0: configuration error in @@CONFIG@@
         1: invalid syntax for audit `unpinned-uses`
-        2: invalid pattern: foo/b*r
+        2: invalid pattern: foo/b*r*
     "
     );
 

--- a/crates/zizmor/tests/integration/test-data/forbidden-uses/configs/allow-glob.yml
+++ b/crates/zizmor/tests/integration/test-data/forbidden-uses/configs/allow-glob.yml
@@ -1,0 +1,14 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # just to make unrelated findings go away
+        "*": ref-pin
+
+  forbidden-uses:
+    config:
+      allow:
+        # Allow all actions/* repos using glob
+        - "actions/*"
+        # Allow pypa repos starting with "gh-action-"
+        - "pypa/gh-action-*"

--- a/crates/zizmor/tests/integration/test-data/forbidden-uses/configs/deny-glob.yml
+++ b/crates/zizmor/tests/integration/test-data/forbidden-uses/configs/deny-glob.yml
@@ -1,0 +1,12 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # just to make unrelated findings go away
+        "*": ref-pin
+
+  forbidden-uses:
+    config:
+      deny:
+        # Deny all repos ending with "-pypi-publish"
+        - "pypa/*-pypi-publish"

--- a/crates/zizmor/tests/integration/test-data/unpinned-uses/configs/invalid-policy-syntax-4.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-uses/configs/invalid-policy-syntax-4.yml
@@ -2,5 +2,5 @@ rules:
   unpinned-uses:
     config:
       policies:
-        # Invalid: * must be alone in repo position
-        "foo/b*r": "any"
+        # Invalid: multiple wildcards in a single segment
+        "foo/b*r*": "any"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,7 +182,9 @@ common syntaxes, and are described here.
 
 Repository patterns are used to match `#!yaml uses:` clauses.
 
-The following patterns are supported, in order of specificity:
+The following patterns are supported, in order of specificity (most specific first).
+When multiple patterns match a `#!yaml uses:` clause, the most specific pattern
+takes precedence.
 
 * `owner/repo/subpath@ref`: matches the exact repository, including
   subpath (if given) and ref. The subpath is optional.
@@ -212,6 +214,51 @@ The following patterns are supported, in order of specificity:
         but **not** `#!yaml uses: actions/cache/save@v3` or
         `#!yaml uses: actions/cache/restore@v3`.
 
+* `owner/prefix-*`, `owner/*-suffix`, `owner/prefix-*-suffix`: match repos where
+  the repo name matches the given prefix and/or suffix. A single `*` acts as a
+  wildcard matching any characters. No subpath is matched.
+
+    !!! example
+
+        `myorg/action-*` matches `#!yaml uses: myorg/action-checkout@v1`
+        and `#!yaml uses: myorg/action-setup@v2`, but **not**
+        `#!yaml uses: myorg/action-checkout/subdir@v1` (which has a subpath).
+
+        `myorg/*-action` matches `#!yaml uses: myorg/checkout-action@v1`
+        and `#!yaml uses: myorg/setup-action@v2`.
+
+* `owner/prefix-*/*`: match repos where the repo name matches the prefix,
+  including any subpath.
+
+    !!! example
+
+        `myorg/action-*/*` matches `#!yaml uses: myorg/action-checkout@v1`,
+        `#!yaml uses: myorg/action-checkout/subdir@v1`, and
+        `#!yaml uses: myorg/action-setup/init@v2`.
+
+* `owner/prefix-*/subpath`, `owner/repo/subpath-*`, `owner/prefix-*/subpath-*`:
+  match using wildcards in the repo name, subpath, or both.
+
+    !!! example
+
+        `github/codeql-*/init` matches `#!yaml uses: github/codeql-action/init@v3`
+        and `#!yaml uses: github/codeql-bundle/init@v2`.
+
+        `github/codeql-action/init-*` matches
+        `#!yaml uses: github/codeql-action/init-db@v3` but **not**
+        `#!yaml uses: github/codeql-action/upload@v3`.
+
+        `myorg/action-*/init-*` matches `#!yaml uses: myorg/action-db/init-schema@v1`
+        and `#!yaml uses: myorg/action-cache/init-store@v2`.
+
+* `owner/prefix-*@ref`: match repos where the repo name matches the prefix,
+  with an exact ref.
+
+    !!! example
+
+        `myorg/action-*@v1` matches `#!yaml uses: myorg/action-checkout@v1`
+        but **not** `#!yaml uses: myorg/action-checkout@v2`.
+
 * `owner/repo/*`: match all `#!yaml uses:` clauses that come from the given
   `owner/repo`. Any subpath or ref is matched.
 
@@ -237,79 +284,6 @@ The following patterns are supported, in order of specificity:
 
         `*` matches `#!yaml uses: actions/checkout` and
         `#!yaml uses: pypa/gh-action-pypi-publish@release/v1`.
-
-#### Glob patterns
-
-In addition to exact matches and full wildcards (`*`), patterns can include
-**glob wildcards** within repo or subpath segments. A glob pattern contains
-exactly one `*` character within a segment, allowing prefix or suffix matching.
-
-!!! note
-
-    Glob patterns are less specific than exact patterns. When multiple patterns
-    match a `#!yaml uses:` clause, the most specific pattern takes precedence.
-
-The following glob patterns are supported:
-
-* `owner/prefix-*`: match repos starting with `prefix-`. No subpath is matched.
-
-    !!! example
-
-        `myorg/action-*` matches `#!yaml uses: myorg/action-checkout@v1`
-        and `#!yaml uses: myorg/action-setup@v2`, but **not**
-        `#!yaml uses: myorg/action-checkout/subdir@v1` (which has a subpath).
-
-* `owner/*-suffix`: match repos ending with `-suffix`. No subpath is matched.
-
-    !!! example
-
-        `myorg/*-action` matches `#!yaml uses: myorg/checkout-action@v1`
-        and `#!yaml uses: myorg/setup-action@v2`.
-
-* `owner/prefix-*-suffix`: match repos starting with `prefix-` and ending with `-suffix`.
-
-    !!! example
-
-        `myorg/action-*-v2` matches `#!yaml uses: myorg/action-checkout-v2@v1`
-        and `#!yaml uses: myorg/action-setup-v2@v1`, but **not**
-        `#!yaml uses: myorg/action-checkout-v1@v1`.
-
-* `owner/prefix-*/*`: match repos starting with `prefix-`, including any subpath.
-
-    !!! example
-
-        `myorg/action-*/*` matches `#!yaml uses: myorg/action-checkout@v1`,
-        `#!yaml uses: myorg/action-checkout/subdir@v1`, and
-        `#!yaml uses: myorg/action-setup/init@v2`.
-
-* `owner/prefix-*/subpath`: match repos starting with `prefix-` with an exact subpath.
-
-    !!! example
-
-        `github/codeql-*/init` matches `#!yaml uses: github/codeql-action/init@v3`
-        and `#!yaml uses: github/codeql-bundle/init@v2`.
-
-* `owner/prefix-*@ref`: match repos starting with `prefix-` with an exact ref.
-
-    !!! example
-
-        `myorg/action-*@v1` matches `#!yaml uses: myorg/action-checkout@v1`
-        but **not** `#!yaml uses: myorg/action-checkout@v2`.
-
-* `owner/repo/subpath-*`: match subpaths starting with `subpath-` in an exact repo.
-
-    !!! example
-
-        `github/codeql-action/init-*` matches
-        `#!yaml uses: github/codeql-action/init-db@v3` but **not**
-        `#!yaml uses: github/codeql-action/upload@v3`.
-
-* Combined patterns: both repo and subpath can use globs.
-
-    !!! example
-
-        `myorg/action-*/init-*` matches `#!yaml uses: myorg/action-db/init-schema@v1`
-        and `#!yaml uses: myorg/action-cache/init-store@v2`.
 
 !!! warning
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,3 +237,81 @@ The following patterns are supported, in order of specificity:
 
         `*` matches `#!yaml uses: actions/checkout` and
         `#!yaml uses: pypa/gh-action-pypi-publish@release/v1`.
+
+#### Glob patterns
+
+In addition to exact matches and full wildcards (`*`), patterns can include
+**glob wildcards** within repo or subpath segments. A glob pattern contains
+exactly one `*` character within a segment, allowing prefix or suffix matching.
+
+!!! note
+
+    Glob patterns are less specific than exact patterns. When multiple patterns
+    match a `#!yaml uses:` clause, the most specific pattern takes precedence.
+
+The following glob patterns are supported:
+
+* `owner/prefix-*`: match repos starting with `prefix-`. No subpath is matched.
+
+    !!! example
+
+        `myorg/action-*` matches `#!yaml uses: myorg/action-checkout@v1`
+        and `#!yaml uses: myorg/action-setup@v2`, but **not**
+        `#!yaml uses: myorg/action-checkout/subdir@v1` (which has a subpath).
+
+* `owner/*-suffix`: match repos ending with `-suffix`. No subpath is matched.
+
+    !!! example
+
+        `myorg/*-action` matches `#!yaml uses: myorg/checkout-action@v1`
+        and `#!yaml uses: myorg/setup-action@v2`.
+
+* `owner/prefix-*-suffix`: match repos starting with `prefix-` and ending with `-suffix`.
+
+    !!! example
+
+        `myorg/action-*-v2` matches `#!yaml uses: myorg/action-checkout-v2@v1`
+        and `#!yaml uses: myorg/action-setup-v2@v1`, but **not**
+        `#!yaml uses: myorg/action-checkout-v1@v1`.
+
+* `owner/prefix-*/*`: match repos starting with `prefix-`, including any subpath.
+
+    !!! example
+
+        `myorg/action-*/*` matches `#!yaml uses: myorg/action-checkout@v1`,
+        `#!yaml uses: myorg/action-checkout/subdir@v1`, and
+        `#!yaml uses: myorg/action-setup/init@v2`.
+
+* `owner/prefix-*/subpath`: match repos starting with `prefix-` with an exact subpath.
+
+    !!! example
+
+        `github/codeql-*/init` matches `#!yaml uses: github/codeql-action/init@v3`
+        and `#!yaml uses: github/codeql-bundle/init@v2`.
+
+* `owner/prefix-*@ref`: match repos starting with `prefix-` with an exact ref.
+
+    !!! example
+
+        `myorg/action-*@v1` matches `#!yaml uses: myorg/action-checkout@v1`
+        but **not** `#!yaml uses: myorg/action-checkout@v2`.
+
+* `owner/repo/subpath-*`: match subpaths starting with `subpath-` in an exact repo.
+
+    !!! example
+
+        `github/codeql-action/init-*` matches
+        `#!yaml uses: github/codeql-action/init-db@v3` but **not**
+        `#!yaml uses: github/codeql-action/upload@v3`.
+
+* Combined patterns: both repo and subpath can use globs.
+
+    !!! example
+
+        `myorg/action-*/init-*` matches `#!yaml uses: myorg/action-db/init-schema@v1`
+        and `#!yaml uses: myorg/action-cache/init-store@v2`.
+
+!!! warning
+
+    Multiple wildcards within a single segment are **not** supported.
+    For example, `owner/foo-*-*` is invalid (two `*` characters in the repo segment).

--- a/support/zizmor.schema.json
+++ b/support/zizmor.schema.json
@@ -125,7 +125,7 @@
     },
     "RepositoryUsesPattern": {
       "title": "Represents a pattern for matching repository `uses` references.",
-      "description": "These patterns are ordered by specificity; more specific patterns\nshould be listed first.",
+      "description": "These patterns are ordered by specificity; more specific patterns\nshould be listed first. The ordering is:\n\n1. `ExactWithRef` - most specific (matches owner/repo/subpath@ref exactly)\n2. `ExactPath` - matches owner/repo/subpath (any ref)\n3. `ExactRepo` - matches owner/repo with no subpath (any ref)\n4. `InRepo` - matches owner/repo/* (any subpath, any ref)\n5. `InOwner` - matches owner/* (any repo, any subpath, any ref)\n6. `Any` - matches * (everything)\n\nWithin variants that have `Segment` fields, patterns with exact segments\nare more specific than patterns with wildcard segments.",
       "type": "string"
     },
     "RulesConfig": {


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first) - discussed with @woodruffw on discord

- [x] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use. - code review, slight optimization regarding string allocation

## Summary
Add support for glob wildcards (e.g., `foo-*`, `*-bar`, `foo-*-bar`) in repository and subpath pattern matching for `uses:` clauses. This allows more flexible policy configuration for any audit that uses repository patterns, such as `unpinned-uses` and `forbidden-uses`. Used intuition for each of the possible cases and how they should behave, so I'm happy to adjust based on other perspectives!

Changes:
- Add `Segment` enum to represent exact or glob pattern matches
- Add `ParsedSegment` enum for parsing patterns with `*` wildcards
- Update `RepositoryUsesPattern` to use `Segment` for repo/subpath fields
- Implement specificity ordering so exact patterns take precedence over globs
- Optimize case-insensitive matching to avoid string allocations
- Add comprehensive tests for glob pattern parsing and matching
- Document glob patterns in configuration.md

## New Patterns Supported

- `owner/prefix-*` - match repos starting with `prefix-`
- `owner/*-suffix` - match repos ending with `-suffix`
- `owner/prefix-*-suffix` - match repos with both prefix and suffix
- `owner/prefix-*/*` - match repos with prefix, any subpath
- `owner/repo/subpath-*` - match subpaths with glob
- Combined: `owner/prefix-*/subpath-*`

## Example Configuration

### unpinned-uses:

```yaml
rules:
  unpinned-uses:
    config:
      policies:
        "github/codeql-*/*": "hash-pin"  # All codeql actions
        "myorg/action-*": "ref-pin"       # All myorg action-* repos
```

### forbidden-uses:

```yaml
rules:
  forbidden-uses:
    config:
      allow:
        - "actions/*"           # Allow all actions org repos
        - "myorg/trusted-*"     # Allow myorg repos starting with "trusted-"
      # OR
      deny:
        - "untrusted-org/*-exploit"  # Deny repos ending with "-exploit"
 ```

## Implementation

- New `Segment` enum handles exact vs glob matching
- Glob patterns with single * are supported while multiple wildcards per segment are rejected
- Specificity ordering ensures exact patterns take precedence over globs
- Case-insensitive matching optimized to avoid heap allocations

## Test Plan

- Added unit tests for `Segment` and `ParsedSegment` parsing
- Added pattern matching tests covering all glob variants
- Added ordering tests to verify specificity
- Added integration tests for `unpinned-uses` with invalid multi-wildcard patterns and `forbidden-uses` with glob patterns in allow/deny lists
- All existing tests continue to pass