### PR TITLE
Tweak release-binaries trigger

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
     inputs:
       release-tag:
+        type: string
         description: "The tag to release (e.g., v1.0.0)"
         required: true
 

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -7,6 +7,7 @@ on:
   workflow_call:
     inputs:
       release-tag:
+        type: string
         description: "The tag to release (e.g., v1.0.0)"
         required: true
 

--- a/.github/workflows/release-zizmor-crate.yml
+++ b/.github/workflows/release-zizmor-crate.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       release-tag:
+        type: string
         description: "The tag to release (e.g., v1.0.0)"
         required: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-  IS_PRERELEASE: ${{ contains(env.RELEASE_TAG, "-rc") }}
+  IS_PRERELEASE: ${{ contains(env.RELEASE_TAG, '-rc') }}
 
 permissions: {}
 
@@ -43,7 +43,7 @@ jobs:
           gh release create --repo zizmorcore/zizmor --draft --verify-tag ${PRERELEASE_FLAG} "${RELEASE_TAG}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRERELEASE_FLAG: ${{ env.IS_PRERELEASE && "--prerelease" || "" }}
+          PRERELEASE_FLAG: ${{ env.IS_PRERELEASE && '--prerelease' || '' }}
 
   release-binaries:
     name: Build and attach binaries for ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
This is because GitHub refuses to emit `release: created` for draft releases. This doesn't make any sense given that they want everything to be an immutable release, but here we are.