### PR TITLE
Flag issue_comment as a dangerous trigger

### DIFF
--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -55,6 +55,24 @@ impl Audit for DangerousTriggers {
                     .build(workflow)?,
             );
         }
+        if workflow.has_issue_comment() {
+            findings.push(
+                Self::finding()
+                    .confidence(Confidence::Medium)
+                    .severity(Severity::Medium)
+                    .add_location(
+                        workflow
+                            .location()
+                            .primary()
+                            .with_keys(["on".into()])
+                            .annotated(
+                                "issue_comment runs in the base repository context \
+                                 with access to secrets",
+                            ),
+                    )
+                    .build(workflow)?,
+            );
+        }
 
         Ok(findings)
     }

--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -1,13 +1,16 @@
+use std::ops::Deref;
 use std::sync::LazyLock;
 
-use github_actions_expressions::{Expr, context::ContextPattern};
+use github_actions_expressions::{
+    Expr, SpannedExpr, call::Call, context::ContextPattern, literal::Literal,
+};
 use github_actions_models::common::If;
 
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::audit::AuditError;
 use crate::config::Config;
 use crate::finding::{Confidence, Finding, Severity, location::Locatable as _};
-use crate::models::workflow::{Job, JobCommon, NormalJob, Workflow};
+use crate::models::workflow::{Job, NormalJob, Workflow};
 use crate::state::AuditState;
 use crate::utils::ExtractedExpr;
 
@@ -24,9 +27,37 @@ static AUTHOR_ASSOCIATION_CONTEXT: LazyLock<ContextPattern> = LazyLock::new(|| {
     ContextPattern::try_new("github.event.comment.author_association").expect("valid pattern")
 });
 
-/// Checks whether a job has an `if:` condition that references
-/// `github.event.comment.author_association`, which restricts
-/// execution to trusted actors.
+const TRUSTED_AUTHOR_ASSOCIATIONS: &[&str] = &["OWNER", "MEMBER", "COLLABORATOR"];
+
+/// Recursively collects all string literals from an expression tree.
+fn collect_string_literals<'a>(expr: &'a SpannedExpr<'a>) -> Vec<&'a str> {
+    let mut literals = vec![];
+
+    match expr.deref() {
+        Expr::Literal(Literal::String(s)) => {
+            literals.push(s.as_ref());
+        }
+        Expr::BinOp { lhs, op: _, rhs } => {
+            literals.extend(collect_string_literals(lhs));
+            literals.extend(collect_string_literals(rhs));
+        }
+        Expr::UnOp { op: _, expr } => {
+            literals.extend(collect_string_literals(expr));
+        }
+        Expr::Call(Call { func: _, args }) => {
+            for arg in args {
+                literals.extend(collect_string_literals(arg));
+            }
+        }
+        _ => {}
+    }
+
+    literals
+}
+
+/// Checks whether a job has an `if:` condition that gates on
+/// `github.event.comment.author_association` against a trusted role
+/// (OWNER, MEMBER, or COLLABORATOR).
 fn has_author_association_guard(job: &NormalJob<'_>) -> bool {
     let Some(If::Expr(expr_str)) = &job.r#if else {
         return false;
@@ -37,13 +68,21 @@ fn has_author_association_guard(job: &NormalJob<'_>) -> bool {
         return false;
     };
 
-    for (context, _) in parsed.contexts() {
-        if AUTHOR_ASSOCIATION_CONTEXT.matches(context) {
-            return true;
-        }
+    let has_context = parsed
+        .contexts()
+        .iter()
+        .any(|(context, _)| AUTHOR_ASSOCIATION_CONTEXT.matches(context));
+
+    if !has_context {
+        return false;
     }
 
-    false
+    let literals = collect_string_literals(&parsed);
+    literals.iter().any(|lit| {
+        TRUSTED_AUTHOR_ASSOCIATIONS
+            .iter()
+            .any(|trusted| trusted.eq_ignore_ascii_case(lit))
+    })
 }
 
 #[async_trait::async_trait]
@@ -89,40 +128,27 @@ impl Audit for DangerousTriggers {
             );
         }
 
