### PR TITLE
fix(ref-version-mismatch): handle prerelease tags in version comment parsing

### DIFF
--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -30,14 +30,12 @@ audit_meta!(
 #[allow(clippy::unwrap_used)]
 static VERSION_COMMENT_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     vec![
-        // Matches "# tag=v2.8.0" or "# tag=v1.2.3"
-        Regex::new(r"#\s*tag\s*=\s*(v\d+(?:\.\d+)*(?:\.\d+)?)").unwrap(),
-        // Matches "# v2.8.0"
-        Regex::new(r"#\s*(v\d+(?:\.\d+)*(?:\.\d+)?)").unwrap(),
-        // Matches version without 'v' prefix: "# tag=2.8.0"
-        Regex::new(r"#\s*tag\s*=\s*(\d+(?:\.\d+)*(?:\.\d+)?)").unwrap(),
+        // Matches "# tag=v2.8.0", "# tag=v6-beta", or any non-whitespace tag token.
+        Regex::new(r"#\s*tag\s*=\s*(\S+)").unwrap(),
+        // Matches "# v2.8.0" and prerelease forms like "# v1.2.3-rc.1".
+        Regex::new(r"#\s*(v\d+(?:\.\d+)*(?:-[\w.-]+)?)").unwrap(),
         // More flexible: "# version: 2.8.0"
-        Regex::new(r"#\s*(?:version|ver)\s*[:=]\s*(v?\d+(?:\.\d+)*(?:\.\d+)?)").unwrap(),
+        Regex::new(r"#\s*(?:version|ver)\s*[:=]\s*(v?\d+(?:\.\d+)*(?:-[\w.-]+)?)").unwrap(),
     ]
 });
 
@@ -204,10 +202,23 @@ mod tests {
     fn test_version_comment_patterns() {
         let test_cases = vec![
             ("# tag=v2.8.0", Some("v2.8.0")),
+            ("# tag=v6-beta", Some("v6-beta")),
+            ("# tag=v1.2.3-rc.1", Some("v1.2.3-rc.1")),
+            ("# tag=v6-beta-2", Some("v6-beta-2")),
+            ("# tag=release-2024-01", Some("release-2024-01")),
             ("# v2.8.0", Some("v2.8.0")),
+            ("# v6-beta", Some("v6-beta")),
+            ("# v1.2.3-rc.1", Some("v1.2.3-rc.1")),
+            ("# v6-beta-2", Some("v6-beta-2")),
+            ("# v1.0.0-rc-1", Some("v1.0.0-rc-1")),
+            ("# v2.0-preview-3", Some("v2.0-preview-3")),
             ("# tag=2.8.0", Some("2.8.0")),
             ("# version: 2.8.0", Some("2.8.0")),
+            ("# version: v1.2.3-rc.1", Some("v1.2.3-rc.1")),
+            ("# version: v6-beta-2", Some("v6-beta-2")),
+            ("# version: v1.0.0-rc-1", Some("v1.0.0-rc-1")),
             ("# ver=1.0.0", Some("1.0.0")),
+            ("# visit the docs", None),
             ("# some other comment", None),
         ];
 

--- a/crates/zizmor/tests/integration/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/tests/integration/audit/ref_version_mismatch.rs
@@ -94,3 +94,17 @@ fn test_issue_1853() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
+fn test_issue_1869() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(false)
+            .input(input_under_test("ref-version-mismatch/issue-1869-repro.yml"))
+            .run()?,
+        @"No findings to report. Good job! (1 suppressed)"
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/ref-version-mismatch/issue-1869-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/ref-version-mismatch/issue-1869-repro.yml
@@ -1,0 +1,15 @@
+name: ISSUE-1869-REPRO
+
+on:
+  push:
+
+permissions: {}
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -94,6 +94,10 @@ of `zizmor`.
 * Fixed a bug where `nix` would not be recognized as a `package-ecosystem` in
   `dependabot.yml` (#1867)
 
+* Fixed a bug where the [ref-version-mismatch] audit would incorrectly parse
+  prerelease version comments (such as `# v6-beta`), causing some findings
+  to appear unresolvable (#1870)
+
 ### Changes ⚠️
 
 * The [secrets-outside-env] audit now only flags findings with the 'auditor'


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [X] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [X] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes #1869 

Modifies the `ref-version-mismatch` comment parser to capture full tag names including prerelease suffixes.

Previously, `VERSION_COMMENT_PATTERNS` used `v\d+(?:\.\d+)*`. This would stop at the last numeric segment, so e.g., `# v6-beta` was parsed as `v6`, causing a perpetual false positive (since the "fix" would correctly update to the same `# v6-beta` comment).

This PR implements two behavioral changes to the regex patterns:

1.` tag=` form: replaces the version-specific regex with `(\S+)`. Since `tag=` is an explicit signal that the next token is a tag name, capturing up to whitespace is appropriate.
2. `# v...` and `version:`/`ver=` forms: added an optional prerelease group `(?:-[\w.-]+)?` to capture suffixes like `-beta`, `-rc.1`, and compound forms like `-beta-2`.

## Test Plan

- Unit tests for prerelease version comment parsing across several pattern forms
- Added integration test with MRE from #1869
- Manually verified autofix behavior end-to-end (`--fix=all` -> re-run -> no findings)

