### PR TITLE
Handle bare-image container references

### DIFF
--- a/crates/github-actions-models/src/workflow/job.rs
+++ b/crates/github-actions-models/src/workflow/job.rs
@@ -163,7 +163,7 @@ pub struct Matrix {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Container {
-    Name(String),
+    Name(LoE<DockerUses>),
     Container {
         image: LoE<DockerUses>,
         credentials: Option<DockerCredentials>,

--- a/crates/zizmor/src/audit/unpinned_images.rs
+++ b/crates/zizmor/src/audit/unpinned_images.rs
@@ -98,13 +98,22 @@ impl Audit for UnpinnedImages {
         let mut image_refs_with_locations: Vec<(&'doc LoE<DockerUses>, SymbolicLocation<'doc>)> =
             vec![];
 
-        if let Some(Container::Container { image, .. }) = &job.container {
-            image_refs_with_locations.push((
-                image,
-                job.location()
-                    .primary()
-                    .with_keys(["container".into(), "image".into()]),
-            ));
+        match &job.container {
+            Some(Container::Name(image)) => {
+                image_refs_with_locations.push((
+                    image,
+                    job.location().primary().with_keys(["container".into()]),
+                ));
+            }
+            Some(Container::Container { image, .. }) => {
+                image_refs_with_locations.push((
+                    image,
+                    job.location()
+                        .primary()
+                        .with_keys(["container".into(), "image".into()]),
+                ));
+            }
+            None => {}
         }
 
         for (service, config) in job.services.iter() {

--- a/crates/zizmor/tests/integration/audit/unpinned_images.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_images.rs
@@ -201,3 +201,26 @@ fn test_matrix_in_image_regular() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_issue_1942_repro() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("unpinned-images/issue-1942-repro.yml"))
+            .args(["--persona=pedantic"])
+            .run()?,
+        @"
+    error[unpinned-images]: unpinned image references
+      --> @@INPUT@@:13:5
+       |
+    13 |     container: node:18
+       |     ^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+       |
+       = note: audit confidence → High
+
+    1 finding: 0 informational, 0 low, 0 medium, 1 high
+    "
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__astral_sh_uv.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__astral_sh_uv.snap
@@ -1096,6 +1096,14 @@ help[ref-version-mismatch]: action's hash pin has mismatched or missing version 
     = tip: add version comment '# v3.0.1'
     = note: this finding has an auto-fix
 
+error[unpinned-images]: unpinned image references
+  --> .github/workflows/test-smoke.yml:78:5
+   |
+78 |     container: alpine:latest
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ container image is pinned to latest
+   |
+   = note: audit confidence → High
+
 help[anonymous-definition]: workflow or action definition without a name
    --> .github/workflows/test-smoke.yml:1:1
     |
@@ -1118,6 +1126,38 @@ help[template-injection]: code injection via template expansion
     |         ---            ^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
     |         |
     |         this run block
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/test-system.yml:138:5
+    |
+138 |     container: rockylinux/rockylinux:${{ matrix.rocky-version }}
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/test-system.yml:251:5
+    |
+251 |     container: pyston/pyston:2.3.5
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/test-system.yml:275:5
+    |
+275 |     container: alpine:latest
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^ container image is pinned to latest
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/test-system.yml:687:5
+    |
+687 |     container: amazonlinux:2023
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
     |
     = note: audit confidence → High
 
@@ -1365,4 +1405,4 @@ help[anonymous-definition]: workflow or action definition without a name
     = note: audit confidence → High
     = tip: use 'name: ...' to give this workflow a name
 
-125 findings (2 suppressed): 24 informational, 81 low, 16 medium, 2 high
+130 findings (2 suppressed): 24 informational, 81 low, 16 medium, 7 high

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
@@ -21,6 +21,56 @@ expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=
  INFO audit: zizmor: 🌈 completed .github/workflows/macos.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/non-native.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/windows.yml
+error[unpinned-images]: unpinned image references
+  --> .github/workflows/linux-old.yml:58:5
+   |
+58 |     container: 'debian:stretch'
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+   |
+   = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/linux.yml:64:5
+    |
+ 64 |     container: ${{ matrix.build.container }}
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+...
+ 73 |       matrix:
+    |       ------ this matrix
+...
+390 |             container: 'andy5995/slackware-build-essential:15.0'
+    |             ---------------------------------------------------- this expansion of matrix.build.container
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/linux.yml:64:5
+    |
+ 64 |     container: ${{ matrix.build.container }}
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+...
+ 73 |       matrix:
+    |       ------ this matrix
+...
+394 |             container: 'alpine:3.20'
+    |             ------------------------ this expansion of matrix.build.container
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+   --> .github/workflows/linux.yml:64:5
+    |
+ 64 |     container: ${{ matrix.build.container }}
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+...
+ 73 |       matrix:
+    |       ------ this matrix
+...
+398 |             container: 'alpine:3.20'
+    |             ------------------------ this expansion of matrix.build.container
+    |
+    = note: audit confidence → High
+
 warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
   --> .github/workflows/windows.yml:57:87
    |
@@ -32,4 +82,4 @@ warning[ref-version-mismatch]: action's hash pin has mismatched or missing versi
    = note: audit confidence → High
    = note: this finding has an auto-fix
 
-47 findings (2 ignored, 44 suppressed): 0 informational, 0 low, 1 medium, 0 high
+51 findings (2 ignored, 44 suppressed): 0 informational, 0 low, 1 medium, 4 high

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__pyca_cryptography.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__pyca_cryptography.snap
@@ -315,6 +315,14 @@ help[template-injection]: code injection via template expansion
     = note: audit confidence → High
 
 error[unpinned-images]: unpinned image references
+   --> .github/workflows/ci.yml:152:5
+    |
+152 |     container: ghcr.io/pyca/cryptography-runner-${{ matrix.IMAGE.IMAGE }}
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is unpinned
+    |
+    = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
    --> .github/workflows/ci.yml:215:7
     |
 215 |       image: ghcr.io/pyca/cryptography-runner-${{ matrix.IMAGE.IMAGE }}
@@ -781,4 +789,4 @@ info[superfluous-actions]: action functionality is already included by the runne
    |
    = note: audit confidence → Low
 
-79 findings (9 suppressed): 19 informational, 35 low, 7 medium, 9 high
+80 findings (9 suppressed): 19 informational, 35 low, 7 medium, 10 high

--- a/crates/zizmor/tests/integration/test-data/unpinned-images/issue-1942-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-images/issue-1942-repro.yml
@@ -1,0 +1,16 @@
+name: issue-1942-repro
+on:
+  push:
+    branches: [main]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  container-test-job:
+    name: issue-1942-repro
+    runs-on: ubuntu-latest
+    container: node:18
+    steps:
+      - name: Check for dockerenv file
+        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -54,6 +54,9 @@ of `zizmor`.
 * Fixed a bug where local directory input collection could miss workflows for
   relative-path invocations from within `.github` subdirectories (#1909)
 
+* Fixed a bug where the [unpinned-images] audit would miss images defined
+  in `container: <image>` clauses (#1944)
+
 ## 1.24.1
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
Fixes #1942. Previously we were only handling the object form of `container:`, which was incorrect.