### PR TITLE
Update `--quiet` flag and introduce `--silent` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,16 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-verbosity-flag"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
-dependencies = [
- "clap",
- "tracing-core",
-]
-
-[[package]]
 name = "clap_builder"
 version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,7 +4400,6 @@ dependencies = [
  "async-trait",
  "camino",
  "clap",
- "clap-verbosity-flag",
  "clap_complete",
  "clap_complete_nushell",
  "csv",

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -37,7 +37,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 clap = { workspace = true, features = ["derive", "env"] }
-clap-verbosity-flag = { workspace = true, features = ["tracing"] }
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true
 etcetera.workspace = true

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -11,7 +11,7 @@ use annotate_snippets::{Group, Level, Renderer};
 use anstream::{eprintln, println, stderr, stream::IsTerminal};
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
-use clap::{Args, CommandFactory, Parser, ValueEnum, builder::NonEmptyStringValueParser};
+use clap::{Args, ArgAction, CommandFactory, Parser, ValueEnum, builder::NonEmptyStringValueParser};
 use clap_complete::Generator;
 
 use etcetera::AppStrategy as _;
@@ -119,12 +119,16 @@ struct App {
     no_online_audits: bool,
 
     /// Print diagnostics, but nothing else.
-    #[arg(short, long, conflicts_with = "silent")]
+    #[arg(short, long, conflicts_with_all = ["silent", "verbose"])]
     quiet: bool,
 
     /// Disable all output (but still exit with status code "1" upon detecting diagnostics).
-    #[arg(short, long, conflicts_with = "quiet")]
+    #[arg(short, long, conflicts_with_all = ["quiet", "verbose"])]
     silent: bool,
+
+    /// Increase logging verbosity.
+    #[arg(short, long, action = ArgAction::Count, conflicts_with_all = ["quiet", "silent"])]
+    verbose: u8,
 
     /// Don't show progress bars, even if the terminal supports them.
     #[arg(long)]
@@ -778,7 +782,11 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
     } else if app.quiet {
         tracing_subscriber::filter::LevelFilter::WARN
     } else {
-        tracing_subscriber::filter::LevelFilter::INFO
+        match app.verbose {
+            0 => tracing_subscriber::filter::LevelFilter::INFO,
+            1 => tracing_subscriber::filter::LevelFilter::DEBUG,
+            _ => tracing_subscriber::filter::LevelFilter::TRACE,
+        }
     };
 
     let filter = EnvFilter::builder()

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -13,7 +13,7 @@ use anyhow::anyhow;
 use camino::Utf8PathBuf;
 use clap::{Args, CommandFactory, Parser, ValueEnum, builder::NonEmptyStringValueParser};
 use clap_complete::Generator;
-use clap_verbosity_flag::InfoLevel;
+
 use etcetera::AppStrategy as _;
 use finding::{Confidence, Persona, Severity};
 use futures::stream::{FuturesOrdered, StreamExt};
@@ -118,8 +118,13 @@ struct App {
     #[arg(long, env = "ZIZMOR_NO_ONLINE_AUDITS")]
     no_online_audits: bool,
 
-    #[command(flatten)]
-    verbose: clap_verbosity_flag::Verbosity<InfoLevel>,
+    /// Print diagnostics, but nothing else.
+    #[arg(short, long, conflicts_with = "silent")]
+    quiet: bool,
+
+    /// Disable all output (but still exit with status code "1" upon detecting diagnostics).
+    #[arg(short, long, conflicts_with = "quiet")]
+    silent: bool,
 
     /// Don't show progress bars, even if the terminal supports them.
     #[arg(long)]
@@ -721,6 +726,11 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
 
     anstream::ColorChoice::write_global(color_mode.into());
 
+    // Disable progress bars in quiet and silent modes.
+    if app.quiet || app.silent {
+        app.no_progress = true;
+    }
+
     // Disable progress bars if colorized output is disabled.
     // We do this because `anstream` and `tracing_indicatif` don't
     // compose perfectly: `anstream` wants to strip all ANSI escapes,
@@ -763,8 +773,16 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         color_mode.color_choice_for_terminal(std::io::stderr()),
     ));
 
+    let level = if app.silent {
+        tracing_subscriber::filter::LevelFilter::OFF
+    } else if app.quiet {
+        tracing_subscriber::filter::LevelFilter::WARN
+    } else {
+        tracing_subscriber::filter::LevelFilter::INFO
+    };
+
     let filter = EnvFilter::builder()
-        .with_default_directive(app.verbose.tracing_level_filter().into())
+        .with_default_directive(level.into())
         .from_env()
         .expect("failed to parse RUST_LOG");
 
