### PR TITLE
fix: Fix recompilation of zizmor

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,11 +18,6 @@ of `zizmor`.
 
     Many thanks to @shaanmajid for proposing and implementing this improvement!
 
-### Bug Fixes 🐛
-
-* Fixed a bug in `build.rs` causing `zizmor` to recompile on every build even without
-  code changes (#1742)
-
 ## 1.23.1
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first). (#1741)

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

This change seems to fix the recompilation even if source file do not change:


Measured with `cargo run -p zizmor -- --version` after a clean build:

| Scenario | Before fix | After fix |
|---|---|---|
| Cached run | **21.3s** | **0.5s** |

## Test Plan

Run `cargo run -- --version` twice in a row, before an after the fix.

## Note

The fix was found by Claude, and it works in practice _but_ I can't find any indications of it in the [manual](https://doc.rust-lang.org/cargo/reference/build-scripts.html) (except that all examples use `println` instead of `print`)