### PR TITLE
Document nvim-lspconfig integration

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -237,6 +237,22 @@ to work.
 
 See @zizmorcore/zizmor-vscode for full installation and configuration instructions.
 
+### Neovim
+
+Support for `zizmor` in neovim is provided by
+[`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig). As with Visual
+Studio Code, you must install `zizmor` [separately](./installation.md) for the
+LSP server to work. Then [follow the
+instructions](https://github.com/neovim/nvim-lspconfig#install) for installing
+`nvim-lspconfig` with your neovim package manager, and enable the LSP server in
+your `init.lua`:
+
+```lua
+vim.lsp.enable('zizmor')
+```
+
+For more information about LSP configuration in neovim, see `:h lspconfig-all`.
+
 ### Generic LSP integration
 
 `zizmor` can be integrated with any editor or IDE that supports LSP.
@@ -253,7 +269,7 @@ with the editor over `stdin` and `stdout`. No other transports are supported.
 ## VCS integrations
 
 ### `pre-commit`
-  
+
 `zizmor` can be used with the [`pre-commit`](https://pre-commit.com/) framework.
 To do so, add the following to your `.pre-commit-config.yaml` `#!yaml repos:` section:
 
@@ -278,7 +294,7 @@ This will run `zizmor` on every commit.
     information on how to configure `pre-commit`.
 
 !!! tip
-  
+
     `zizmor-pre-commit` also works with [`prek`](https://github.com/j178/prek),
     a rewrite of `pre-commit` in Rust.
 


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

This PR adds a note in the documentation about `nvim-lspconfig` integration, merged in https://github.com/neovim/nvim-lspconfig/pull/4382.

Here's what the relevant section of the docs looks like when rendered:

<img width="853" height="1328" alt="image" src="https://github.com/user-attachments/assets/f9dd9e17-6692-4efb-ad11-a98dd770bcf9" />

Closes #1916.


Please note that these changes haven't yet been released upstream in `nvim-lspconfig`, but can be found on the `master` branch there. If it would be better to wait for a release, I can move this back into draft and reopen at the next release.