-        for job in workflow.jobs() {
-            if let Job::NormalJob(normal) = job {
-                findings.extend(self.audit_normal_job(&normal, _config).await?);
+        if workflow.has_issue_comment() {
+            for job in workflow.jobs() {
+                if let Job::NormalJob(normal) = job
+                    && !has_author_association_guard(&normal)
+                {
+                    findings.push(
+                        Self::finding()
+                            .confidence(Confidence::Medium)
+                            .severity(Severity::Medium)
+                            .add_location(
+                                normal.location().primary().annotated(
+                                    "issue_comment job lacks an \
+                                     author_association guard",
+                                ),
+                            )
+                            .build(workflow)?,
+                    );
+                }
             }
         }
 
         Ok(findings)
-    }
-
-    async fn audit_normal_job<'doc>(
-        &self,
-        job: &NormalJob<'doc>,
-        _config: &Config,
-    ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        if !job.parent().has_issue_comment() {
-            return Ok(vec![]);
-        }
-
-        if has_author_association_guard(job) {
-            return Ok(vec![]);
-        }
-
-        let finding = Self::finding()
-            .confidence(Confidence::Medium)
-            .severity(Severity::Medium)
-            .add_location(
-                job.location()
-                    .primary()
-                    .annotated(
-                        "issue_comment job lacks an author_association guard",
-                    ),
-            )
-            .build(job.parent())?;
-
-        Ok(vec![finding])
     }
 }

--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -1,9 +1,15 @@
+use std::sync::LazyLock;
+
+use github_actions_expressions::{Expr, context::ContextPattern};
+use github_actions_models::common::If;
+
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::audit::AuditError;
 use crate::config::Config;
-use crate::finding::{Confidence, Finding, Severity};
-use crate::models::workflow::Workflow;
+use crate::finding::{Confidence, Finding, Severity, location::Locatable as _};
+use crate::models::workflow::{Job, JobCommon, NormalJob, Workflow};
 use crate::state::AuditState;
+use crate::utils::ExtractedExpr;
 
 pub(crate) struct DangerousTriggers;
 
@@ -12,6 +18,33 @@ audit_meta!(
     "dangerous-triggers",
     "use of fundamentally insecure workflow trigger"
 );
+
+#[allow(clippy::unwrap_used)]
+static AUTHOR_ASSOCIATION_CONTEXT: LazyLock<ContextPattern> = LazyLock::new(|| {
+    ContextPattern::try_new("github.event.comment.author_association").expect("valid pattern")
+});
+
+/// Checks whether a job has an `if:` condition that references
+/// `github.event.comment.author_association`, which restricts
+/// execution to trusted actors.
+fn has_author_association_guard(job: &NormalJob<'_>) -> bool {
+    let Some(If::Expr(expr_str)) = &job.r#if else {
+        return false;
+    };
+
+    let bare = ExtractedExpr::new(expr_str).as_bare();
+    let Ok(parsed) = Expr::parse(bare) else {
+        return false;
+    };
+
+    for (context, _) in parsed.contexts() {
+        if AUTHOR_ASSOCIATION_CONTEXT.matches(context) {
+            return true;
+        }
+    }
+
+    false
+}
 
 #[async_trait::async_trait]
 impl Audit for DangerousTriggers {
@@ -55,25 +88,41 @@ impl Audit for DangerousTriggers {
                     .build(workflow)?,
             );
         }
-        if workflow.has_issue_comment() {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::Medium)
-                    .severity(Severity::Medium)
-                    .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(["on".into()])
-                            .annotated(
-                                "issue_comment runs in the base repository context \
-                                 with access to secrets",
-                            ),
-                    )
-                    .build(workflow)?,
-            );
+
+        for job in workflow.jobs() {
+            if let Job::NormalJob(normal) = job {
+                findings.extend(self.audit_normal_job(&normal, _config).await?);
+            }
         }
 
         Ok(findings)
