### PR TITLE
fix: include filename in validation warning message

### DIFF
--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -392,7 +392,7 @@ impl InputGroup {
                 Ok(())
             }
             Err(e @ CollectionError::Schema { .. }) if !strict => {
-                tracing::warn!("failed to validate input as {kind}: {e}");
+                tracing::warn!("failed to validate input {} as {kind}: {e}", key.presentation_path());
                 Ok(())
             }
             Err(e) => Err(CollectionError::Inner(e.into(), key.to_string(), kind)),


### PR DESCRIPTION
## Summary

When a file fails validation as a workflow/action/dependabot config, the warning message now includes the file path to help users identify which files are causing issues.

## Before

```
WARN collect_inputs: zizmor::registry::input: failed to validate input as workflow: input does not match expected validation schema
WARN collect_inputs: zizmor::registry::input: failed to validate input as workflow: input does not match expected validation schema
```

Users had to guess which files failed by elimination.

## After

```
WARN collect_inputs: zizmor::registry::input: failed to validate input .github/release.yml as workflow: input does not match expected validation schema
WARN collect_inputs: zizmor::registry::input: failed to validate input .github/zizmor.yml as workflow: input does not match expected validation schema
```

## Changes

- Modified the warning message in `InputGroup::register()` to include `key.presentation_path()`

Fixes #1835

---

Thanks for maintaining zizmor! It's an awesome tool for securing GitHub Actions workflows. 🙏