### PR TITLE
feat(cache-poisoning): add new action to audit

### DIFF
--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -17,7 +17,7 @@ use yamlpatch::{Op, Patch};
 
 use super::AuditLoadError;
 
-/// The list of know cache-aware actions
+/// The list of known cache-aware actions
 /// In the future we can easily retrieve this list from the static API,
 /// since it should be easily serializable
 #[allow(clippy::unwrap_used)]
@@ -215,6 +215,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 satisfied_by_default: true,
             },
         },
+        // https://github.com/awalsh128/cache-apt-pkgs-action/blob/master/action.yml
+        ActionCoordinate::NotConfigurable("awalsh128/cache-apt-pkgs-action".parse().unwrap()),
     ]
 });
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -36,6 +36,9 @@ of `zizmor`.
 * The SARIF output format now adds `zizmor/confidence`, `zizmor/persona` and `zizmor/severity`
   to the `properties` of findings (#1656)
 
+* Added [awalsh128/cache-apt-pkgs-action](https://github.com/awalsh128/cache-apt-pkgs-action)
+  as a cache-aware action to the cache-poisoning audit (#1708)
+
 ### Changes ⚠️
 
 * SARIF categories have been regraded. `zizmor`'s "medium" is changed from SARIF's "warning" to "low" (#1635)


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue #1685 .

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Adds [awalsh128/cache-apt-pkgs-action](https://github.com/awalsh128/cache-apt-pkgs-action) to the list of cache aware actions in the cache-poisoning audit.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

Not too sure if any testing is required for adding a new member to the list...

Closes #1685.