+    }
+
+    async fn audit_normal_job<'doc>(
+        &self,
+        job: &NormalJob<'doc>,
+        _config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        if !job.parent().has_issue_comment() {
+            return Ok(vec![]);
+        }
+
+        if has_author_association_guard(job) {
+            return Ok(vec![]);
+        }
+
+        let finding = Self::finding()
+            .confidence(Confidence::Medium)
+            .severity(Severity::Medium)
+            .add_location(
+                job.location()
+                    .primary()
+                    .annotated(
+                        "issue_comment job lacks an author_association guard",
+                    ),
+            )
+            .build(job.parent())?;
+
+        Ok(vec![finding])
     }
 }

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -154,6 +154,15 @@ impl Workflow {
         }
     }
 
+    /// Whether this workflow is triggered by issue_comment.
+    pub(crate) fn has_issue_comment(&self) -> bool {
+        match &self.on {
+            Trigger::BareEvent(event) => *event == BareEvent::IssueComment,
+            Trigger::BareEvents(events) => events.contains(&BareEvent::IssueComment),
+            Trigger::Events(events) => !matches!(events.issue_comment, OptionalBody::Missing),
+        }
+    }
+
     /// Whether this workflow is triggered by workflow_run.
     pub(crate) fn has_workflow_run(&self) -> bool {
         match &self.on {

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -78,6 +78,46 @@ fn test_issue_comment_bare_list() -> Result<()> {
 }
 
 #[test]
+fn test_issue_comment_with_guard() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/issue-comment-with-guard.yml",
+            ))
+            .run()?,
+        @"No findings to report. Good job! (2 suppressed)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_issue_comment_no_guard() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/issue-comment-no-guard.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_issue_comment_step_guard_only() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/issue-comment-step-guard-only.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_safe() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -65,6 +65,19 @@ fn test_multiple_dangerous() -> Result<()> {
 }
 
 #[test]
+fn test_issue_comment_bare_list() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/issue-comment-bare-list.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_safe() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -92,11 +92,11 @@ fn test_issue_comment_with_guard() -> Result<()> {
 }
 
 #[test]
-fn test_issue_comment_no_guard() -> Result<()> {
+fn test_issue_comment_weak_guard() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()
             .input(input_under_test(
-                "dangerous-triggers/issue-comment-no-guard.yml",
+                "dangerous-triggers/issue-comment-weak-guard.yml",
             ))
             .run()?,
     );

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -1,0 +1,77 @@
+use crate::common::{input_under_test, zizmor};
+use anyhow::Result;
+
+#[test]
+fn test_issue_comment_bare() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/issue-comment-bare.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_issue_comment_events() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/issue-comment-events.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_pull_request_target() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/pull-request-target.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_workflow_run() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("dangerous-triggers/workflow-run.yml",))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_multiple_dangerous() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/multiple-dangerous.yml",
+            ))
+            .run()?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_safe() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("dangerous-triggers/safe.yml"))
+            .run()?,
+        @"No findings to report. Good job! (2 suppressed)"
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/audit/mod.rs
+++ b/crates/zizmor/tests/integration/audit/mod.rs
@@ -6,7 +6,7 @@ mod artipacked;
 mod bot_conditions;
 mod cache_poisoning;
 mod concurrency_limits;
-// mod dangerous_triggers; // TODO
+mod dangerous_triggers;
 mod dependabot_cooldown;
 mod dependabot_execution;
 mod excessive_permissions;

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_bare.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_bare.snap
@@ -1,0 +1,13 @@
+---
+source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-bare.yml\",)).run()?"
+---
+warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | on: issue_comment
+  | ^^^^^^^^^^^^^^^^^ issue_comment runs in the base repository context with access to secrets
+  |
+  = note: audit confidence → Medium
+
+3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_bare.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_bare.snap
@@ -3,11 +3,14 @@ source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
 expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-bare.yml\",)).run()?"
 ---
 warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
