### PR TITLE
Tweak release workflow triggers

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -2,7 +2,7 @@ name: zizmor binary releases for GitHub 🐙
 
 on:
   release:
-    types: [published]
+    types: [created]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
The idea here is to do more single-sourcing on release state, i.e. all releases begin when I create a draft release (triggering release binary builds). Then, the rest of the release process continues when the release is actually published (triggering PyPI wheel uploads).

This should also allow me to enable immutable releases on GitHub.