### PR TITLE
fix(collect): absolutize paths before .github/workflows check

### DIFF
--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -410,13 +410,9 @@ impl InputGroup {
         // with action definitions). Consequently, we make a best effort
         // disambiguate them by looking at their parent path.
         // See: https://github.com/zizmorcore/zizmor/issues/1341
-        let is_workflow_path = {
-            let resolved = path.canonicalize_utf8()?;
-
-            resolved
-                .parent()
-                .is_some_and(|parent| parent.ends_with(".github/workflows"))
-        };
+        let is_workflow_path = camino::absolute_utf8(path)?
+            .parent()
+            .is_some_and(|parent| parent.ends_with(".github/workflows"));
 
         let mut group = Self::new(config);
 
@@ -485,7 +481,7 @@ impl InputGroup {
             if options.mode_set.workflows()
                 && entry.is_file()
                 && matches!(entry.extension(), Some("yml" | "yaml"))
-                && entry
+                && camino::absolute_utf8(entry)?
                     .parent()
                     .is_some_and(|dir| dir.ends_with(".github/workflows"))
             {

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -82,6 +82,30 @@ fn menagerie() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for #1907.
+///
+/// Ensures that directory collection finds workflows when invoked
+/// from inside `.github/` with a relative path.
+#[test]
+fn issue_1907() -> Result<()> {
+    let working_dir = format!("{}/.github", input_under_test("issue-1907-repro"));
+
+    insta::assert_snapshot!(
+        zizmor()
+            .output(OutputMode::Both)
+            .working_dir(working_dir)
+            .input("./workflows")
+            .run()?,
+        @r"
+         INFO zizmor: 🌈 zizmor v@@VERSION@@
+         INFO audit: zizmor: 🌈 completed @@INPUT@@/test.yml
+        No findings to report. Good job! (1 suppressed)
+        "
+    );
+
+    Ok(())
+}
+
 #[test]
 fn color_control_basic() -> Result<()> {
     // No terminal and not CI, so no color by default.

--- a/crates/zizmor/tests/integration/test-data/issue-1907-repro/.github/workflows/test.yml
+++ b/crates/zizmor/tests/integration/test-data/issue-1907-repro/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+on: push
+name: Test
+permissions: {}
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'test'

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where local directory input collection could miss workflows for
+  relative-path invocations from within `.github` subdirectories (#1909)
+
 ## 1.24.1
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes #1907.

`collect_from_dir` checked `parent.ends_with(".github/workflows")` against the raw walker-emitted path, so `zizmor .` (or any relative-path argument) from inside `.github/` or `.github/workflows/` collected zero workflows. The single-file path (`collect_from_file`) was already absolutizing via `canonicalize_utf8`; both call sites now use `camino::absolute_utf8`

## Test Plan

Added new e2e regression test.