### PR TITLE
various: migrate actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Attest to artifacts
         if: ${{ inputs.release-tag != '' }}
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "distrib/*"
 

--- a/crates/github-actions-models/tests/sample-workflows/homebrew-core-dispatch-rebottle.yml
+++ b/crates/github-actions-models/tests/sample-workflows/homebrew-core-dispatch-rebottle.yml
@@ -153,8 +153,8 @@ jobs:
       contents: write # for Homebrew/actions/git-try-push
       packages: write # for brew pr-upload
       pull-requests: write # for gh pr
-      attestations: write # for actions/attest-build-provenance
-      id-token: write # for actions/attest-build-provenance
+      attestations: write # for actions/attest
+      id-token: write # for actions/attest
     runs-on: ubuntu-22.04
     needs: bottle
     if: inputs.upload
@@ -198,7 +198,7 @@ jobs:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest@v4
         with:
           subject-path: ${{ env.BOTTLES_DIR }}/*.tar.gz
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

As of version 4, actions/attest-build-provenance is simply a wrapper on top of [actions/attest](https://github.com/actions/attest) per https://github.com/actions/attest-build-provenance#usage.

