### PR TITLE
fix(superfluous-actions): skip dtolnay/rust-toolchain on self-hosted runners

### DIFF
--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -132,9 +132,7 @@ impl SuperfluousActions {
         // On self-hosted runners, rustup/cargo may not be pre-installed, so
         // dtolnay/rust-toolchain is NOT superfluous.
         let is_self_hosted = job.map_or(false, |j| Self::is_self_hosted_runner(j));
-        let rust_toolchain_pattern: RepositoryUsesPattern =
-            "dtolnay/rust-toolchain".parse().expect("valid pattern");
-        let is_rust_toolchain = rust_toolchain_pattern.matches(uses);
+        let is_rust_toolchain = uses.repository() == "dtolnay/rust-toolchain";
 
         let mut findings = vec![];
         for (pattern, recommendation, persona, confidence) in SUPERFLUOUS_ACTIONS.iter() {
@@ -166,15 +164,24 @@ impl SuperfluousActions {
     }
 
     /// Returns true if the job runs on a self-hosted runner.
-    fn is_self_hosted_runner<'doc>(job: &NormalJob<'doc>) -> bool {
+    fn is_self_hosted_runner(job: &NormalJob<'_>) -> bool {
         use github_actions_models::common::expr::LoE;
         use github_actions_models::workflow::job::RunsOn;
 
         match &job.runs_on {
-            // Expression-based runs-on: conservatively assume self-hosted
-            // since we can't statically determine the runner type.
-            LoE::Expr(_) => true,
-            LoE::Literal(RunsOn::Group { labels, .. }) | LoE::Literal(RunsOn::Target(labels)) => {
+            // Expression-based runs-on: only treat as self-hosted if the
+            // matrix expansion actually contains "self-hosted".
+            LoE::Expr(exp) => {
+                let Some(matrix) = job.matrix() else {
+                    return false;
+                };
+                matrix.expansions().iter().any(|expansion| {
+                    exp.as_bare() == expansion.path && expansion.value.contains("self-hosted")
+                })
+            }
+            // Runner groups always imply self-hosted runners.
+            LoE::Literal(RunsOn::Group { .. }) => true,
+            LoE::Literal(RunsOn::Target(labels)) => {
                 // A runner is considered self-hosted if no label matches
                 // known GitHub-hosted runner patterns (ubuntu-*, macos*, windows-*).
                 !labels.iter().any(|label| {

--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -131,8 +131,8 @@ impl SuperfluousActions {
         // For dtolnay/rust-toolchain, check if running on a self-hosted runner.
         // On self-hosted runners, rustup/cargo may not be pre-installed, so
         // dtolnay/rust-toolchain is NOT superfluous.
-        let is_self_hosted = job.map_or(false, |j| Self::is_self_hosted_runner(j));
-        let is_rust_toolchain = uses.repository() == "dtolnay/rust-toolchain";
+        let is_self_hosted = job.is_some_and(|j| Self::is_self_hosted_runner(j));
+        let is_rust_toolchain = uses.slug() == "dtolnay/rust-toolchain";
 
         let mut findings = vec![];
         for (pattern, recommendation, persona, confidence) in SUPERFLUOUS_ACTIONS.iter() {
@@ -164,21 +164,14 @@ impl SuperfluousActions {
     }
 
     /// Returns true if the job runs on a self-hosted runner.
-    fn is_self_hosted_runner(job: &NormalJob<'_>) -> bool {
+    fn is_self_hosted_runner<'doc>(job: &NormalJob<'doc>) -> bool {
         use github_actions_models::common::expr::LoE;
         use github_actions_models::workflow::job::RunsOn;
 
         match &job.runs_on {
-            // Expression-based runs-on: only treat as self-hosted if the
-            // matrix expansion actually contains "self-hosted".
-            LoE::Expr(exp) => {
-                let Some(matrix) = job.matrix() else {
-                    return false;
-                };
-                matrix.expansions().iter().any(|expansion| {
-                    exp.as_bare() == expansion.path && expansion.value.contains("self-hosted")
-                })
-            }
+            // Expression-based runs-on: conservatively treat as GitHub-hosted
+            // since we cannot determine the actual runner type at analysis time.
+            LoE::Expr(_exp) => false,
             // Runner groups always imply self-hosted runners.
             LoE::Literal(RunsOn::Group { .. }) => true,
             LoE::Literal(RunsOn::Target(labels)) => {

--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -7,7 +7,9 @@ use crate::{
     audit::{Audit, AuditError, AuditLoadError, audit_meta},
     config::Config,
     finding::{Confidence, Finding, Persona, Severity},
-    models::{StepCommon, action::CompositeStep, uses::RepositoryUsesPattern, workflow::Step},
+    models::{
+        StepCommon, action::CompositeStep, uses::RepositoryUsesPattern, workflow::{NormalJob, Step},
+    },
     state::AuditState,
 };
 
@@ -33,7 +35,7 @@ impl Audit for SuperfluousActions {
         step: &Step<'doc>,
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        self.process_step(step).await
+        self.process_step(step, Some(step.job()))
     }
 
     async fn audit_composite_step<'doc>(
@@ -41,7 +43,8 @@ impl Audit for SuperfluousActions {
         step: &CompositeStep<'doc>,
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        self.process_step(step).await
+        // Composite steps don't have access to a workflow job context.
+        self.process_step(step, None)
     }
 }
 
@@ -119,14 +122,27 @@ impl SuperfluousActions {
     async fn process_step<'doc>(
         &self,
         step: &impl StepCommon<'doc>,
+        job: Option<&NormalJob<'doc>>,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
         let Some(Uses::Repository(uses)) = step.uses() else {
             return Ok(vec![]);
         };
 
+        // For dtolnay/rust-toolchain, check if running on a self-hosted runner.
+        // On self-hosted runners, rustup/cargo may not be pre-installed, so
+        // dtolnay/rust-toolchain is NOT superfluous.
+        let is_self_hosted = job.map_or(false, |j| Self::is_self_hosted_runner(j));
+        let is_rust_toolchain = "dtolnay/rust-toolchain".parse::<RepositoryUsesPattern>().unwrap()
+            .matches(uses);
+
         let mut findings = vec![];
         for (pattern, recommendation, persona, confidence) in SUPERFLUOUS_ACTIONS.iter() {
             if pattern.matches(uses) {
+                // Skip dtolnay/rust-toolchain on self-hosted runners.
+                if is_self_hosted && is_rust_toolchain {
+                    continue;
+                }
+
                 findings.push(
                     Self::finding()
                         .confidence(*confidence)
@@ -146,5 +162,25 @@ impl SuperfluousActions {
         }
 
         Ok(findings)
+    }
+
+    /// Returns true if the job runs on a self-hosted runner.
+    fn is_self_hosted_runner(job: &NormalJob) -> bool {
+        use github_actions_models::common::expr::LoE;
+        use github_actions_models::workflow::job::RunsOn;
+
+        match &job.runs_on {
+            // Expression-based runs-on: conservatively assume self-hosted
+            // since we can't statically determine the runner type.
+            LoE::Expr(_) => true,
+            LoE::Literal(RunsOn::Group { labels, .. }) | LoE::Literal(RunsOn::Target(labels)) => {
+                // A runner is considered self-hosted if no label matches
+                // known GitHub-hosted runner patterns (ubuntu-*, macos*, windows-*).
+                !labels.iter().any(|label| {
+                    let l = label.as_str();
+                    l.contains("ubuntu-") || l.contains("macos") || l.contains("windows-")
+                })
+            }
+        }
     }
 }

--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -35,7 +35,7 @@ impl Audit for SuperfluousActions {
         step: &Step<'doc>,
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        self.process_step(step, Some(step.job()))
+        self.process_step(step, Some(step.job())).await
     }
 
     async fn audit_composite_step<'doc>(
@@ -44,7 +44,7 @@ impl Audit for SuperfluousActions {
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
         // Composite steps don't have access to a workflow job context.
-        self.process_step(step, None)
+        self.process_step(step, None).await
     }
 }
 
@@ -132,8 +132,9 @@ impl SuperfluousActions {
         // On self-hosted runners, rustup/cargo may not be pre-installed, so
         // dtolnay/rust-toolchain is NOT superfluous.
         let is_self_hosted = job.map_or(false, |j| Self::is_self_hosted_runner(j));
-        let is_rust_toolchain = "dtolnay/rust-toolchain".parse::<RepositoryUsesPattern>().unwrap()
-            .matches(uses);
+        let rust_toolchain_pattern: RepositoryUsesPattern =
+            "dtolnay/rust-toolchain".parse().expect("valid pattern");
+        let is_rust_toolchain = rust_toolchain_pattern.matches(uses);
 
         let mut findings = vec![];
         for (pattern, recommendation, persona, confidence) in SUPERFLUOUS_ACTIONS.iter() {
@@ -165,7 +166,7 @@ impl SuperfluousActions {
     }
 
     /// Returns true if the job runs on a self-hosted runner.
-    fn is_self_hosted_runner(job: &NormalJob) -> bool {
+    fn is_self_hosted_runner<'doc>(job: &NormalJob<'doc>) -> bool {
         use github_actions_models::common::expr::LoE;
         use github_actions_models::workflow::job::RunsOn;
 


### PR DESCRIPTION
On self-hosted runners, `rustup`/`cargo` may not be pre-installed, making `dtolnay/rust-toolchain` a necessary step rather than a superfluous one. Skip this check when the job's `runs-on` label does not match known GitHub-hosted runner patterns (`ubuntu-*`, `macos*`, `windows-*`).

Fixes zizmorcore/zizmor#1865