### PR TITLE
fix(registry): show filename in schema and syntax validation warnings

### DIFF
--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -388,11 +388,11 @@ impl InputGroup {
         match input {
             Ok(input) => self.register_input(input),
             Err(CollectionError::Syntax(e)) if !strict => {
-                tracing::warn!("failed to parse input: {e}");
+                tracing::warn!("failed to parse {key}: {e}");
                 Ok(())
             }
             Err(e @ CollectionError::Schema { .. }) if !strict => {
-                tracing::warn!("failed to validate input as {kind}: {e}");
+                tracing::warn!("failed to validate {key} as {kind}: {e}");
                 Ok(())
             }
             Err(e) => Err(CollectionError::Inner(e.into(), key.to_string(), kind)),


### PR DESCRIPTION
Hey there! 👋

I noticed issue #1835 where validation warnings don't include the filename, making it hard to track down which files are causing problems. This PR fixes that.

**The Problem**
When running zizmor in non-strict mode on a repo with multiple workflow files, if one of them fails schema validation, you get a warning like:
```
WARN failed to validate input as workflow: input does not match expected validation schema
```

But you have no idea which file! 😅

**The Fix**
Simple change to include the `key` (which contains the filename) in both the syntax and schema validation warnings:

```
WARN failed to validate file://.github/workflows/broken.yml as workflow: input does not match expected validation schema
```

**Testing**
- [x] Ran `cargo test` - all tests pass
- [x] Tested locally with a repo containing malformed workflow files
- [x] Verified the filename now appears in warning output

The fix is minimal and only affects the warning message format - no functional changes.

Let me know if you'd like any adjustments! 🙏

Fixes #1835