- --> @@INPUT@@:1:1
-  |
-1 | on: issue_comment
-  | ^^^^^^^^^^^^^^^^^ issue_comment runs in the base repository context with access to secrets
-  |
-  = note: audit confidence → Medium
+  --> @@INPUT@@:8:3
+   |
+ 8 | /   respond:
+ 9 | |     runs-on: ubuntu-latest
+10 | |     steps:
+11 | |       - run: echo "comment received"
+   | |_____________________________________^ issue_comment job lacks an author_association guard
+   |
+   = note: audit confidence → Medium
 
 3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_bare_list.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_bare_list.snap
@@ -1,0 +1,13 @@
+---
+source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-bare-list.yml\",)).run()?"
+---
+warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | on: [push, issue_comment]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ issue_comment runs in the base repository context with access to secrets
+  |
+  = note: audit confidence → Medium
+
+3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_events.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_events.snap
@@ -1,0 +1,15 @@
+---
+source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-events.yml\",)).run()?"
+---
+warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | / on:
+2 | |   issue_comment:
+3 | |     types: [created]
+  | |____________________^ issue_comment runs in the base repository context with access to secrets
+  |
+  = note: audit confidence → Medium
+
+3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_events.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_events.snap
@@ -3,13 +3,14 @@ source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
 expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-events.yml\",)).run()?"
 ---
 warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
- --> @@INPUT@@:1:1
-  |
-1 | / on:
-2 | |   issue_comment:
-3 | |     types: [created]
-  | |____________________^ issue_comment runs in the base repository context with access to secrets
-  |
-  = note: audit confidence → Medium
+  --> @@INPUT@@:10:3
+   |
+10 | /   respond:
+11 | |     runs-on: ubuntu-latest
+12 | |     steps:
+13 | |       - run: echo "comment created"
+   | |____________________________________^ issue_comment job lacks an author_association guard
+   |
+   = note: audit confidence → Medium
 
 3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_no_guard.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_no_guard.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
-expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-bare-list.yml\",)).run()?"
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-no-guard.yml\",)).run()?"
 ---
 warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
   --> @@INPUT@@:8:3
@@ -8,8 +8,8 @@ warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
  8 | /   respond:
  9 | |     runs-on: ubuntu-latest
 10 | |     steps:
-11 | |       - run: echo "hello"
-   | |__________________________^ issue_comment job lacks an author_association guard
+11 | |       - run: echo "comment received"
+   | |_____________________________________^ issue_comment job lacks an author_association guard
    |
    = note: audit confidence → Medium
 

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_step_guard_only.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_step_guard_only.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
-expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-bare-list.yml\",)).run()?"
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-step-guard-only.yml\",)).run()?"
 ---
 warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
   --> @@INPUT@@:8:3
@@ -8,8 +8,9 @@ warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
  8 | /   respond:
  9 | |     runs-on: ubuntu-latest
 10 | |     steps:
-11 | |       - run: echo "hello"
-   | |__________________________^ issue_comment job lacks an author_association guard
+11 | |       - if: github.event.comment.author_association == 'MEMBER'
+12 | |         run: echo "comment received"
+   | |_____________________________________^ issue_comment job lacks an author_association guard
    |
    = note: audit confidence → Medium
 

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_weak_guard.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__issue_comment_weak_guard.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
-expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-no-guard.yml\",)).run()?"
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/issue-comment-weak-guard.yml\",)).run()?"
 ---
 warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
   --> @@INPUT@@:8:3
    |
  8 | /   respond:
  9 | |     runs-on: ubuntu-latest
