### PR TITLE
fix(ci): skip benchmarks on fork repos for all event types

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
     # PRs only get benchmarked if they have the `run-benchmarks` label.
     # Forks don't have access to CodSpeed secrets, so skip them.
     if: |
-      !github.event.pull_request.head.repo.fork
+      github.repository_owner == 'zizmorcore'
         && (contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
           || github.event_name == 'push'
           || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [X] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes #1861. Follow-up to #1755.

Skips CodSpeed benchmark workflow runs on fork repos for all event types. This should now avoid workflow failures when syncing a fork's main branch (e.g., https://github.com/shaanmajid/zizmor/actions/runs/24013818939/job/70029637195).