### PR TITLE
feat(config): use toml for configuring zizmor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sysinfo",
- "toml",
+ "toml 0.9.10+spec-1.1.0",
  "uuid",
 ]
 
@@ -3226,8 +3226,23 @@ checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
 dependencies = [
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_writer",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3237,6 +3252,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -4232,6 +4265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4485,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "toml 1.0.3+spec-1.1.0",
  "tower-lsp-server",
  "tracing",
  "tracing-indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 resolver = "2"
 members = [
-    "crates/github-actions-expressions",
-    "crates/github-actions-models",
-    "crates/subfeature",
-    "crates/tree-sitter-iter",
-    "crates/yamlpatch",
-    "crates/yamlpath",
-    "crates/zizmor",
+  "crates/github-actions-expressions",
+  "crates/github-actions-models",
+  "crates/subfeature",
+  "crates/tree-sitter-iter",
+  "crates/yamlpatch",
+  "crates/yamlpath",
+  "crates/zizmor",
 ]
 
 [workspace.package]
@@ -81,6 +81,7 @@ tree-sitter-bash = "0.25.1"
 tree-sitter-powershell = "=0.25.10"
 tree-sitter-yaml = "0.7.2"
 tikv-jemallocator = "0.6"
+toml = "1"
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -68,6 +68,7 @@ subfeature.workspace = true
 tar.workspace = true
 terminal-link.workspace = true
 thiserror.workspace = true
+toml.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
 tower-lsp-server = { workspace = true, optional = true }
 tracing.workspace = true

--- a/crates/zizmor/src/audit/forbidden_uses.rs
+++ b/crates/zizmor/src/audit/forbidden_uses.rs
@@ -3,7 +3,7 @@ use subfeature::Subfeature;
 
 use super::{Audit, AuditLoadError, AuditState, audit_meta};
 use crate::audit::AuditError;
-use crate::config::{Config, ForbiddenUsesConfigInner};
+use crate::config::{Config, ForbiddenUsesConfig};
 use crate::finding::{Confidence, Finding, Persona, Severity};
 use crate::models::{StepCommon, action::CompositeStep, workflow::Step};
 
@@ -12,7 +12,7 @@ pub(crate) struct ForbiddenUses;
 audit_meta!(ForbiddenUses, "forbidden-uses", "forbidden action used");
 
 impl ForbiddenUses {
-    fn use_denied(&self, uses: &Uses, config: &ForbiddenUsesConfigInner) -> bool {
+    fn use_denied(&self, uses: &Uses, config: &ForbiddenUsesConfig) -> bool {
         match uses {
             // Local uses are never denied.
             Uses::Local(_) => false,
@@ -24,12 +24,10 @@ impl ForbiddenUses {
                 false
             }
             Uses::Repository(uses) => match config {
-                ForbiddenUsesConfigInner::Allow(allow) => {
+                ForbiddenUsesConfig::Allow(allow) => {
                     !allow.iter().any(|pattern| pattern.matches(uses))
                 }
-                ForbiddenUsesConfigInner::Deny(deny) => {
-                    deny.iter().any(|pattern| pattern.matches(uses))
-                }
+                ForbiddenUsesConfig::Deny(deny) => deny.iter().any(|pattern| pattern.matches(uses)),
             },
         }
     }

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -972,7 +972,7 @@ async fn main() -> ExitCode {
                     let mut group = Group::with_title(Level::ERROR.primary_title(err.to_string()));
 
                     match err.source {
-                        ConfigErrorInner::Syntax(_) => {
+                        ConfigErrorInner::TomlSyntax(_) | ConfigErrorInner::YamlSyntax(_) => {
                             group = group.elements([
                                 Level::HELP
                                     .message("check your configuration file for syntax errors"),


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue: #1560 .

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

This PR is currently a **DRAFT** for the purposes of obtaining feedback.

The changes are broadly:
* Introduction of a `ConfigFormat` enum so that the appropriate deserializer is called.
* Updates of signatures of `load` to accept `ConfigFormat`
* Use of `serde_json::Value` as the intermediate representation. This was chosen since its variants could be produced by yaml or toml configs in zizmor (as opposed to `serde_yaml::Value` which has `Tagged` variants for example).
* Removal of `ForbiddenUsesConfigInner`, the change to `serde_json` removed keys being deserialized as yaml tags from being an issue.
* Additional error variants for `ConfigErrorInner::Syntax` since it could be due to a toml or serde_yaml deserialization error.

### TODO:
[ ] Migration from yaml config to toml

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

I've so far tested dummy configs (yaml and toml) against the coreutils workflows and managed to obtain the same results. When the approach is more set in stone, I will add some tests.
