### PR TITLE
fix: disable use of jemalloc as global allocator on OpenBSD

### DIFF
--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -79,7 +79,7 @@ tree-sitter-powershell.workspace = true
 yamlpath.workspace = true
 yamlpatch.workspace = true
 
-[target.'cfg(not(target_family = "windows"))'.dependencies]
+[target.'cfg(not(any(target_family = "windows", target_os = "openbsd")))'.dependencies]
 tikv-jemallocator.workspace = true
 
 [build-dependencies]

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -58,6 +58,7 @@ mod utils;
 
 #[cfg(all(
     not(target_family = "windows"),
+    not(target_os = "openbsd"),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",


### PR DESCRIPTION
Fix #1809 

Build OK on OpenBSD current/amd64 with Rust 1.93.1
```sh
$ uname -a
OpenBSD openbsd-dev.home.lan 7.9 GENERIC.MP#347 amd64
$ rustc 1.93.1 (01f6ddf75 2026-02-11) (built from a source tarball)
binary: rustc
commit-hash: 01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf
commit-date: 2026-02-11
host: x86_64-unknown-openbsd
release: 1.93.1
LLVM version: 20.1.8

$ target/debug/zizmor -V
zizmor 1.23.1
```