### PR TITLE
Add five more cases of superfluous actions and recommend their replacements

### DIFF
--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -130,6 +130,24 @@ static SUPERFLUOUS_ACTIONS: LazyLock<Vec<(RepositoryUsesPattern, &str, Persona, 
                 Persona::Pedantic,
                 Confidence::Medium,
             ),
+            (
+                "stefanzweifel/git-auto-commit-action".parse().unwrap(),
+                "use `git add`, `git commit`, and `git push` in a script step",
+                // NOTE: Currently pedantic because replicating this action's
+                // full behaviour (empty commit detection, auth setup, etc.)
+                // requires multiple git commands and some care.
+                Persona::Pedantic,
+                Confidence::Low,
+            ),
+            (
+                "EndBug/add-and-commit".parse().unwrap(),
+                "use `git add`, `git commit`, and `git push` in a script step",
+                // NOTE: Currently pedantic because replicating this action's
+                // full behaviour (empty commit detection, auth setup, etc.)
+                // requires multiple git commands and some care.
+                Persona::Pedantic,
+                Confidence::Low,
+            ),
         ]
     });
 

--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -115,6 +115,12 @@ static SUPERFLUOUS_ACTIONS: LazyLock<Vec<(RepositoryUsesPattern, &str, Persona, 
                 Confidence::High,
             ),
             (
+                "sergeysova/jq-action".parse().unwrap(),
+                "use `jq` in a script step",
+                Persona::Regular,
+                Confidence::High,
+            ),
+            (
                 "dtolnay/rust-toolchain".parse().unwrap(),
                 "use `rustup` and/or `cargo` in a script step",
                 // NOTE(ww): Currently pedantic because this action does

--- a/crates/zizmor/src/audit/superfluous_actions.rs
+++ b/crates/zizmor/src/audit/superfluous_actions.rs
@@ -91,6 +91,18 @@ static SUPERFLUOUS_ACTIONS: LazyLock<Vec<(RepositoryUsesPattern, &str, Persona, 
                 Confidence::High,
             ),
             (
+                "actions-ecosystem/action-add-labels".parse().unwrap(),
+                "use `gh issue edit --add-label` or `gh pr edit --add-label` in a script step",
+                Persona::Regular,
+                Confidence::High,
+            ),
+            (
+                "actions-ecosystem/action-remove-labels".parse().unwrap(),
+                "use `gh issue edit --remove-label` or `gh pr edit --remove-label` in a script step",
+                Persona::Regular,
+                Confidence::High,
+            ),
+            (
                 "svenstaro/upload-release-action".parse().unwrap(),
                 "use `gh release create` and `gh release upload` in a script step",
                 Persona::Regular,

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1605,6 +1605,8 @@ The following table lists some common superfluous actions and their recommended 
 | @peter-evans/create-pull-request | `gh pr create` |
 | @peter-evans/create-or-update-comment | `gh pr comment` or `gh issue comment` |
 | @dacbd/create-issue-action | `gh issue create` |
+| @actions-ecosystem/action-add-labels | `gh issue edit --add-label` or `gh pr edit --add-label` |
+| @actions-ecosystem/action-remove-labels | `gh issue edit --remove-label` or `gh pr edit --remove-label` |
 | @svenstaro/upload-release-action | `gh release create` and `gh release upload` |
 | @addnab/docker-run-action | `docker run` |
 | @dtolnay/rust-toolchain | `rustup` |

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1611,6 +1611,8 @@ The following table lists some common superfluous actions and their recommended 
 | @addnab/docker-run-action | `docker run` |
 | @sergeysova/jq-action | `jq <...>` |
 | @dtolnay/rust-toolchain | `rustup` |
+| @stefanzweifel/git-auto-commit-action | `git add`, `git commit`, and `git push` |
+| @EndBug/add-and-commit | `git add`, `git commit`, and `git push` |
 
 !!! example
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1609,6 +1609,7 @@ The following table lists some common superfluous actions and their recommended 
 | @actions-ecosystem/action-remove-labels | `gh issue edit --remove-label` or `gh pr edit --remove-label` |
 | @svenstaro/upload-release-action | `gh release create` and `gh release upload` |
 | @addnab/docker-run-action | `docker run` |
+| @sergeysova/jq-action | `jq <...>` |
 | @dtolnay/rust-toolchain | `rustup` |
 
 !!! example

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,12 @@ of `zizmor`.
 
 ### Enhancements
 
+* Recommend `gh issue edit --add-label` / `gh pr edit --add-label` as a replacement for
+  @actions-ecosystem/action-add-labels in [superfluous-actions]
+
+* Recommend `gh issue edit --remove-label` / `gh pr edit --remove-label` as a replacement for
+  @actions-ecosystem/action-remove-labels in [superfluous-actions]
+
 * @tibdex/github-app-token is now recognized as an archived action by
   [archived-uses] (#1910)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,6 +33,14 @@ of `zizmor`.
 * Recommend `gh issue edit --remove-label` / `gh pr edit --remove-label` as a replacement for
   @actions-ecosystem/action-remove-labels in [superfluous-actions]
 
+* Recommend `jq` as a replacement for @sergeysova/jq-action in [superfluous-actions]
+
+* Recommend `git add`, `git commit`, and `git push` as a replacement for
+  @stefanzweifel/git-auto-commit-action in [superfluous-actions]
+
+* Recommend `git add`, `git commit`, and `git push` as a replacement for
+  @EndBug/add-and-commit in [superfluous-actions]
+
 * @tibdex/github-app-token is now recognized as an archived action by
   [archived-uses] (#1910)
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

In continuation of my previous contribution via #1873, I discovered that some actions across the projects I am involved in are superfluous and can be replaced with simpler commands. This PR adds them to the list. All of these have more than a hundred uses at this time, as noted in the table below.

| Action | Why?   | Usage metrics |
|--------|--------|-------------|
| `actions-ecosystem/action-add-labels` | Can be replaced with `gh issue` or `gh pr` commands | [Search results](https://github.com/search?q=%22actions-ecosystem/action-add-labels%22+language:YAML&type=code) (3.6K hits) |
| `actions-ecosystem/action-remove-labels` | Can be replaced with `gh issue` or `gh pr` commands | [Search results](https://github.com/search?q=%22actions-ecosystem/action-remove-labels%22+language:YAML&type=code) (2.3K hits) |
| `sergeysova/jq-action` | It's literally just `jq`! It's installed by default on GHA Linux runners. However, `jq` needs to be installed on macOS runners (via Homebrew or other package managers), from the last time I remember trying it. | [Search results](https://github.com/search?q=%22sergeysova/jq-action%22+language:YAML&type=code) (636 hits, and this is pretty surprising to me! 🙈) |
| `stefanzweifel/git-auto-commit-action` | Commonly used to add files and commit them to a PR or a branch. I've noted this with a pedantic persona and a low-confidence score: there are some features, such as the dirty check (`git status --porcelain` plus an early exit), committer identity config, and push setup, etc., that require enough boilerplate to justify their existence. | [Search results](https://github.com/search?q=%22stefanzweifel/git-auto-commit-action%22+language:YAML&type=code) (44.5K hits) |
| `EndBug/add-and-commit` | Same use case as `stefanzweifel`. It also exposes outputs like `commit_long_sha` and `pushed`, which downstream steps may consume — those need `git rev-parse HEAD`, and so on to replicate. Again, I believe this is all doable with `git`, but feel that there are enough moving parts for `Pedantic`/`Low`. | [Search results](https://github.com/search?q=%22EndBug/add-and-commit%22+language:YAML&type=code) (21.6K hits) | 

Thank you :D