### PR TITLE
fix: clarify available fix reporting

### DIFF
--- a/crates/zizmor/src/finding.rs
+++ b/crates/zizmor/src/finding.rs
@@ -76,7 +76,7 @@ pub(crate) struct Determinations {
 }
 
 /// Represents the "disposition" of a fix.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum FixDisposition {
     /// The fix is safe to apply automatically.
     #[allow(dead_code)]

--- a/crates/zizmor/src/finding.rs
+++ b/crates/zizmor/src/finding.rs
@@ -3,6 +3,7 @@
 use anyhow::anyhow;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use self::location::{Location, SymbolicLocation};
 use crate::{
@@ -75,7 +76,7 @@ pub(crate) struct Determinations {
 }
 
 /// Represents the "disposition" of a fix.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub(crate) enum FixDisposition {
     /// The fix is safe to apply automatically.
     #[allow(dead_code)]
@@ -83,6 +84,15 @@ pub(crate) enum FixDisposition {
     /// The fix should be applied with manual oversight.
     #[default]
     Unsafe,
+}
+
+impl fmt::Display for FixDisposition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FixDisposition::Safe => write!(f, "safe"),
+            FixDisposition::Unsafe => write!(f, "unsafe"),
+        }
+    }
 }
 
 /// Represents a suggested fix for a finding.

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashSet,
-    env,
+    env, fmt,
     io::{Write, stdout},
     process::ExitCode,
 };
@@ -689,6 +689,16 @@ pub(crate) enum FixMode {
     UnsafeOnly,
     /// Apply all fixes, both safe and unsafe.
     All,
+}
+
+impl fmt::Display for FixMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FixMode::Safe => write!(f, "safe"),
+            FixMode::UnsafeOnly => write!(f, "unsafe-only"),
+            FixMode::All => write!(f, "all"),
+        }
+    }
 }
 
 /// State used when collecting input groups.