@@ -784,7 +802,9 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         reg.with(indicatif_layer).init();
     }
 
-    eprintln!("🌈 zizmor v{version}", version = env!("CARGO_PKG_VERSION"));
+    if !app.quiet && !app.silent {
+        eprintln!("🌈 zizmor v{version}", version = env!("CARGO_PKG_VERSION"));
+    }
 
     let collection_mode_set = CollectionModeSet::from(app.collect.as_slice());
 
@@ -888,25 +908,28 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         }
     }
 
-    match app.format {
-        OutputFormat::Plain => output::plain::render_findings(
-            &registry,
-            &results,
-            &app.show_audit_urls.into(),
-            &app.render_links.into(),
-            app.naches,
-        ),
-        OutputFormat::Json | OutputFormat::JsonV1 => {
-            output::json::v1::output(stdout(), results.findings()).map_err(Error::Output)?
-        }
-        OutputFormat::Sarif => {
-            serde_json::to_writer_pretty(stdout(), &output::sarif::build(results.findings()))
-                .map_err(|err| Error::Output(anyhow!(err)))?
-        }
-        OutputFormat::Github => {
-            output::github::output(stdout(), results.findings()).map_err(Error::Output)?
-        }
-    };
+    if !app.silent {
+        match app.format {
+            OutputFormat::Plain => output::plain::render_findings(
+                &registry,
+                &results,
+                &app.show_audit_urls.into(),
+                &app.render_links.into(),
+                app.naches,
+                app.quiet,
+            ),
+            OutputFormat::Json | OutputFormat::JsonV1 => {
+                output::json::v1::output(stdout(), results.findings()).map_err(Error::Output)?
+            }
+            OutputFormat::Sarif => {
+                serde_json::to_writer_pretty(stdout(), &output::sarif::build(results.findings()))
+                    .map_err(|err| Error::Output(anyhow!(err)))?
+            }
+            OutputFormat::Github => {
+                output::github::output(stdout(), results.findings()).map_err(Error::Output)?
+            }
+        };
+    }
 
     let all_fixed = if let Some(fix_mode) = app.fix {
         let fix_result =

--- a/crates/zizmor/src/output/plain.rs
+++ b/crates/zizmor/src/output/plain.rs
@@ -111,96 +111,94 @@ pub(crate) fn render_findings(
         println!();
     }
 
-    if quiet {
-        return;
-    }
+    if !quiet {
+        let mut qualifiers = vec![];
 
-    let mut qualifiers = vec![];
+        if !findings.ignored().is_empty() {
+            qualifiers.push(format!(
+                "{nignored} ignored",
+                nignored = findings.ignored().len().bright_yellow()
+            ));
+        }
 
-    if !findings.ignored().is_empty() {
-        qualifiers.push(format!(
-            "{nignored} ignored",
-            nignored = findings.ignored().len().bright_yellow()
-        ));
-    }
+        if !findings.suppressed().is_empty() {
+            qualifiers.push(format!(
+                "{nsuppressed} suppressed",
+                nsuppressed = findings.suppressed().len().bright_yellow()
+            ));
+        }
 
-    if !findings.suppressed().is_empty() {
-        qualifiers.push(format!(
-            "{nsuppressed} suppressed",
-            nsuppressed = findings.suppressed().len().bright_yellow()
-        ));
-    }
+        let nfixable = findings.fixable_findings().count();
+        if nfixable > 0 {
+            qualifiers.push(format!(
+                "{nfixable} fixable",
+                nfixable = nfixable.bright_green()
+            ));
+        }
 
-    let nfixable = findings.fixable_findings().count();
-    if nfixable > 0 {
-        qualifiers.push(format!(
-            "{nfixable} fixable",
-            nfixable = nfixable.bright_green()
-        ));
-    }
+        if findings.findings().is_empty() {
+            if qualifiers.is_empty() {
+                println!("{}", "No findings to report. Good job!".green());
+            } else {
+                println!(
+                    "{no_findings} ({qualifiers})",
+                    no_findings = "No findings to report. Good job!".green(),
+                    qualifiers = qualifiers.join(", ").bold(),
+                );
+            }
 
-    if findings.findings().is_empty() {
-        if qualifiers.is_empty() {
-            println!("{}", "No findings to report. Good job!".green());
+            if naches_mode {
+                naches();
+            }
         } else {
-            println!(
-                "{no_findings} ({qualifiers})",
-                no_findings = "No findings to report. Good job!".green(),
-                qualifiers = qualifiers.join(", ").bold(),
-            );
-        }
+            let mut findings_by_severity = HashMap::new();
 
-        if naches_mode {
-            naches();
-        }
-    } else {
-        let mut findings_by_severity = HashMap::new();
-
-        for finding in findings.findings() {
-            match findings_by_severity.entry(&finding.determinations.severity) {
-                Entry::Occupied(mut e) => {
-                    *e.get_mut() += 1;
-                }
-                Entry::Vacant(e) => {
-                    e.insert(1);
+            for finding in findings.findings() {
+                match findings_by_severity.entry(&finding.determinations.severity) {
+                    Entry::Occupied(mut e) => {
+                        *e.get_mut() += 1;
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(1);
+                    }
                 }
             }
-        }
 
-        if qualifiers.is_empty() {
-            let nfindings = findings.count();
-            print!(
-                "{nfindings} finding{s}: ",
-                nfindings = nfindings.green(),
-                s = if nfindings == 1 { "" } else { "s" },
-            );
-        } else {
-            print!(
-                "{nfindings} findings ({qualifiers}): ",
-                nfindings = findings.count().green(),
-                qualifiers = qualifiers.join(", ").bold(),
+            if qualifiers.is_empty() {
+                let nfindings = findings.count();
+                print!(
+                    "{nfindings} finding{s}: ",
+                    nfindings = nfindings.green(),
+                    s = if nfindings == 1 { "" } else { "s" },
+                );
+            } else {
+                print!(
+                    "{nfindings} findings ({qualifiers}): ",
+                    nfindings = findings.count().green(),
+                    qualifiers = qualifiers.join(", ").bold(),
+                );
+            }
+
+            println!(
+                "{ninformational} informational, {nlow} low, {nmedium} medium, {nhigh} high",
+                ninformational = findings_by_severity
+                    .get(&Severity::Informational)
+                    .unwrap_or(&0)
+                    .purple(),
+                nlow = findings_by_severity
+                    .get(&Severity::Low)
+                    .unwrap_or(&0)
+                    .cyan(),
+                nmedium = findings_by_severity
+                    .get(&Severity::Medium)
+                    .unwrap_or(&0)
+                    .yellow(),
+                nhigh = findings_by_severity
+                    .get(&Severity::High)
+                    .unwrap_or(&0)
+                    .red(),
             );
         }
-
-        println!(
-            "{ninformational} informational, {nlow} low, {nmedium} medium, {nhigh} high",
-            ninformational = findings_by_severity
-                .get(&Severity::Informational)
-                .unwrap_or(&0)
-                .purple(),
-            nlow = findings_by_severity
-                .get(&Severity::Low)
-                .unwrap_or(&0)
-                .cyan(),
-            nmedium = findings_by_severity
-                .get(&Severity::Medium)
-                .unwrap_or(&0)
-                .yellow(),
-            nhigh = findings_by_severity
-                .get(&Severity::High)
-                .unwrap_or(&0)
-                .red(),
-        );
     }
 }
 

--- a/crates/zizmor/src/output/plain.rs
+++ b/crates/zizmor/src/output/plain.rs
@@ -104,10 +104,15 @@ pub(crate) fn render_findings(
     show_urls_mode: &ShowAuditUrls,
     render_links_mode: &RenderLinks,
     naches_mode: bool,
+    quiet: bool,
 ) {
     for finding in findings.findings() {
         render_finding(registry, finding, show_urls_mode, render_links_mode);
         println!();
+    }
+
+    if quiet {
+        return;
     }
 
     let mut qualifiers = vec![];

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -201,6 +201,73 @@ fn progress_bar_tty() -> Result<()> {
 }
 
 #[test]
+fn quiet_flag() -> Result<()> {
+    // --quiet: shows findings but suppresses banner, INFO logs, and summary.
+    let quiet_with_findings = zizmor()
+        .output(OutputMode::Both)
+        .args(["--quiet"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(!quiet_with_findings.contains("🌈 zizmor"));
+    assert!(!quiet_with_findings.contains(" INFO "));
+    assert!(quiet_with_findings.contains("warning[artipacked]"));
+    assert!(!quiet_with_findings.contains("findings"));
+    assert!(!quiet_with_findings.contains("No findings"));
+
+    // --quiet with no findings: produces no output at all.
+    let quiet_no_findings = zizmor()
+        .output(OutputMode::Both)
+        .args(["--quiet", "--min-severity=high"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(quiet_no_findings.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn silent_flag() -> Result<()> {
+    // --silent: suppresses all output, but preserves exit code.
+    let silent_with_findings = zizmor()
+        .output(OutputMode::Both)
+        .args(["--silent"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(silent_with_findings.is_empty());
+
+    // --silent with no findings: also produces no output.
+    let silent_no_findings = zizmor()
+        .output(OutputMode::Both)
+        .args(["--silent", "--min-severity=high"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(silent_no_findings.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn quiet_silent_conflict() -> Result<()> {
+    // --quiet and --silent are mutually exclusive.
+    insta::assert_snapshot!(
+        zizmor()
+            .expects_failure(2)
+            .args(["--quiet", "--silent"])
+            .input(input_under_test("artipacked.yml"))
+            .run()?,
+        @r"
+    error: the argument '--quiet' cannot be used with '--silent'
+
+    Usage: zizmor --quiet --offline --no-progress --show-audit-urls <SHOW_AUDIT_URLS> <INPUTS>...
+
+    For more information, try '--help'.
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn issue_612_repro() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -247,6 +247,51 @@ fn silent_flag() -> Result<()> {
 }
 
 #[test]
+fn verbose_flag() -> Result<()> {
+    // Default (no flags): INFO level — no DEBUG messages.
+    let default_output = zizmor()
+        .output(OutputMode::Both)
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(!default_output.contains("DEBUG"));
+
+    // -v: DEBUG level — DEBUG messages appear.
+    let verbose_output = zizmor()
+        .output(OutputMode::Both)
+        .args(["-v"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(verbose_output.contains("DEBUG"));
+    assert!(verbose_output.contains("🌈 zizmor"));
+
+    Ok(())
+}
+
+#[test]
+fn verbose_quiet_conflict() -> Result<()> {
+    let output = zizmor()
+        .expects_failure(2)
+        .args(["--verbose", "--quiet"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(output.contains("cannot be used with"));
+
+    Ok(())
+}
+
+#[test]
+fn verbose_silent_conflict() -> Result<()> {
+    let output = zizmor()
+        .expects_failure(2)
+        .args(["--verbose", "--silent"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(output.contains("cannot be used with"));
+
+    Ok(())
+}
+
+#[test]
 fn quiet_silent_conflict() -> Result<()> {
     // --quiet and --silent are mutually exclusive.
     let output = zizmor()

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -249,20 +249,14 @@ fn silent_flag() -> Result<()> {
 #[test]
 fn quiet_silent_conflict() -> Result<()> {
     // --quiet and --silent are mutually exclusive.
-    insta::assert_snapshot!(
-        zizmor()
-            .expects_failure(2)
-            .args(["--quiet", "--silent"])
-            .input(input_under_test("artipacked.yml"))
-            .run()?,
-        @r"
-    error: the argument '--quiet' cannot be used with '--silent'
-
-    Usage: zizmor --quiet --offline --no-progress --show-audit-urls <SHOW_AUDIT_URLS> <INPUTS>...
-
-    For more information, try '--help'.
-    "
-    );
+    let output = zizmor()
+        .expects_failure(2)
+        .args(["--quiet", "--silent"])
+        .input(input_under_test("artipacked.yml"))
+        .run()?;
+    assert!(output.contains("cannot be used with"));
+    assert!(output.contains("--quiet"));
+    assert!(output.contains("--silent"));
 
     Ok(())
 }


### PR DESCRIPTION
## Pre-submission checks

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

## Summary

Closes https://github.com/zizmorcore/zizmor/issues/1695. This PR updates the `--quiet` flag and introduces a `--silent` flag, which both follow the Ruff approach to logging.

### No diagnostics example
```
$ ./zizmor.exe .                                                                                                                                                                                                           
🌈 zizmor v1.23.0-rc5                                                                                                                                                                                                      
 INFO audit: zizmor: 🌈 completed .\.github\workflows\ci.yml
 INFO audit: zizmor: 🌈 completed .\.github\workflows\lint-pull-request.yml
No findings to report. Good job!
                                                                                                                                                                                                                                                                                                                                                               
$ ./zizmor.exe . -q                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                               
$ ./zizmor.exe . -s      
```
### When there are diagnostics
```
$ ./zizmor.exe .
🌈 zizmor v1.23.0-rc5
 INFO audit: zizmor: 🌈 completed .\.github\workflows\ci.yml
 INFO audit: zizmor: 🌈 completed .\.github\workflows\lint-pull-request.yml
help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .\.github\workflows\ci.yml:49:9                                                                                                                                                                                      
   |                                                                                                                                                                                                                       
49 |         - name: Checkout repository                                                                                                                                                                                   
   |  _________^                                                                                                                                                                                                           
50 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2                                                                                                                                    
   | |________________________________________________________________________________^ does not set persist-credentials: false                                                                                            
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

1 findings (1 fixable): 0 informational, 1 low, 0 medium, 0 high

$ ./zizmor.exe . --quiet
help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .\.github\workflows\ci.yml:49:9
   |
49 |         - name: Checkout repository
   |  _________^
50 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   | |________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

$ ./zizmor.exe . --silent

```

## Test Plan

Tests for these flags have been added.