### PR TITLE
fix: include filename in validation warning message

### DIFF
--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -392,7 +392,7 @@ impl InputGroup {
                 Ok(())
             }
             Err(e @ CollectionError::Schema { .. }) if !strict => {
-                tracing::warn!("failed to validate input as {kind}: {e}");
+                tracing::warn!("failed to validate input {} as {kind}: {e}", key.presentation_path());
                 Ok(())
             }
             Err(e) => Err(CollectionError::Inner(e.into(), key.to_string(), kind)),


### PR DESCRIPTION
When a file fails validation as a workflow/action/dependabot config, the warning message now includes the file path to help users identify which files are causing issues.

Fixes #1835

Changes:
- Modified the warning message in registry/input.rs to include the file path when validation fails

Before:
> failed to validate input as workflow: input does not match expected validation schema

After:
> failed to validate input .github/release.yml as workflow: input does not match expected validation schema

This makes it much easier for users to identify which files need attention when running zizmor on directories with multiple workflow files.