### PR TITLE
Add a dangerous-triggers exception for actions/labeler

### DIFF
--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -1,7 +1,12 @@
+use github_actions_models::common::Uses;
+use github_actions_models::workflow::Job;
+use github_actions_models::workflow::job::StepBody;
+
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::audit::AuditError;
 use crate::config::Config;
 use crate::finding::{Confidence, Finding, Severity};
+use crate::models::uses::RepositoryUsesExt;
 use crate::models::workflow::Workflow;
 use crate::state::AuditState;
 
@@ -12,6 +17,28 @@ audit_meta!(
     "dangerous-triggers",
     "use of fundamentally insecure workflow trigger"
 );
+
+impl DangerousTriggers {
+    fn is_labeler_exception(workflow: &Workflow) -> bool {
+        // If a workflow has exactly one job, that job has exactly one step,
+        // and that step is `actions/labeler`, then we suppress any
+        // finding for `pull_request_target`. Our rationale for this is
+        // that it's a blessed and presumed-secure use of an otherwise
+        // fundamentally insecure trigger.
+        if workflow.jobs.len() == 1
+            && let Some((_, Job::NormalJob(job))) = workflow.jobs.get_index(0)
+            && let [step] = job.steps.as_slice()
+            && let StepBody::Uses {
+                uses: Uses::Repository(uses),
+                ..
+            } = &step.body
+            && uses.matches("actions/labeler")
+        {
+            return true;
+        }
+        false
+    }
+}
 
 #[async_trait::async_trait]
 impl Audit for DangerousTriggers {
@@ -25,7 +52,7 @@ impl Audit for DangerousTriggers {
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
         let mut findings = vec![];
-        if workflow.has_pull_request_target() {
+        if workflow.has_pull_request_target() && !Self::is_labeler_exception(workflow) {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::Medium)

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -1,0 +1,18 @@
+use crate::common::{input_under_test, zizmor};
+
+/// A workflow that only contains one step (of `actions/labeler`)
+/// should not produce a `dangerous-triggers` finding, even if
+/// `pull_request_target` is used.
+#[test]
+fn test_actions_labeler_exception() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/actions-labeler.yml"
+            ))
+            .run()?,
+        @"No findings to report. Good job! (3 suppressed)"
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/audit/mod.rs
+++ b/crates/zizmor/tests/integration/audit/mod.rs
@@ -6,7 +6,7 @@ mod artipacked;
 mod bot_conditions;
 mod cache_poisoning;
 mod concurrency_limits;
-// mod dangerous_triggers; // TODO
+mod dangerous_triggers;
 mod dependabot_cooldown;
 mod dependabot_execution;
 mod excessive_permissions;

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
@@ -82,4 +82,4 @@ warning[ref-version-mismatch]: action's hash pin has mismatched or missing versi
    = note: audit confidence → High
    = note: this finding has an auto-fix
 
-51 findings (2 ignored, 44 suppressed): 0 informational, 0 low, 1 medium, 4 high
+50 findings (1 ignored, 44 suppressed): 0 informational, 0 low, 1 medium, 4 high

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/actions-labeler.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/actions-labeler.yml
@@ -1,0 +1,14 @@
+# No dangerous-triggers finding for this workflow, since the only job
+# contains one step and that step is considered safe (actions/labeler).
+
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  vulnerable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -46,6 +46,9 @@ of `zizmor`.
 * @tibdex/github-app-token is now recognized as an archived action by
   [archived-uses] (#1910)
 
+* The [dangerous-triggers] audit now explicitly exempts workflows that only
+  invoke @actions/labeler (#1956)
+
 ### Bug Fixes 🐛
 
 * Fixed a crash in the [template-injection] audit when a workflow uses


### PR DESCRIPTION
This is long overdue. We no longer flag a workflow for having `pull_request_target` if it only has one step, and that step is `actions/labeler` (since it's presumed safe and designed to be used with that trigger).

CC @uncenter since I know you were interested in this 🙂 

Closes #1168.