### PR TITLE
Fix parenthesized compound expression

### DIFF
--- a/crates/github-actions-expressions/src/context.rs
+++ b/crates/github-actions-expressions/src/context.rs
@@ -94,23 +94,22 @@ impl<'src> Context<'src> {
     /// Returns None if the context doesn't have a sensible pattern
     /// equivalent, e.g. if it starts with a call.
     pub fn as_pattern(&self) -> Option<String> {
-        fn push_part(part: &Expr<'_>, pattern: &mut String) -> bool {
+        fn transform_part<'src>(part: &'src Expr<'src>) -> Option<&'src str> {
             match part {
-                Expr::Identifier(ident) => pattern.push_str(ident.0),
-                Expr::Star => pattern.push('*'),
+                Expr::Identifier(ident) => Some(ident.0),
+                Expr::Star => Some("*"),
                 Expr::Index(idx) => match &idx.inner {
                     // foo['bar'] -> foo.bar
-                    Expr::Literal(Literal::String(idx)) => pattern.push_str(idx),
+                    Expr::Literal(Literal::String(idx)) => Some(idx),
                     // any kind of numeric or computed index, e.g.:
                     // foo[0], foo[1 + 2], foo[bar]
-                    _ => pattern.push('*'),
+                    _ => Some("*"),
                 },
                 // Compound expressions like `(a || b).foo` could be expanded
                 // into multiple patterns (one per branch). For now, bail out
                 // and let the caller handle the `None` via its fallback path.
-                _ => return false,
+                _ => None,
             }
-            true
         }
 
         // TODO: Optimization ideas:
@@ -118,24 +117,17 @@ impl<'src> Context<'src> {
         //    identifiers? Problem: case normalization.
         // 2. Use `regex-automata` to return a case insensitive
         //    automation here?
-        let mut pattern = String::new();
-
-        let mut parts = self.parts.iter().peekable();
-
-        let head = parts.next()?;
+        let head = self.parts.first()?;
         if matches!(**head, Expr::Call { .. }) {
             return None;
         }
 
-        if !push_part(head, &mut pattern) {
-            return None;
-        }
-        for part in parts {
-            pattern.push('.');
-            if !push_part(part, &mut pattern) {
-                return None;
-            }
-        }
+        let mut pattern = self
+            .parts
+            .iter()
+            .map(|part| transform_part(part))
+            .collect::<Option<Vec<_>>>()?
+            .join(".");
 
         pattern.make_ascii_lowercase();
         Some(pattern)

--- a/crates/github-actions-expressions/src/context.rs
+++ b/crates/github-actions-expressions/src/context.rs
@@ -94,7 +94,7 @@ impl<'src> Context<'src> {
     /// Returns None if the context doesn't have a sensible pattern
     /// equivalent, e.g. if it starts with a call.
     pub fn as_pattern(&self) -> Option<String> {
-        fn push_part(part: &Expr<'_>, pattern: &mut String) {
+        fn push_part(part: &Expr<'_>, pattern: &mut String) -> bool {
             match part {
                 Expr::Identifier(ident) => pattern.push_str(ident.0),
                 Expr::Star => pattern.push('*'),
@@ -105,8 +105,12 @@ impl<'src> Context<'src> {
                     // foo[0], foo[1 + 2], foo[bar]
                     _ => pattern.push('*'),
                 },
-                _ => unreachable!("unexpected part in context pattern"),
+                // Compound expressions like `(a || b).foo` could be expanded
+                // into multiple patterns (one per branch). For now, bail out
+                // and let the caller handle the `None` via its fallback path.
+                _ => return false,
             }
+            true
         }
 
         // TODO: Optimization ideas:
@@ -123,10 +127,14 @@ impl<'src> Context<'src> {
             return None;
         }
 
-        push_part(head, &mut pattern);
+        if !push_part(head, &mut pattern) {
+            return None;
+        }
         for part in parts {
             pattern.push('.');
-            push_part(part, &mut pattern);
+            if !push_part(part, &mut pattern) {
+                return None;
+            }
         }
 
         pattern.make_ascii_lowercase();
@@ -385,6 +393,12 @@ mod tests {
             ("foo .* .*", Some("foo.*.*")),
             // Invalid cases
             ("fromJSON('{}').bar", None),
+            // Grouped/compound expressions in context position return None
+            // rather than panicking.
+            (
+                "(github.event.pull_request || github.event.issue).number",
+                None,
+            ),
         ] {
             let ctx = Context::parse(*case).unwrap();
             assert_eq!(ctx.as_pattern().as_deref(), *expected);

--- a/crates/zizmor/tests/integration/audit/template_injection.rs
+++ b/crates/zizmor/tests/integration/audit/template_injection.rs
@@ -616,6 +616,34 @@ fn test_issue_1664() -> Result<()> {
     Ok(())
 }
 
+/// Repro case for #1903: parenthesized compound expressions in context
+/// position (e.g. `(a || b).foo`) should not crash zizmor.
+///
+/// See: <https://github.com/zizmorcore/zizmor/issues/1903>
+#[test]
+fn test_issue_1903() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("template-injection/issue-1903-repro.yml"))
+            .run()?,
+        @r#"
+    info[template-injection]: code injection via template expansion
+      --> @@INPUT@@:21:24
+       |
+    21 |       - run: echo "${{ (github.event.pull_request || github.event.issue).number }}"
+       |         ---            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
+       |         |
+       |         this run block
+       |
+       = note: audit confidence → Low
+
+    1 finding: 1 informational, 0 low, 0 medium, 0 high
+    "#
+    );
+
+    Ok(())
+}
+
 /// Repro case for #1802: `needs.*.result` expressions should not be considered injection risks in the default persona.
 ///
 /// See: <https://github.com/zizmorcore/zizmor/issues/1802>

--- a/crates/zizmor/tests/integration/test-data/template-injection/issue-1903-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/template-injection/issue-1903-repro.yml
@@ -1,0 +1,21 @@
+# See: https://github.com/zizmorcore/zizmor/issues/1903
+#
+# Parenthesized compound expressions in context position
+# (e.g. `(a || b).foo`) should not crash zizmor.
+
+name: issue-1903-repro
+
+on: issue_comment
+
+permissions: {}
+
+concurrency:
+  group: issue-1903-repro
+  cancel-in-progress: true
+
+jobs:
+  repro:
+    name: Repro
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ (github.event.pull_request || github.event.issue).number }}"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed a crash in the [template-injection] audit when a workflow uses
+  a parenthesized compound expression in context position (#XXXX)
+
 ## 1.24.1
 
 ### Bug Fixes 🐛

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,7 +12,7 @@ of `zizmor`.
 ### Bug Fixes 🐛
 
 * Fixed a crash in the [template-injection] audit when a workflow uses
-  a parenthesized compound expression in context position (#XXXX)
+  a parenthesized compound expression in context position (#1904)
 
 ## 1.24.1
 


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first). (#1903 )

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fix a crash in `Context::as_pattern` when a workflow contains a parenthesized compound expression in     
context position. The expression parser (since #1692) correctly parses these into a BinOp node, but as_pattern hit an `unreachable!()` on the unexpected variant.

## Test Plan

Test in both context.rs and full regression test.