### PR TITLE
CLI: improve GitHub API failure guidance for audit errors

### DIFF
--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -1083,6 +1083,36 @@ async fn main() -> ExitCode {
                     }
                     _ => None,
                 },
+                Error::Audit { source, .. } => {
+                    let source_text = source.to_string().to_lowercase();
+                    let is_github_rate_limit = source_text.contains("403 forbidden")
+                        || source_text.contains("rate limit")
+                        || source_text.contains("couldn't list tags");
+
+                    if is_github_rate_limit {
+                        let group = Group::with_title(Level::ERROR.primary_title(
+                            "GitHub API request failed while running an audit".to_string(),
+                        ))
+                        .elements([
+                            Level::HELP.message(
+                                "this usually means your GitHub token is missing scopes or has hit a rate limit",
+                            ),
+                            Level::HELP.message(
+                                "set a token with --gh-token (or GH_TOKEN) that can read the target repository",
+                            ),
+                            Level::HELP.message(
+                                "retry after the rate limit resets, or rerun with --offline to skip GitHub API-dependent checks",
+                            ),
+                        ]);
+
+                        let renderer = Renderer::styled();
+                        let report = renderer.render(&[group]);
+
+                        Some(report)
+                    } else {
+                        None
+                    }
+                }
                 _ => None,
             };
 


### PR DESCRIPTION
## Summary
- add a targeted fatal help block when an audit fails due to GitHub API access/rate-limit style errors (for example HTTP 403 or 'couldn't list tags')
- keep the existing underlying error chain, but provide immediate actionable guidance to reduce confusion
- suggest token configuration and offline mode as recovery paths

## Testing
- Not run locally in this environment because the Rust toolchain is unavailable (cargo: command not found), so I could not execute the test suite.
- Change is intentionally minimal and isolated to error-report rendering in main.rs for Error::Audit.

## Related
Fixes #1252