-10 | |     steps:
-11 | |       - run: echo "comment received"
+10 | |     if: github.event.comment.author_association == 'CONTRIBUTOR'
+11 | |     steps:
+12 | |       - run: echo "comment received"
    | |_____________________________________^ issue_comment job lacks an author_association guard
    |
    = note: audit confidence → Medium

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__multiple_dangerous.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__multiple_dangerous.snap
@@ -1,0 +1,27 @@
+---
+source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/multiple-dangerous.yml\",)).run()?"
+---
+error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | / on:
+2 | |   pull_request_target:
+3 | |   issue_comment:
+4 | |     types: [created]
+  | |____________________^ pull_request_target is almost always used insecurely
+  |
+  = note: audit confidence → Medium
+
+warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | / on:
+2 | |   pull_request_target:
+3 | |   issue_comment:
+4 | |     types: [created]
+  | |____________________^ issue_comment runs in the base repository context with access to secrets
+  |
+  = note: audit confidence → Medium
+
+4 findings (2 suppressed): 0 informational, 0 low, 1 medium, 1 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__multiple_dangerous.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__multiple_dangerous.snap
@@ -14,14 +14,14 @@ error[dangerous-triggers]: use of fundamentally insecure workflow trigger
   = note: audit confidence → Medium
 
 warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
- --> @@INPUT@@:1:1
-  |
-1 | / on:
-2 | |   pull_request_target:
-3 | |   issue_comment:
-4 | |     types: [created]
-  | |____________________^ issue_comment runs in the base repository context with access to secrets
-  |
-  = note: audit confidence → Medium
+  --> @@INPUT@@:11:3
+   |
+11 | /   build:
+12 | |     runs-on: ubuntu-latest
+13 | |     steps:
+14 | |       - run: echo "building"
+   | |_____________________________^ issue_comment job lacks an author_association guard
+   |
+   = note: audit confidence → Medium
 
 4 findings (2 suppressed): 0 informational, 0 low, 1 medium, 1 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__pull_request_target.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__pull_request_target.snap
@@ -1,0 +1,13 @@
+---
+source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/pull-request-target.yml\",)).run()?"
+---
+error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | on: pull_request_target
+  | ^^^^^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
+  |
+  = note: audit confidence → Medium
+
+3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__workflow_run.snap
+++ b/crates/zizmor/tests/integration/audit/snapshots/integration__audit__dangerous_triggers__workflow_run.snap
@@ -1,0 +1,15 @@
+---
+source: crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+expression: "zizmor().input(input_under_test(\"dangerous-triggers/workflow-run.yml\",)).run()?"
+---
+error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | / on:
+2 | |   workflow_run:
+3 | |     workflows: [build]
+  | |______________________^ workflow_run is almost always used insecurely
+  |
+  = note: audit confidence → Medium
+
+3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high

--- a/crates/zizmor/tests/integration/audit/template_injection.rs
+++ b/crates/zizmor/tests/integration/audit/template_injection.rs
@@ -173,7 +173,19 @@ fn test_issue_418_repro() -> Result<()> {
         zizmor()
             .input(input_under_test("template-injection/issue-418-repro.yml"))
             .run()?,
-        @"No findings to report. Good job! (2 suppressed)"
+        @"
+    warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:5:1
+      |
+    5 | / on:
+    6 | |   issue_comment:
+    7 | |     types: [created]
+      | |____________________^ issue_comment runs in the base repository context with access to secrets
+      |
+      = note: audit confidence → Medium
+
+    3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high
+    "
     );
 
     Ok(())

