### PR TITLE
chore(ci): don't run benchmarks on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,10 +25,12 @@ jobs:
   benchmarks:
     name: Run benchmarks
     # PRs only get benchmarked if they have the `run-benchmarks` label.
+    # Forks don't have access to CodSpeed secrets, so skip them.
     if: |
-      contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
-        || github.event_name == 'push'
-        || github.event_name == 'workflow_dispatch'
+      !github.event.pull_request.head.repo.fork
+        && (contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
+          || github.event_name == 'push'
+          || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Prevents failures from forks trying to unsuccessfully upload benchmarks to CodSpeed