### PR TITLE
Add a section on fixing findings to the quickstart docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -89,3 +89,24 @@ Here are some different ways you can run `zizmor` locally:
     ```
 
 See [Usage](./usage.md) for more examples, including examples of configuration.
+
+## Fixing findings
+
+Some findings can be fixed automatically by running `zizmor` with `--fix`.
+
+For findings that can't be fixed automatically, consult the documentation for the relevant [audit
+rule](./audits.md). In many modern terminals, the audit rule name in the terminal output is a link
+that goes directly to that rule's documentation. For example, in this output:
+
+```console
+error[template-injection]: code injection via template expansion
+```
+
+`template-injection` within the square brackets is a clickable link that takes you to
+the [template-injection](./audits#template-injection) audit documentation. See [Audit documentation
+links](./usage#audit-documentation-links) for more detail.
+
+For findings that aren't right for your use case that you want to ignore, you can add a `# zizmor:
+ignore[rulename]` comment to the relevant line. More details, including how to ignore multiple
+findings or entire files by using a `zizmor.yml` configuration file, are in the [Ignoring
+results](./usage#ignoring-results) section.


### PR DESCRIPTION
Fixes https://github.com/zizmorcore/zizmor/issues/1960

<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Adds a section to the quickstart that covers:

- Automatic fixing with --fix
- The "Audit Rules" page
- That the default console output has clickable links
- How to ignore findings you're not ready to fix

by mirroring statements made elsewhere in the docs, and largely providing links to other documentation so that this section remains "quick".

I'm happy to take or make suggested edits!!

## Test Plan

N/A