### PR TITLE
Use the GitHub client's host correctly in two more places

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -275,9 +275,13 @@ impl Artipacked {
 #[async_trait::async_trait]
 impl Audit for Artipacked {
     fn new(state: &AuditState) -> Result<Self, AuditLoadError> {
-        Ok(Self {
-            client: state.gh_client.clone(),
-        })
+        let client = if state.no_online_audits {
+            None
+        } else {
+            state.gh_client.clone()
+        };
+
+        Ok(Self { client })
     }
 
     async fn audit_action<'doc>(

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -237,7 +237,7 @@ struct RemoteHead {
 #[derive(Clone)]
 pub(crate) struct Client {
     api_base: String,
-    _host: GitHubHost,
+    host: GitHubHost,
     token: GitHubToken,
     base_client: ClientWithMiddleware,
     api_client: ClientWithMiddleware,
@@ -298,7 +298,7 @@ impl Client {
 
         Ok(Self {
             api_base: host.to_api_url(),
-            _host: host.clone(),
+            host: host.clone(),
             token: token.clone(),
             base_client: base_client.into(),
             api_client,
@@ -344,7 +344,10 @@ impl Client {
     }
 
     async fn list_refs(&self, owner: &str, repo: &str) -> Result<Vec<RemoteHead>, ClientError> {
-        let url = format!("https://github.com/{owner}/{repo}.git/git-upload-pack");
+        let url = format!(
+            "https://{host}/{owner}/{repo}.git/git-upload-pack",
+            host = self.host
+        );
 
         let entry = self
             .ref_cache
@@ -584,7 +587,10 @@ impl Client {
     ) -> Result<BranchCommits, ClientError> {
         // NOTE(ww): This API is undocumented.
         // See: https://github.com/orgs/community/discussions/78161
-        let url = format!("https://github.com/{owner}/{repo}/branch_commits/{commit}");
+        let url = format!(
+            "https://{host}/{owner}/{repo}/branch_commits/{commit}",
+            host = self.host
+        );
 
         // We ask GitHub for JSON, because it sends HTML by default for this endpoint.
         self.base_client

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -104,6 +104,12 @@ of `zizmor`.
 * Fixed a bug where various string comparisons in expressions did not perfectly
   match GitHub's own special uppercasing semantics (#1879)
 
+* Fixed a bug where zizmor would incorrectly contact `github.com` instead
+  of the user's requested `--gh-hostname` for some online requests (#1874)
+
+* Fixed a bug where the [artipacked] audit would fail to honor the
+  `--no-online-audits` flag (#1874)
+
 ### Changes ⚠️
 
 * The [secrets-outside-env] audit now only flags findings with the 'auditor'


### PR DESCRIPTION
Fixes #1874 by using the client's host (which stems from `GH_HOST`/`GITHUB_HOST`) instead of hard-coding it as `github.com` in two exceptional cases.