### PR TITLE
feat(superfluous-actions): Recommend `gh issue create` as a replacement for @dacbd/create-issue-action

### DIFF
--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -85,6 +85,12 @@ static SUPERFLUOUS_ACTIONS: LazyLock<Vec<(RepositoryUsesPattern, &str, Persona, 
                 Confidence::Low,
             ),
             (
+                "dacbd/create-issue-action".parse().unwrap(),
+                "use `gh issue create` in a script step",
+                Persona::Regular,
+                Confidence::High,
+            ),
+            (
                 "svenstaro/upload-release-action".parse().unwrap(),
                 "use `gh release create` and `gh release upload` in a script step",
                 Persona::Regular,

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1530,6 +1530,7 @@ The following table lists some common superfluous actions and their recommended 
 | @elgohr/Github-Release-Action | `gh release create` |
 | @peter-evans/create-pull-request | `gh pr create` |
 | @peter-evans/create-or-update-comment | `gh pr comment` or `gh issue comment` |
+| @dacbd/create-issue-action | `gh issue create` |
 | @svenstaro/upload-release-action | `gh release create` and `gh release upload` |
 | @addnab/docker-run-action | `docker run` |
 | @dtolnay/rust-toolchain | `rustup` |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -36,6 +36,9 @@ of `zizmor`.
 * Recommend `gh release upload` as a replacement for @svenstaro/upload-release-action in
   [superfluous-actions] (#1801)
 
+* Recommend `gh issue create` as a replacement for @dacbd/create-issue-action in
+  [superfluous-actions] (#1873)
+
 * The [obfuscation] audit now emits a finding for `with: ${{ expr }}`
   clauses cannot be analyzed (#1772)
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

This PR closes #1872. It adds https://github.com/dacbd/create-issue-action, which is an action to create a GitHub issue, and is superfluous in functionality.

I also double-checked the action's source code, and it is inferior to the `gh issue create` CLI in that `gh` supports `--project`, `--template`, and `--body-file`, which the action does not. The only benefit of the action is the output, but that's easily workaroundable by using the `gh api` command to browse through issues. This is my basis for the regular persona and a high-confidence audit.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->
There shouldn't be any test changes needed, but happy to add one if you suggest! I only ran `cargo test` at this time.