--- a/crates/zizmor/src/output/fix.rs
+++ b/crates/zizmor/src/output/fix.rs
@@ -49,8 +49,13 @@ pub fn apply_fixes(
 
     if fixes_by_input.is_empty() {
         if total_fixes > 0 {
+            let suggestion = match fix_mode {
+                FixMode::Safe => "Use --fix=unsafe or --fix=all to apply unsafe fixes.",
+                FixMode::UnsafeOnly => "Use --fix=safe or --fix=all to apply safe fixes.",
+                FixMode::All => unreachable!(),
+            };
             anstream::eprintln!(
-                "No fixes available to apply ({total_fixes} held back by fix mode)."
+                "No fixes available to apply ({total_fixes} held back by {fix_mode} mode). {suggestion}",
             );
         } else {
             anstream::eprintln!("No fixes available to apply.");

--- a/crates/zizmor/src/output/fix.rs
+++ b/crates/zizmor/src/output/fix.rs
@@ -50,12 +50,13 @@ pub fn apply_fixes(
     if fixes_by_input.is_empty() {
         if total_fixes > 0 {
             let suggestion = match fix_mode {
-                FixMode::Safe => "Use --fix=unsafe or --fix=all to apply unsafe fixes.",
-                FixMode::UnsafeOnly => "Use --fix=safe or --fix=all to apply safe fixes.",
-                FixMode::All => unreachable!(),
+                FixMode::Safe => Some("Use --fix=unsafe or --fix=all to apply unsafe fixes."),
+                FixMode::UnsafeOnly => Some("Use --fix=safe or --fix=all to apply safe fixes."),
+                FixMode::All => None,
             };
             anstream::eprintln!(
-                "No fixes available to apply ({total_fixes} held back by {fix_mode} mode). {suggestion}",
+                "No fixes available to apply ({total_fixes} held back by {fix_mode} mode).{}",
+                suggestion.map(|s| format!(" {s}")).unwrap_or_default()
             );
         } else {
             anstream::eprintln!("No fixes available to apply.");

--- a/crates/zizmor/src/output/plain.rs
+++ b/crates/zizmor/src/output/plain.rs
@@ -1,5 +1,6 @@
 //! "plain" (i.e. cargo-style) output.
 
+use itertools::Itertools;
 use std::collections::{HashMap, hash_map::Entry};
 
 use annotate_snippets::{Annotation, AnnotationKind, Group, Level, Renderer, Snippet};
@@ -9,7 +10,7 @@ use owo_colors::OwoColorize;
 use crate::{
     RenderLinks, ShowAuditUrls,
     finding::{
-        Finding, Severity,
+        Finding, FixDisposition, Severity,
         location::{Location, LocationKind},
     },
     models::AsDocument,
@@ -126,11 +127,18 @@ pub(crate) fn render_findings(
         ));
     }
 
-    let nfixable = findings.fixable_findings().count();
-    if nfixable > 0 {
+    let fixes_by_disposition: HashMap<FixDisposition, usize> = findings
+        .fixable_findings()
+        .flat_map(|finding| &finding.fixes)
+        .map(|fix| fix.disposition)
+        .counts();
+    for (disposition, count) in fixes_by_disposition {
         qualifiers.push(format!(
-            "{nfixable} fixable",
-            nfixable = nfixable.bright_green()
+            "{} {disposition} fixes",
+            match disposition {
+                FixDisposition::Safe => count.bright_green().to_string(),
+                FixDisposition::Unsafe => count.bright_red().to_string(),
+            }
         ));
     }
 

--- a/crates/zizmor/src/output/plain.rs
+++ b/crates/zizmor/src/output/plain.rs
@@ -132,7 +132,9 @@ pub(crate) fn render_findings(
         .flat_map(|finding| &finding.fixes)
         .map(|fix| fix.disposition)
         .counts();
-    for (disposition, count) in fixes_by_disposition {
+    let mut sorted_fixes_by_disposition: Vec<_> = fixes_by_disposition.iter().collect();
+    sorted_fixes_by_disposition.sort_by_key(|a| a.0);
+    for (disposition, count) in sorted_fixes_by_disposition {
         qualifiers.push(format!(
             "{} {disposition} fixes",
             match disposition {

--- a/crates/zizmor/tests/integration/audit/artipacked.rs
+++ b/crates/zizmor/tests/integration/audit/artipacked.rs
@@ -14,7 +14,7 @@ fn test_regular_persona() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 
@@ -38,7 +38,7 @@ fn test_pedantic_persona() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 
@@ -74,7 +74,7 @@ fn test_auditor_persona() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (2 fixable): 0 informational, 0 low, 2 medium, 0 high
+    2 findings (2 unsafe fixes): 0 informational, 0 low, 2 medium, 0 high
     "
     );
 
@@ -107,7 +107,7 @@ fn test_issue_447() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    1 findings (1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "#
     );
 
@@ -138,7 +138,7 @@ fn test_issue_1709() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    1 findings (1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 
@@ -204,7 +204,7 @@ fn test_composite_action() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (2 fixable): 0 informational, 0 low, 2 medium, 0 high
+    2 findings (2 unsafe fixes): 0 informational, 0 low, 2 medium, 0 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/bot_conditions.rs
+++ b/crates/zizmor/tests/integration/audit/bot_conditions.rs
@@ -147,7 +147,7 @@ fn test_regular_persona() -> anyhow::Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    13 findings (1 suppressed, 11 fixable): 0 informational, 0 low, 0 medium, 12 high
+    13 findings (1 suppressed, 11 safe fixes): 0 informational, 0 low, 0 medium, 12 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -35,7 +35,7 @@ fn test_caching_enabled_by_default() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (1 ignored, 2 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     ",
     );
 
@@ -67,7 +67,7 @@ fn test_caching_opt_in_boolean_toggle() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (1 ignored, 2 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#,
     );
 
@@ -99,7 +99,7 @@ fn test_caching_opt_in_expression() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    3 findings (1 ignored, 1 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    3 findings (1 ignored, 1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#,
     );
 
@@ -184,7 +184,7 @@ fn test_workflow_tag_trigger() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (1 ignored, 2 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#
     );
 
@@ -217,7 +217,7 @@ fn test_caching_opt_in_boolish_toggle() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#,
     );
 
@@ -243,7 +243,7 @@ fn test_publisher_step() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    3 findings (1 ignored, 1 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    3 findings (1 ignored, 1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "
     );
 
@@ -315,7 +315,7 @@ fn test_issue_343() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    5 findings (2 suppressed, 3 fixable): 0 informational, 0 low, 0 medium, 3 high
+    5 findings (2 suppressed, 3 unsafe fixes): 0 informational, 0 low, 0 medium, 3 high
     "#
     );
 
@@ -376,7 +376,7 @@ fn test_workflow_release_branch_trigger() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (1 ignored, 2 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#
     );
 
@@ -466,7 +466,7 @@ fn test_issue_1081() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    3 findings (1 suppressed, 2 fixable): 0 informational, 0 low, 0 medium, 2 high
+    3 findings (1 suppressed, 2 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
     "
     );
 
@@ -611,7 +611,7 @@ fn test_workflow_release_trigger_object() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (1 ignored, 2 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
@@ -20,7 +20,7 @@ fn test_missing_cooldown() -> anyhow::Result<()> {
       = note: audit confidence → High
       = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    1 findings (1 safe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 
@@ -45,7 +45,7 @@ fn test_no_default_days() -> anyhow::Result<()> {
       = note: audit confidence → High
       = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    1 findings (1 safe fixes): 0 informational, 0 low, 1 medium, 0 high
     ");
 
     Ok(())
@@ -69,7 +69,7 @@ fn test_default_days_too_short() -> anyhow::Result<()> {
       = note: audit confidence → Medium
       = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 1 low, 0 medium, 0 high
+    1 findings (1 safe fixes): 0 informational, 1 low, 0 medium, 0 high
     ");
 
     Ok(())
@@ -228,7 +228,7 @@ fn test_opentofu_cooldown() -> anyhow::Result<()> {
       = note: audit confidence → High
       = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    1 findings (1 safe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/dependabot_execution.rs
+++ b/crates/zizmor/tests/integration/audit/dependabot_execution.rs
@@ -21,7 +21,7 @@ fn test_regular_persona() -> anyhow::Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    1 findings (1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/insecure_commands.rs
+++ b/crates/zizmor/tests/integration/audit/insecure_commands.rs
@@ -27,7 +27,7 @@ fn test_insecure_commands_auditor() -> Result<()> {
        |
        = note: audit confidence → Low
 
-    2 findings (1 fixable): 0 informational, 0 low, 0 medium, 2 high
+    2 findings (1 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
     "
     );
 
@@ -51,7 +51,7 @@ fn test_insecure_commands_default() -> Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "
     );
 
@@ -94,7 +94,7 @@ fn test_action_auditor() -> Result<()> {
        |
        = note: audit confidence → Low
 
-    3 findings (2 fixable): 0 informational, 0 low, 0 medium, 3 high
+    3 findings (2 unsafe fixes): 0 informational, 0 low, 0 medium, 3 high
     "
     );
 
@@ -127,7 +127,7 @@ fn test_issue_839_repro() -> Result<()> {
        |
        = note: audit confidence → Low
 
-    2 findings (1 fixable): 0 informational, 0 low, 0 medium, 2 high
+    2 findings (1 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/obfuscation.rs
+++ b/crates/zizmor/tests/integration/audit/obfuscation.rs
@@ -195,7 +195,7 @@ fn test_obfuscation() -> Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    37 findings (1 ignored, 16 suppressed, 19 fixable): 0 informational, 20 low, 0 medium, 0 high
+    37 findings (1 ignored, 16 suppressed, 19 safe fixes): 0 informational, 20 low, 0 medium, 0 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/template_injection.rs
+++ b/crates/zizmor/tests/integration/audit/template_injection.rs
@@ -49,7 +49,7 @@ fn test_template_injection_dynamic_matrix() -> Result<()> {
        = note: audit confidence → Medium
        = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    1 findings (1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "#
     );
 
@@ -86,7 +86,7 @@ fn test_pr_317_repro() -> Result<()> {
        = note: audit confidence → Medium
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 1 medium, 0 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 
@@ -133,7 +133,7 @@ fn test_static_env() -> Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    7 findings (4 suppressed, 3 fixable): 0 informational, 3 low, 0 medium, 0 high
+    7 findings (4 suppressed, 3 unsafe fixes): 0 informational, 3 low, 0 medium, 0 high
     "
     );
 
@@ -244,7 +244,7 @@ fn test_pr_425_backstop_action() -> Result<()> {
        |
        = note: audit confidence → High
 
-    5 findings (1 fixable): 0 informational, 0 low, 0 medium, 5 high
+    5 findings (1 unsafe fixes): 0 informational, 0 low, 0 medium, 5 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/unsound_condition.rs
+++ b/crates/zizmor/tests/integration/audit/unsound_condition.rs
@@ -87,7 +87,7 @@ fn test_normal_persona() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    16 findings (6 ignored, 1 suppressed, 3 fixable): 0 informational, 0 low, 0 medium, 9 high
+    16 findings (6 ignored, 1 suppressed, 3 safe fixes): 0 informational, 0 low, 0 medium, 9 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/config.rs
+++ b/crates/zizmor/tests/integration/config.rs
@@ -303,7 +303,7 @@ fn test_severity_remap() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "
     );
 
@@ -329,7 +329,7 @@ fn test_severity_remap_affects_min_severity() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    2 findings (1 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "
     );
 

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -767,7 +767,7 @@ fn test_no_ignores() -> Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    1 findings (1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    1 findings (1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/e2e/anchors.rs
+++ b/crates/zizmor/tests/integration/e2e/anchors.rs
@@ -61,7 +61,7 @@ fn test_basic() -> Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    5 findings (1 suppressed, 4 fixable): 0 informational, 0 low, 0 medium, 4 high
+    5 findings (1 suppressed, 4 unsafe fixes): 0 informational, 0 low, 0 medium, 4 high
     "#
     );
 
@@ -87,7 +87,7 @@ fn test_scalar_cross_context() -> Result<()> {
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
-    3 findings (2 suppressed, 1 fixable): 0 informational, 0 low, 0 medium, 1 high
+    3 findings (2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     "#
     );
 
@@ -124,7 +124,7 @@ fn test_with_mapping_alias() -> Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (2 suppressed, 2 fixable): 0 informational, 0 low, 2 medium, 0 high
+    4 findings (2 suppressed, 2 unsafe fixes): 0 informational, 0 low, 2 medium, 0 high
     "
     );
 
@@ -215,7 +215,7 @@ fn test_steps_list_alias() -> Result<()> {
       = note: audit confidence → High
       = note: this finding has an auto-fix
 
-    5 findings (3 suppressed, 2 fixable): 0 informational, 0 low, 0 medium, 2 high
+    5 findings (3 suppressed, 2 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
     "#
     );
 
@@ -363,7 +363,7 @@ fn test_dummy_job_anchors() -> Result<()> {
       = note: audit confidence → High
       = note: this finding has an auto-fix
 
-    6 findings (3 suppressed, 3 fixable): 0 informational, 1 low, 2 medium, 0 high
+    6 findings (3 suppressed, 1 safe fixes, 2 unsafe fixes): 0 informational, 1 low, 2 medium, 0 high
     "
     );
 
@@ -423,7 +423,7 @@ fn test_flow_mapping_step() -> Result<()> {
       |
       = note: audit confidence → High
 
-    6 findings (2 suppressed, 2 fixable): 0 informational, 0 low, 2 medium, 2 high
+    6 findings (2 suppressed, 2 unsafe fixes): 0 informational, 0 low, 2 medium, 2 high
     "#
     );
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

**Discussed on Discord.**

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Generally clarifies the reporting of available fixes, a) by outputting which mode (the current) is causing fixes to be filtered and suggesting flags to remedy this and b) by reporting fix counts split by disposition (safe or unsafe) rather than the total available fix count.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->