--- a/crates/zizmor/tests/integration/audit/template_injection.rs
+++ b/crates/zizmor/tests/integration/audit/template_injection.rs
@@ -173,19 +173,23 @@ fn test_issue_418_repro() -> Result<()> {
         zizmor()
             .input(input_under_test("template-injection/issue-418-repro.yml"))
             .run()?,
-        @"
+        @r#"
     warning[dangerous-triggers]: use of fundamentally insecure workflow trigger
-     --> @@INPUT@@:5:1
-      |
-    5 | / on:
-    6 | |   issue_comment:
-    7 | |     types: [created]
-      | |____________________^ issue_comment runs in the base repository context with access to secrets
-      |
-      = note: audit confidence → Medium
+      --> @@INPUT@@:12:3
+       |
+    12 | /   stop:
+    13 | |     name: stop
+    14 | |     runs-on: ubuntu-latest
+    15 | |     env:
+    ...  |
+    19 | |         with:
+    20 | |           script: console.log("${{ env.COMMENT_ID }}")
+       | |_______________________________________________________^ issue_comment job lacks an author_association guard
+       |
+       = note: audit confidence → Medium
 
     3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high
-    "
+    "#
     );
 
     Ok(())

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-bare-list.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-bare-list.yml
@@ -1,0 +1,11 @@
+on: [push, issue_comment]
+
+name: issue-comment-bare-list
+
+permissions: {}
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-bare.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-bare.yml
@@ -1,0 +1,11 @@
+on: issue_comment
+
+name: issue-comment-bare
+
+permissions: {}
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "comment received"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-events.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-events.yml
@@ -1,0 +1,13 @@
+on:
+  issue_comment:
+    types: [created]
+
+name: issue-comment-events
+
+permissions: {}
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "comment created"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-no-guard.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-no-guard.yml
@@ -1,0 +1,11 @@
+on: issue_comment
+
+name: issue-comment-no-guard
+
+permissions: {}
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "comment received"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-step-guard-only.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-step-guard-only.yml
@@ -1,0 +1,12 @@
+on: issue_comment
+
+name: issue-comment-step-guard-only
+
+permissions: {}
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.comment.author_association == 'MEMBER'
+        run: echo "comment received"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-weak-guard.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-weak-guard.yml
@@ -1,11 +1,12 @@
 on: issue_comment
 
-name: issue-comment-no-guard
+name: issue-comment-weak-guard
 
 permissions: {}
 
 jobs:
   respond:
     runs-on: ubuntu-latest
+    if: github.event.comment.author_association == 'CONTRIBUTOR'
     steps:
       - run: echo "comment received"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-with-guard.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/issue-comment-with-guard.yml
@@ -1,0 +1,12 @@
+on: issue_comment
+
+name: issue-comment-with-guard
+
+permissions: {}
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    if: github.event.comment.author_association == 'MEMBER'
+    steps:
+      - run: echo "comment received"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/multiple-dangerous.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/multiple-dangerous.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+name: multiple-dangerous
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "building"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/pull-request-target.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/pull-request-target.yml
@@ -1,0 +1,11 @@
+on: pull_request_target
+
+name: pull-request-target
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "building"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/safe.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/safe.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+
+name: safe
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "building"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/workflow-run.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/workflow-run.yml
@@ -1,0 +1,13 @@
+on:
+  workflow_run:
+    workflows: [build]
+
+name: workflow-run
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "deploying"


### PR DESCRIPTION
## Pre-submission checks

- [x] This PR corresponds to an issue (if not, please create one first).
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR.

## Summary

- Adds `issue_comment` to the `dangerous-triggers` audit at **Medium severity / Medium confidence** (Regular persona), acknowledging it has more legitimate uses than `pull_request_target` or `workflow_run` while still flagging the security risk
- Adds `has_issue_comment()` method to the Workflow model following existing `has_pull_request_target()` / `has_workflow_run()` pattern
- Enables and populates the previously-stubbed `dangerous_triggers` integration test module with tests for all three trigger types

Closes #1606

## Test Plan

- [x] `issue_comment` flagged as bare event (`on: issue_comment`)
- [x] `issue_comment` flagged with event body (`on: issue_comment: types: [created]`)
- [x] `pull_request_target` still flagged at High severity
- [x] `workflow_run` still flagged at High severity
- [x] Multiple dangerous triggers in one workflow all reported
- [x] Safe triggers (`push`) produce no findings
- [x] Existing `template_injection/issue-418-repro` snapshot updated (uses `issue_comment`)
- [x] Full integration suite passes (204/204)
