### PR TITLE
docs/integrations: do not persist git creds beyond checkout

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -165,6 +165,8 @@ GitHub Actions setup:
         steps:
           - name: Checkout repository
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            with:
+              persist-credentials: false
 
           - name: Install the latest version of uv
             uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

The "With annotations" tab on https://docs.zizmor.sh/integrations/#manual-integration was missing the `persist-credentials: false` bit for `actions/checkout`.

## Test Plan

n/a
