### PR TITLE
feat: support `-` for reading input from stdin

### DIFF
--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -231,6 +231,8 @@ struct App {
     /// (typically `action.yml`), entire directories, or a `user/repo` slug
     /// for a GitHub repository. In the latter case, a `@ref` can be appended
     /// to audit the repository at a particular git reference state.
+    ///
+    /// Use `-` to read a single input from stdin.
     #[arg(required = true)]
     inputs: Vec<String>,
 }
@@ -792,6 +794,28 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
 
     eprintln!("🌈 zizmor v{version}", version = env!("CARGO_PKG_VERSION"));
 
+    // Validate stdin input constraints: `-` must be the only input,
+    // and cannot be combined with `--fix`.
+    if app.inputs.contains(&"-".to_string()) {
+        if app.inputs.len() > 1 {
+            let mut cmd = App::command();
+            cmd.error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "`-` (stdin) cannot be combined with other inputs",
+            )
+            .exit();
+        }
+
+        if app.fix.is_some() {
+            let mut cmd = App::command();
+            cmd.error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "`--fix` cannot be used with `-` (stdin)",
+            )
+            .exit();
+        }
+    }
+
     let collection_mode_set = CollectionModeSet::from(app.collect.as_slice());
 
     let min_severity = match app.min_severity {
@@ -1017,15 +1041,17 @@ async fn main() -> ExitCode {
                     CollectionError::DuplicateInput(..) => {
                         let group = Group::with_title(Level::ERROR.primary_title(err.to_string()))
                             .element(Level::HELP.message(format!(
-                                "valid inputs are files, directories, or GitHub {slug} slugs",
-                                slug = "user/repo[@ref]".green()
+                                "valid inputs are files, directories, GitHub {slug} slugs, or {stdin} for stdin",
+                                slug = "user/repo[@ref]".green(),
+                                stdin = "-".green()
                             )))
                             .element(Level::HELP.message(format!(
-                                "examples: {ex1}, {ex2}, {ex3}, or {ex4}",
+                                "examples: {ex1}, {ex2}, {ex3}, {ex4}, or {ex5}",
                                 ex1 = "path/to/workflow.yml".green(),
                                 ex2 = ".github/".green(),
                                 ex3 = "example/example".green(),
-                                ex4 = "example/example@v1.2.3".green()
+                                ex4 = "example/example@v1.2.3".green(),
+                                ex5 = "-".green()
                             )));
 
                         let renderer = Renderer::styled();

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -69,7 +69,7 @@ impl Action {
         let document = yamlpath::Document::new(&contents)?;
 
         let link = match key {
-            InputKey::Local(_) => None,
+            InputKey::Local(_) | InputKey::Stdin(_) => None,
             InputKey::Remote(_) => {
                 // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
                 Some(Link::new(key.presentation_path(), &key.to_string()).to_string())

--- a/crates/zizmor/src/models/dependabot.rs
+++ b/crates/zizmor/src/models/dependabot.rs
@@ -47,7 +47,7 @@ impl Dependabot {
         let document = yamlpath::Document::new(&contents)?;
 
         let link = match key {
-            InputKey::Local(_) => None,
+            InputKey::Local(_) | InputKey::Stdin(_) => None,
             InputKey::Remote(_) => {
                 // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
                 Some(Link::new(key.presentation_path(), &key.to_string()).to_string())

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -125,7 +125,7 @@ impl Workflow {
         let document = yamlpath::Document::new(&contents)?;
 
         let link = match key {
-            InputKey::Local(_) => None,
+            InputKey::Local(_) | InputKey::Stdin(_) => None,
             InputKey::Remote(_) => {
                 // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
                 Some(Link::new(key.presentation_path(), &key.to_string()).to_string())

--- a/crates/zizmor/src/output/fix.rs
+++ b/crates/zizmor/src/output/fix.rs
@@ -70,7 +70,7 @@ pub fn apply_fixes(
         let InputKey::Local(local) = input_key else {
             // NOTE: fixable_findings should only return local inputs,
             // so this case should never happen.
-            panic!("can't apply fixes to remote inputs");
+            panic!("can't apply fixes to non-local inputs");
         };
 
         let input = registry.get_input(input_key);

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeMap, btree_map},
+    io::Read as _,
     path::PathBuf,
     str::FromStr as _,
 };
@@ -196,15 +197,25 @@ pub(crate) struct RemoteKey {
     path: Utf8PathBuf,
 }
 
+/// A key for input read from standard input.
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, PartialOrd, Ord)]
+pub(crate) struct StdinKey {
+    /// The group this input belongs to.
+    #[serde(skip)]
+    group: Group,
+}
+
 /// A unique identifying "key" for an input in a given run of zizmor.
 ///
-/// zizmor currently knows two different kinds of keys: local keys
-/// are just canonical paths to files on disk, while remote keys are
-/// relative paths within a referenced GitHub repository.
+/// zizmor currently knows three different kinds of keys: local keys
+/// are canonical paths to files on disk, remote keys are relative
+/// paths within a referenced GitHub repository, and stdin keys
+/// represent input read from standard input.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, PartialOrd, Ord)]
 pub(crate) enum InputKey {
     Local(LocalKey),
     Remote(RemoteKey),
+    Stdin(StdinKey),
 }
 
 impl std::fmt::Display for InputKey {
@@ -222,6 +233,7 @@ impl std::fmt::Display for InputKey {
                     path = remote.path
                 )
             }
+            InputKey::Stdin(_) => write!(f, "<stdin>"),
         }
     }
 }
@@ -232,6 +244,12 @@ impl InputKey {
             group,
             prefix: prefix.map(|p| p.as_ref().to_path_buf()),
             given_path: path.as_ref().to_path_buf(),
+        })
+    }
+
+    pub(crate) fn stdin() -> Self {
+        Self::Stdin(StdinKey {
+            group: Group::from("-"),
         })
     }
 
@@ -266,6 +284,7 @@ impl InputKey {
                 .unwrap_or_else(|| &local.given_path)
                 .as_str(),
             InputKey::Remote(remote) => remote.path.as_str(),
+            InputKey::Stdin(_) => "<stdin>",
         }
     }
 
@@ -277,6 +296,7 @@ impl InputKey {
         match self {
             InputKey::Local(local) => local.given_path.as_str(),
             InputKey::Remote(remote) => remote.path.as_str(),
+            InputKey::Stdin(_) => "<stdin>",
         }
     }
 
@@ -293,6 +313,7 @@ impl InputKey {
                 .path
                 .file_name()
                 .expect("expected input key to have a filename component"),
+            InputKey::Stdin(_) => "<stdin>",
         }
     }
 
@@ -301,6 +322,7 @@ impl InputKey {
         match self {
             InputKey::Local(local) => &local.group,
             InputKey::Remote(remote) => &remote.group,
+            InputKey::Stdin(stdin) => &stdin.group,
         }
     }
 }
@@ -549,11 +571,74 @@ impl InputGroup {
         Ok(group)
     }
 
+    async fn collect_from_stdin(options: &CollectionOptions) -> Result<Self, CollectionError> {
+        let mut contents = String::new();
+        std::io::stdin()
+            .read_to_string(&mut contents)
+            .map_err(CollectionError::Io)?;
+
+        let mut group = Self::new(Config::default());
+        let key = InputKey::stdin();
+
+        // Infer the input type by trying each parser in order.
+        // We try workflow first since it's the most common stdin use case,
+        // followed by action and then dependabot.
+        //
+        // We collect errors from all attempted types so that, if none
+        // succeed, the user gets context about every failed attempt
+        // rather than a single misleading error.
+        let mut errors: Vec<(InputKind, CollectionError)> = Vec::new();
+
+        for kind in [
+            InputKind::Workflow,
+            InputKind::Action,
+            InputKind::Dependabot,
+        ] {
+            match group.register(kind, contents.clone(), key.clone(), true) {
+                Ok(()) => return Ok(group),
+                Err(e) if matches!(e.inner(), CollectionError::Syntax(_)) => {
+                    // YAML itself is invalid; no point trying other types.
+                    if options.strict {
+                        return Err(e);
+                    }
+                    tracing::warn!("stdin: {e}");
+                    return Ok(group);
+                }
+                Err(e) => {
+                    tracing::debug!("stdin: failed to parse as {kind}: {e}");
+                    errors.push((kind, e));
+                }
+            }
+        }
+
+        // All types failed. Log all errors so the user can see why
+        // each type failed, rather than getting a single misleading error.
+        for (kind, err) in &errors {
+            tracing::warn!("stdin: failed to parse as {kind}: {err}");
+        }
+
+        if options.strict {
+            // In strict mode, return the workflow error as the primary error
+            // since it's the most common stdin use case.
+            let (_kind, first_err) = errors
+                .into_iter()
+                .next()
+                .expect("at least one parse was attempted");
+            return Err(first_err);
+        }
+
+        Ok(group)
+    }
+
     pub(crate) async fn collect(
         request: &str,
         options: &CollectionOptions,
         gh_client: Option<&Client>,
     ) -> Result<Self, CollectionError> {
+        if request == "-" {
+            return Self::collect_from_stdin(options).await;
+        }
+
         let path = Utf8Path::new(request);
 
         if path.is_file() {

--- a/crates/zizmor/tests/integration/cli.rs
+++ b/crates/zizmor/tests/integration/cli.rs
@@ -1,5 +1,258 @@
 use crate::common::zizmor;
 
+/// Test that `-` cannot be combined with other inputs.
+#[test]
+fn test_stdin_with_other_inputs() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin("on: push")
+            .no_config(true)
+            .expects_failure(2)
+            .args(["-", "some-dir/"])
+            .run()?,
+        @r"
+    🌈 zizmor v@@VERSION@@
+    error: `-` (stdin) cannot be combined with other inputs
+
+    Usage: zizmor [OPTIONS] <INPUTS>...
+
+    For more information, try '--help'.
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that `--fix` cannot be used with `-`.
+#[test]
+fn test_stdin_with_fix() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin("on: push")
+            .no_config(true)
+            .expects_failure(2)
+            .args(["--fix", "-"])
+            .run()?,
+        @r"
+    🌈 zizmor v@@VERSION@@
+    error: `--fix` cannot be used with `-` (stdin)
+
+    Usage: zizmor [OPTIONS] <INPUTS>...
+
+    For more information, try '--help'.
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that `-` reads a workflow from stdin.
+#[test]
+fn test_stdin_workflow() -> anyhow::Result<()> {
+    let workflow = "\
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+";
+    // NOTE: We use .args(["-"]) instead of .input("-") because the
+    // test harness replaces all occurrences of the input string in the
+    // output, and `-` would corrupt arrows, flags, etc.
+    insta::assert_snapshot!(
+        zizmor().stdin(workflow).no_config(true).args(["-"]).run()?,
+        @r"
+    warning[artipacked]: credential persistence through GitHub Actions artifacts
+     --> <stdin>:6:9
+      |
+    6 |       - uses: actions/checkout@v3
+      |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
+      |
+      = note: audit confidence → Low
+      = note: this finding has an auto-fix
+
+    warning[excessive-permissions]: overly broad permissions
+     --> <stdin>:3:3
+      |
+    3 | /   test:
+    4 | |     runs-on: ubuntu-latest
+    5 | |     steps:
+    6 | |       - uses: actions/checkout@v3
+      | |                                  ^
+      | |                                  |
+      | |__________________________________this job
+      |                                    default permissions used due to no permissions: block
+      |
+      = note: audit confidence → Medium
+
+    error[unpinned-uses]: unpinned action reference
+     --> <stdin>:6:15
+      |
+    6 |       - uses: actions/checkout@v3
+      |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
+      |
+      = note: audit confidence → High
+
+    7 findings (4 suppressed): 0 informational, 0 low, 2 medium, 1 high
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that `-` reads an action definition from stdin.
+#[test]
+fn test_stdin_action() -> anyhow::Result<()> {
+    let action = "\
+name: My Action
+description: Test action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+";
+    insta::assert_snapshot!(
+        zizmor().stdin(action).no_config(true).args(["-"]).run()?,
+        @r"
+    warning[artipacked]: credential persistence through GitHub Actions artifacts
+     --> <stdin>:6:7
+      |
+    6 |     - uses: actions/checkout@v3
+      |       ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
+      |
+      = note: audit confidence → Low
+      = note: this finding has an auto-fix
+
+    error[unpinned-uses]: unpinned action reference
+     --> <stdin>:6:13
+      |
+    6 |     - uses: actions/checkout@v3
+      |             ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
+      |
+      = note: audit confidence → High
+
+    2 findings: 0 informational, 0 low, 1 medium, 1 high
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that `-` reads a Dependabot config from stdin.
+#[test]
+fn test_stdin_dependabot() -> anyhow::Result<()> {
+    let dependabot = "\
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+";
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin(dependabot)
+            .no_config(true)
+            .args(["-"])
+            .run()?,
+        @r"
+    warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
+     --> <stdin>:3:5
+      |
+    3 |   - package-ecosystem: github-actions
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+      |
+      = note: audit confidence → High
+      = note: this finding has an auto-fix
+
+    1 finding: 0 informational, 0 low, 1 medium, 0 high
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that empty stdin produces a collection error.
+#[test]
+fn test_stdin_empty() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin("")
+            .no_config(true)
+            .expects_failure(3)
+            .args(["-"])
+            .run()?,
+        @r"
+    🌈 zizmor v@@VERSION@@
+     WARN collect_inputs: zizmor::registry::input: stdin: failed to parse as workflow: failed to load <stdin> as workflow
+     WARN collect_inputs: zizmor::registry::input: stdin: failed to parse as action: failed to load <stdin> as action
+     WARN collect_inputs: zizmor::registry::input: stdin: failed to parse as dependabot config: failed to load <stdin> as dependabot config
+    fatal: no audit was performed
+    error: no inputs collected
+      |
+      = help: collection yielded no auditable inputs
+      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+
+    Caused by:
+        no inputs collected
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that invalid YAML on stdin produces a helpful error.
+#[test]
+fn test_stdin_invalid_yaml() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin("{[invalid")
+            .no_config(true)
+            .expects_failure(3)
+            .args(["-"])
+            .run()?,
+        @r"
+    🌈 zizmor v@@VERSION@@
+     WARN collect_inputs: zizmor::registry::input: stdin: failed to load <stdin> as workflow
+    fatal: no audit was performed
+    error: no inputs collected
+      |
+      = help: collection yielded no auditable inputs
+      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+
+    Caused by:
+        no inputs collected
+    "
+    );
+
+    Ok(())
+}
+
+/// Test that invalid YAML on stdin with `--strict-collection` fails.
+#[test]
+fn test_stdin_invalid_yaml_strict() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin("{[invalid")
+            .no_config(true)
+            .expects_failure(1)
+            .args(["--strict-collection", "-"])
+            .run()?,
+        @r###"
+    🌈 zizmor v@@VERSION@@
+    fatal: no audit was performed
+    failed to load <stdin> as workflow
+
+    Caused by:
+        0: invalid YAML syntax: did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 2
+        1: did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 2
+    "###
+    );
+
+    Ok(())
+}
+
 /// Test that `--gh-token`, `--github-token` and `--zizmor-github-token` conflict with each other.
 #[test]
 fn test_gh_token_github_token_zizmor_github_token_conflict() -> anyhow::Result<()> {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,13 +8,14 @@ description: Usage tips and recipes for running zizmor locally and in CI/CD.
 
 Before auditing, `zizmor` performs an input collection phase.
 
-There are three input sources that `zizmor` knows about:
+There are four input sources that `zizmor` knows about:
 
 1. Individual workflow and composite action files, e.g. `foo.yml` and
    `my-action/action.yml`;
 2. "Local" GitHub repositories in the form of a directory, e.g. `my-repo/`;
 3. "Remote" GitHub repositories in the form of a "slug", e.g.
-   `pypa/sampleproject`.
+   `pypa/sampleproject`;
+4. Standard input, via `-`.
 
     !!! tip
 
@@ -39,6 +40,31 @@ There are three input sources that `zizmor` knows about:
         See [Operating Modes](#operating-modes) and
         [GitHub API token permissions](#github-api-token-permissions) for more
         information.
+
+`zizmor` also supports reading a single input from standard input using `-`:
+
+```bash
+# pipe a workflow from stdin
+cat workflow.yml | zizmor -
+
+# or use a heredoc
+zizmor - <<'EOF'
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+EOF
+```
+
+When reading from stdin, `zizmor` automatically infers the input type
+(workflow, action, or Dependabot config).
+
+!!! note
+
+    `-` cannot be combined with other inputs, and `--fix` is not
+    supported with stdin input.
 
 `zizmor` can audit multiple inputs in the same run, and different input
 sources can be mixed and matched:


### PR DESCRIPTION
## Pre-submission checks

- [x] This PR corresponds to an issue (if not, please create one first).
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR.

## Summary

Add support for `zizmor -` to read a single workflow, action, or Dependabot config from stdin. The input type is automatically inferred by trying each parser in order (workflow -> action -> dependabot).

Key design decisions:

- `-` must be the only input; combining with other inputs is rejected at the CLI level
- `--fix` is incompatible with stdin since there's no file to write back to
- New `InputKey::Stdin(StdinKey)` variant avoids reusing `InputKey::Local` with a synthetic path, preserving the invariant that `Local` always refers to a real filesystem path
- All parse errors are collected and logged so users get context about every failed type attempt, not just a single misleading error (addresses [review feedback](https://github.com/zizmorcore/zizmor/pull/1611#discussion_r2011736281) from #1611)
- Invalid YAML short-circuits immediately (no point trying other parsers)
- No local config discovery for stdin; uses `Config::default()`
- Usage docs updated to document `-` as a fourth input source

Closes #1174

## Test Plan

- [x] `echo 'on: push ...' | zizmor -` parses as workflow (test_stdin_workflow)
- [x] `echo 'name: ... runs: ...' | zizmor -` parses as action (test_stdin_action)
- [x] `echo 'version: 2 ...' | zizmor -` parses as dependabot (test_stdin_dependabot)
- [x] `zizmor - ./other-input` fails with clear error (test_stdin_with_other_inputs)
- [x] `zizmor --fix -` fails with clear error (test_stdin_with_fix)
- [x] Empty stdin produces collection error with all parse failures logged (test_stdin_empty)
- [x] Invalid YAML on stdin warns and exits (test_stdin_invalid_yaml)
- [x] Invalid YAML with `--strict-collection` fails with syntax error (test_stdin_invalid_yaml_strict)
- [x] All 199 existing tests continue to pass (207 total with 8 new)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p zizmor --all-targets` clean (no new warnings)