### PR TITLE
Revert "dependabot-cooldown: skip pre-commit ecosystem (#1758)"

### DIFF
--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -2,7 +2,6 @@ use crate::{
     audit::{Audit, AuditError, audit_meta},
     finding::{Confidence, Fix, FixDisposition, Severity, location::Locatable as _},
 };
-use github_actions_models::dependabot::v2::PackageEcosystem;
 use yamlpatch::{Op, Patch};
 
 audit_meta!(
@@ -12,11 +11,6 @@ audit_meta!(
 );
 
 pub(crate) struct DependabotCooldown;
-
-/// Checks if the given Dependabot package ecosystem supports cooldown configuration.
-fn supports_cooldown(ecosystem: &PackageEcosystem) -> bool {
-    !matches!(ecosystem, PackageEcosystem::PreCommit)
-}
 
 impl DependabotCooldown {
     /// Creates a fix that adds default-days to an existing cooldown block
@@ -96,11 +90,6 @@ impl Audit for DependabotCooldown {
         let mut findings = vec![];
 
         for update in dependabot.updates() {
-            // Skip ecosystems that don't support cooldown
-            if !supports_cooldown(&update.package_ecosystem) {
-                continue;
-            }
-
             match &update.cooldown {
                 // TODO(ww): Should we have opinions about the other
                 // cooldown settings?

--- a/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
@@ -193,15 +193,3 @@ fn test_opentofu_cooldown() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-#[test]
-fn test_pre_commit_no_cooldown_no_findings() -> anyhow::Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .input(input_under_test("dependabot-cooldown/pre-commit-no-cooldown/dependabot.yml"))
-            .run()?,
-        @"No findings to report. Good job!"
-    );
-
-    Ok(())
-}

--- a/crates/zizmor/tests/integration/test-data/dependabot-cooldown/pre-commit-no-cooldown/dependabot.yml
+++ b/crates/zizmor/tests/integration/test-data/dependabot-cooldown/pre-commit-no-cooldown/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: pre-commit
-    directory: /
-    schedule:
-      interval: weekly

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,9 +25,6 @@ of `zizmor`.
 
 ### Bug Fixes 🐛
 
-* The [dependabot-cooldown] audit no longer flags missing cooldowns for
-  the `pre-commit` ecosystem, which does not support cooldown configuration (#1758)
-
 * Fixed a bug where auto-fixes for the [template-injection] audit would fail
   to preserve an environment variable's casing (#1766)
 


### PR DESCRIPTION
This is not needed, since Dependabot has added cooldown support for pre-commit.

See #1757.