### PR TITLE
Support for Docker-based actions

### DIFF
--- a/crates/github-actions-models/src/action.rs
+++ b/crates/github-actions-models/src/action.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::common::{
-    Env, If, Uses,
+    DockerUses, Env, If, Uses,
     expr::{BoE, LoE},
 };
 
@@ -167,7 +167,7 @@ pub struct Docker {
     pub using: String,
 
     /// The Docker image to use.
-    pub image: String,
+    pub image: LoE<DockerUses>,
 
     /// An optional environment mapping for this step.
     #[serde(default)]

--- a/crates/github-actions-models/src/action.rs
+++ b/crates/github-actions-models/src/action.rs
@@ -159,6 +159,18 @@ pub enum StepBody {
     },
 }
 
+/// A `uses` field for a Docker action step, which can be either a literal 'Dockerfile' or a
+/// Docker image (potentially via an expression).
+///
+/// This is essentially a specialization of the common [`DockerUses`] type,
+/// since only actions (and not workflows) allow a 'Dockerfile' "image".
+#[derive(Deserialize, Debug)]
+pub enum DockerActionUses {
+    Dockerfile,
+    #[serde(untagged)]
+    Image(LoE<DockerUses>),
+}
+
 /// A `runs` definition for a Docker action.
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -167,7 +179,7 @@ pub struct Docker {
     pub using: String,
 
     /// The Docker image to use.
-    pub image: LoE<DockerUses>,
+    pub image: DockerActionUses,
 
     /// An optional environment mapping for this step.
     #[serde(default)]
@@ -193,4 +205,18 @@ pub struct Docker {
     ///
     /// If not present, defaults to `always()`
     pub post_if: Option<If>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::action::DockerActionUses;
+
+    #[test]
+    fn test_docker_action_uses_deserialization() {
+        let uses: DockerActionUses = serde_yaml::from_str("Dockerfile").unwrap();
+        assert!(matches!(uses, DockerActionUses::Dockerfile));
+
+        let uses: DockerActionUses = serde_yaml::from_str("ubuntu:latest").unwrap();
+        assert!(matches!(uses, DockerActionUses::Image(_)));
+    }
 }

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     models::{
         AsDocument,
-        action::{Action, CompositeStep},
+        action::{Action, CompositeStep, DockerAction},
         dependabot::Dependabot,
         workflow::{Job, NormalJob, ReusableWorkflowCallJob, Step, Workflow},
     },
@@ -307,6 +307,14 @@ pub(crate) trait Audit: AuditCore {
         Ok(results)
     }
 
+    async fn audit_docker_action<'doc>(
+        &self,
+        _docker: &DockerAction<'doc>,
+        _config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        Ok(vec![])
+    }
+
     async fn audit_composite_step<'doc>(
         &self,
         _step: &CompositeStep<'doc>,
@@ -321,6 +329,10 @@ pub(crate) trait Audit: AuditCore {
         config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
         let mut results = vec![];
+
+        if let Some(docker) = action.docker() {
+            results.extend(self.audit_docker_action(&docker, config).await?);
+        }
 
         if let Some(steps) = action.steps() {
             for step in steps {

--- a/crates/zizmor/src/audit/unpinned_images.rs
+++ b/crates/zizmor/src/audit/unpinned_images.rs
@@ -4,12 +4,16 @@ use crate::{
         Confidence, Finding, Persona, Severity,
         location::{Locatable as _, SymbolicLocation},
     },
+    models::{AsDocument, action::DockerAction, workflow::matrix::Matrix},
     state::AuditState,
 };
 
 use github_actions_expressions::{Expr, literal::Literal};
-use github_actions_models::common::{DockerUses, expr::LoE};
 use github_actions_models::workflow::job::Container;
+use github_actions_models::{
+    action::DockerActionUses,
+    common::{DockerUses, expr::LoE},
+};
 use subfeature::Subfeature;
 
 use super::{Audit, AuditLoadError, audit_meta};
@@ -17,13 +21,188 @@ use super::{Audit, AuditLoadError, audit_meta};
 pub(crate) struct UnpinnedImages;
 
 impl UnpinnedImages {
-    fn build_finding<'doc>(
+    /// Classify a list of image references (with locations) and emit findings
+    /// for any that are unpinned.
+    fn classify_images<'a, 'doc>(
+        &self,
+        image_refs_with_locations: Vec<(&'doc LoE<DockerUses>, SymbolicLocation<'doc>)>,
+        matrix: Option<Matrix<'doc>>,
+        document: &'a impl AsDocument<'a, 'doc>,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let mut findings = vec![];
+
+        // TODO: Clean this mess up.
+        for (image, ref location) in image_refs_with_locations {
+            match image {
+                LoE::Expr(expr) => {
+                    let context = match Expr::parse(expr.as_bare()).map(|e| e.inner) {
+                        // Our expression is `${{ matrix.abc... }}`.
+                        Ok(Expr::Context(context)) if context.child_of("matrix") => context,
+                        // An invalid expression, or otherwise any expression that's
+                        // more complex than a simple matrix reference.
+                        _ => {
+                            // Extract possible leaf expressions from complex
+                            // expressions like `inputs.x == 'true' && 'redis:7' || ''`.
+                            if let Ok(parsed) = Expr::parse(expr.as_bare()) {
+                                for leaf in parsed.leaf_expressions() {
+                                    let leaf_location = location.clone().subfeature(
+                                        Subfeature::new(0, subfeature::Fragment::from(leaf)),
+                                    );
+
+                                    match &leaf.inner {
+                                        // String literals can be analyzed precisely.
+                                        Expr::Literal(Literal::String(s)) => {
+                                            if s.is_empty() {
+                                                continue;
+                                            }
+                                            let image = DockerUses::parse(s.as_ref());
+                                            if image.image().is_empty() {
+                                                continue;
+                                            }
+                                            self.check_image(
+                                                &image,
+                                                &leaf_location,
+                                                document,
+                                                &mut findings,
+                                            )?;
+                                        }
+                                        // Non-string leaves (contexts, calls, etc.)
+                                        // can't be analyzed statically.
+                                        _ => {
+                                            findings.push(self.build_finding(
+                                                &leaf_location,
+                                                "container image may be unpinned",
+                                                Confidence::Low,
+                                                Persona::Regular,
+                                                document,
+                                            )?);
+                                        }
+                                    }
+                                }
+                                continue;
+                            }
+
+                            findings.push(self.build_finding(
+                                location,
+                                "container image may be unpinned",
+                                Confidence::Low,
+                                Persona::Regular,
+                                document,
+                            )?);
+                            continue;
+                        }
+                    };
+
+                    let Some(ref matrix) = matrix else {
+                        tracing::warn!(
+                            "image references {expr} but has no matrix",
+                            expr = expr.as_bare()
+                        );
+                        continue;
+                    };
+
+                    for expansion in matrix
+                        .expansions()
+                        .iter()
+                        .filter(|e| context.matches(e.path.as_str()))
+                    {
+                        if !expansion.is_static() {
+                            findings.push(
+                                Self::finding()
+                                    .severity(Severity::High)
+                                    .confidence(Confidence::Low)
+                                    .persona(Persona::Regular)
+                                    .add_location(
+                                        location
+                                            .clone()
+                                            .primary()
+                                            .annotated("container image may be unpinned"),
+                                    )
+                                    .add_location(expansion.location())
+                                    .build(document)?,
+                            );
+                            break;
+                        } else {
+                            // Try and parse the expanded value as an image reference.
+                            let image = DockerUses::parse(&expansion.value);
+                            match (image.tag(), image.hash()) {
+                                // Image is pinned by hash.
+                                (_, Some(_)) => continue,
+                                // Docker image is pinned to "latest".
+                                (Some("latest"), None) => findings.push(
+                                    Self::finding()
+                                        .severity(Severity::High)
+                                        .confidence(Confidence::High)
+                                        .persona(Persona::Regular)
+                                        .add_location(
+                                            location
+                                                .clone()
+                                                .primary()
+                                                .annotated("container image is pinned to latest"),
+                                        )
+                                        .add_location(matrix.location().key_only())
+                                        .add_location(expansion.location().annotated(format!(
+                                            "this expansion of {path}",
+                                            path = expansion.path
+                                        )))
+                                        .build(document)?,
+                                ),
+                                // Docker image is pined to some other tag.
+                                (Some(_), None) => findings.push(
+                                    Self::finding()
+                                        .severity(Severity::High)
+                                        .confidence(Confidence::High)
+                                        .persona(Persona::Pedantic)
+                                        .add_location(location.clone().primary().annotated(
+                                            "container image is not pinned to a SHA256 hash",
+                                        ))
+                                        .add_location(matrix.location().key_only())
+                                        .add_location(expansion.location().annotated(format!(
+                                            "this expansion of {path}",
+                                            path = expansion.path
+                                        )))
+                                        .build(document)?,
+                                ),
+                                // Image is unpinned.
+                                (None, None) => findings.push(
+                                    Self::finding()
+                                        .severity(Severity::High)
+                                        .confidence(Confidence::High)
+                                        .persona(Persona::Regular)
+                                        .add_location(
+                                            location
+                                                .clone()
+                                                .primary()
+                                                .annotated("container image is unpinned"),
+                                        )
+                                        .add_location(matrix.location().key_only())
+                                        .add_location(expansion.location().annotated(format!(
+                                            "this expansion of {path}",
+                                            path = expansion.path
+                                        )))
+                                        .build(document)?,
+                                ),
+                            }
+                        }
+                    }
+                }
+                LoE::Literal(image) if image.image().is_empty() => continue,
+                LoE::Literal(image) => {
+                    self.check_image(image, location, document, &mut findings)?;
+                }
+            }
+        }
+
+        Ok(findings)
+    }
+
+    fn build_finding<'a, 'doc>(
         &self,
         location: &SymbolicLocation<'doc>,
         annotation: &'static str,
         confidence: Confidence,
         persona: Persona,
-        job: &super::NormalJob<'doc>,
+        document: &'a impl AsDocument<'a, 'doc>,
     ) -> Result<Finding<'doc>, AuditError> {
         let mut annotated_location = location.clone();
         annotated_location = annotated_location.annotated(annotation);
@@ -32,15 +211,15 @@ impl UnpinnedImages {
             .confidence(confidence)
             .add_location(annotated_location)
             .persona(persona)
-            .build(job)
+            .build(document)
     }
 
     /// Classify a `DockerUses` image and push the appropriate finding.
-    fn check_image<'doc>(
+    fn check_image<'a, 'doc>(
         &self,
         image: &DockerUses,
         location: &SymbolicLocation<'doc>,
-        job: &super::NormalJob<'doc>,
+        document: &'a impl AsDocument<'a, 'doc>,
         findings: &mut Vec<Finding<'doc>>,
     ) -> Result<(), AuditError> {
         match (image.tag(), image.hash()) {
@@ -51,7 +230,7 @@ impl UnpinnedImages {
                     "container image is pinned to latest",
                     Confidence::High,
                     Persona::Regular,
-                    job,
+                    document,
                 )?);
             }
             (Some(_), None) => {
@@ -60,7 +239,7 @@ impl UnpinnedImages {
                     "container image is not pinned to a SHA256 hash",
                     Confidence::High,
                     Persona::Pedantic,
-                    job,
+                    document,
                 )?);
             }
             (None, None) => {
@@ -69,7 +248,7 @@ impl UnpinnedImages {
                     "container image is unpinned",
                     Confidence::High,
                     Persona::Regular,
-                    job,
+                    document,
                 )?);
             }
         }
@@ -89,12 +268,29 @@ impl Audit for UnpinnedImages {
         Ok(Self)
     }
 
+    async fn audit_docker_action<'doc>(
+        &self,
+        docker: &DockerAction<'doc>,
+        _config: &crate::config::Config,
+    ) -> anyhow::Result<Vec<Finding<'doc>>, AuditError> {
+        // Nothing to do if the action references its own intrinsic 'Dockerfile'
+        // rather than an external image.
+        let DockerActionUses::Image(image) = &docker.image else {
+            return Ok(vec![]);
+        };
+
+        self.classify_images(
+            vec![(image, docker.location().with_keys(["image".into()]))],
+            None,
+            docker,
+        )
+    }
+
     async fn audit_normal_job<'doc>(
         &self,
         job: &super::NormalJob<'doc>,
         _config: &crate::config::Config,
     ) -> anyhow::Result<Vec<Finding<'doc>>, AuditError> {
-        let mut findings = vec![];
         let mut image_refs_with_locations: Vec<(&'doc LoE<DockerUses>, SymbolicLocation<'doc>)> =
             vec![];
 
@@ -129,167 +325,7 @@ impl Audit for UnpinnedImages {
             }
         }
 
-        // TODO: Clean this mess up.
-        for (image, ref location) in image_refs_with_locations {
-            match image {
-                LoE::Expr(expr) => {
-                    let context = match Expr::parse(expr.as_bare()).map(|e| e.inner) {
-                        // Our expression is `${{ matrix.abc... }}`.
-                        Ok(Expr::Context(context)) if context.child_of("matrix") => context,
-                        // An invalid expression, or otherwise any expression that's
-                        // more complex than a simple matrix reference.
-                        _ => {
-                            // Extract possible leaf expressions from complex
-                            // expressions like `inputs.x == 'true' && 'redis:7' || ''`.
-                            if let Ok(parsed) = Expr::parse(expr.as_bare()) {
-                                for leaf in parsed.leaf_expressions() {
-                                    let leaf_location = location.clone().subfeature(
-                                        Subfeature::new(0, subfeature::Fragment::from(leaf)),
-                                    );
-
-                                    match &leaf.inner {
-                                        // String literals can be analyzed precisely.
-                                        Expr::Literal(Literal::String(s)) => {
-                                            if s.is_empty() {
-                                                continue;
-                                            }
-                                            let image = DockerUses::parse(s.as_ref());
-                                            if image.image().is_empty() {
-                                                continue;
-                                            }
-                                            self.check_image(
-                                                &image,
-                                                &leaf_location,
-                                                job,
-                                                &mut findings,
-                                            )?;
-                                        }
-                                        // Non-string leaves (contexts, calls, etc.)
-                                        // can't be analyzed statically.
-                                        _ => {
-                                            findings.push(self.build_finding(
-                                                &leaf_location,
-                                                "container image may be unpinned",
-                                                Confidence::Low,
-                                                Persona::Regular,
-                                                job,
-                                            )?);
-                                        }
-                                    }
-                                }
-                                continue;
-                            }
-
-                            findings.push(self.build_finding(
-                                location,
-                                "container image may be unpinned",
-                                Confidence::Low,
-                                Persona::Regular,
-                                job,
-                            )?);
-                            continue;
-                        }
-                    };
-
-                    let Some(matrix) = job.matrix() else {
-                        tracing::warn!(
-                            "job references {expr} but has no matrix",
-                            expr = expr.as_bare()
-                        );
-                        continue;
-                    };
-
-                    for expansion in matrix
-                        .expansions()
-                        .iter()
-                        .filter(|e| context.matches(e.path.as_str()))
-                    {
-                        if !expansion.is_static() {
-                            findings.push(
-                                Self::finding()
-                                    .severity(Severity::High)
-                                    .confidence(Confidence::Low)
-                                    .persona(Persona::Regular)
-                                    .add_location(
-                                        location
-                                            .clone()
-                                            .primary()
-                                            .annotated("container image may be unpinned"),
-                                    )
-                                    .add_location(expansion.location())
-                                    .build(job)?,
-                            );
-                            break;
-                        } else {
-                            // Try and parse the expanded value as an image reference.
-                            let image = DockerUses::parse(&expansion.value);
-                            match (image.tag(), image.hash()) {
-                                // Image is pinned by hash.
-                                (_, Some(_)) => continue,
-                                // Docker image is pinned to "latest".
-                                (Some("latest"), None) => findings.push(
-                                    Self::finding()
-                                        .severity(Severity::High)
-                                        .confidence(Confidence::High)
-                                        .persona(Persona::Regular)
-                                        .add_location(
-                                            location
-                                                .clone()
-                                                .primary()
-                                                .annotated("container image is pinned to latest"),
-                                        )
-                                        .add_location(matrix.location().key_only())
-                                        .add_location(expansion.location().annotated(format!(
-                                            "this expansion of {path}",
-                                            path = expansion.path
-                                        )))
-                                        .build(job)?,
-                                ),
-                                // Docker image is pined to some other tag.
-                                (Some(_), None) => findings.push(
-                                    Self::finding()
-                                        .severity(Severity::High)
-                                        .confidence(Confidence::High)
-                                        .persona(Persona::Pedantic)
-                                        .add_location(location.clone().primary().annotated(
-                                            "container image is not pinned to a SHA256 hash",
-                                        ))
-                                        .add_location(matrix.location().key_only())
-                                        .add_location(expansion.location().annotated(format!(
-                                            "this expansion of {path}",
-                                            path = expansion.path
-                                        )))
-                                        .build(job)?,
-                                ),
-                                // Image is unpinned.
-                                (None, None) => findings.push(
-                                    Self::finding()
-                                        .severity(Severity::High)
-                                        .confidence(Confidence::High)
-                                        .persona(Persona::Regular)
-                                        .add_location(
-                                            location
-                                                .clone()
-                                                .primary()
-                                                .annotated("container image is unpinned"),
-                                        )
-                                        .add_location(matrix.location().key_only())
-                                        .add_location(expansion.location().annotated(format!(
-                                            "this expansion of {path}",
-                                            path = expansion.path
-                                        )))
-                                        .build(job)?,
-                                ),
-                            }
-                        }
-                    }
-                }
-                LoE::Literal(image) if image.image().is_empty() => continue,
-                LoE::Literal(image) => {
-                    self.check_image(image, location, job, &mut findings)?;
-                }
-            }
-        }
+        let findings = self.classify_images(image_refs_with_locations, job.matrix(), job)?;
 
         Ok(findings)
     }

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -85,7 +85,7 @@ impl Action {
     }
 
     /// Returns a [`DockerAction`] if this action is a Docker action, or `None` otherwise.
-    pub(crate) fn docker(&self) -> Option<DockerAction<'_>> {
+    pub(crate) fn docker<'doc>(&'doc self) -> Option<DockerAction<'doc>> {
         match &self.inner.runs {
             action::Runs::Docker(docker) => Some(DockerAction {
                 inner: docker,
@@ -153,8 +153,8 @@ impl<'doc> Locatable<'doc> for DockerAction<'doc> {
     // TODO(ww): Reasonable location_with_grip here?
 }
 
-impl<'a> AsDocument<'a, 'a> for DockerAction<'a> {
-    fn as_document(&'a self) -> &'a yamlpath::Document {
+impl<'a, 'doc> AsDocument<'a, 'doc> for DockerAction<'doc> {
+    fn as_document(&'a self) -> &'doc yamlpath::Document {
         self.parent.as_document()
     }
 }

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -84,6 +84,17 @@ impl Action {
         })
     }
 
+    /// Returns a [`DockerAction`] if this action is a Docker action, or `None` otherwise.
+    pub(crate) fn docker(&self) -> Option<DockerAction<'_>> {
+        match &self.inner.runs {
+            action::Runs::Docker(docker) => Some(DockerAction {
+                inner: docker,
+                parent: self,
+            }),
+            _ => None,
+        }
+    }
+
     /// Returns a [`CompositeSteps`] iterator over this actions's constituent
     /// [`CompositeStep`]s, or `None` if the action is not a composite action.
     pub(crate) fn steps(&self) -> Option<CompositeSteps<'_>> {
@@ -114,6 +125,37 @@ impl Action {
             .into_iter()
             .flatten()
             .filter_map(|step| step.r#if.as_ref().map(|cond| (cond, step.location())))
+    }
+}
+
+/// A wrapper around [`action::Docker`] that also provides access to the parent [`Action`].
+pub(crate) struct DockerAction<'a> {
+    inner: &'a action::Docker,
+    parent: &'a Action,
+}
+
+impl<'a> std::ops::Deref for DockerAction<'a> {
+    type Target = &'a action::Docker;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'doc> Locatable<'doc> for DockerAction<'doc> {
+    fn location(&self) -> SymbolicLocation<'doc> {
+        self.parent
+            .location()
+            .annotated("this Docker action")
+            .with_keys(["runs".into()])
+    }
+
+    // TODO(ww): Reasonable location_with_grip here?
+}
+
+impl<'a> AsDocument<'a, 'a> for DockerAction<'a> {
+    fn as_document(&'a self) -> &'a yamlpath::Document {
+        self.parent.as_document()
     }
 }
 

--- a/crates/zizmor/tests/integration/audit/unpinned_images.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_images.rs
@@ -224,3 +224,28 @@ fn test_issue_1942_repro() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Tests that `unpinned-images` handles Docker-style action definitions, not just images
+/// in jobs/steps within workflows.
+#[test]
+fn test_docker_action() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("unpinned-images/docker-action/"))
+            .args(["--persona=pedantic"])
+            .run()?,
+        @r#"
+    error[unpinned-images]: unpinned image references
+     --> @@INPUT@@action.yml:7:3
+      |
+    7 |   image: "docker://ghcr.io/super-linter/super-linter:slim-v8.5.0" # x-release-please-version
+      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+      |
+      = note: audit confidence → High
+
+    1 finding: 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/unpinned-images/docker-action/action.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-images/docker-action/action.yml
@@ -1,0 +1,12 @@
+---
+name: "Super-Linter slim"
+author: "Super-linter contributors"
+description: "Super-linter is a ready-to-run collection of linters and code analyzers, to help validate your source code."
+runs:
+  using: "docker"
+  image: "docker://ghcr.io/super-linter/super-linter:slim-v8.5.0" # x-release-please-version
+branding:
+  icon: "check-square"
+  color: "white"
+# You can view https://github.com/super-linter/super-linter#environment-variables
+# to see a comprehensive list of all environment variables that can be passed

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,9 @@ of `zizmor`.
 
 * `zizmor`'s LSP now honors the `--persona` flag on the CLI (#1943)
 
+* `zizmor` is now aware of Docker-based action definitions, in addition to the
+  pre-existing support for "composite" actions (#1965)
+
 ### Enhancements
 
 * Recommend `gh issue edit --add-label` / `gh pr edit --add-label` as a replacement for
@@ -48,6 +51,9 @@ of `zizmor`.
 
 * The [dangerous-triggers] audit now explicitly exempts workflows that only
   invoke @actions/labeler (#1956)
+
+* The [unpinned-images] audit now detects unpinned image references in
+  Docker-based action definitions (#1965)
 
 ### Bug Fixes 🐛
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ Before auditing, `zizmor` performs an input collection phase.
 
 There are four input sources that `zizmor` knows about:
 
-1. Individual workflow and composite action files, e.g. `foo.yml` and
+1. Individual workflow and action files, e.g. `foo.yml` and
    `my-action/action.yml`;
 2. "Local" GitHub repositories in the form of a directory, e.g. `my-repo/`;
 3. "Remote" GitHub repositories in the form of a "slug", e.g.
@@ -47,30 +47,28 @@ There are four input sources that `zizmor` knows about:
         Support for auditing from standard input is available in `v1.24.0`
         and later.
 
-`zizmor` also supports reading a single input from standard input using `-`:
-
-```bash
-# pipe a workflow from stdin
-cat workflow.yml | zizmor -
-
-# or use a heredoc
-zizmor - <<'EOF'
-on: push
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-EOF
-```
-
-When reading from stdin, `zizmor` automatically infers the input type
-(workflow, action, or Dependabot config).
-
-!!! note
-
-    `-` cannot be combined with other inputs, and `--fix` is not
-    supported with stdin input.
+    ```bash
+    # pipe a workflow from stdin
+    cat workflow.yml | zizmor -
+    
+    # or use a heredoc
+    zizmor - <<'EOF'
+    on: push
+    jobs:
+      test:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+    EOF
+    ```
+    
+    When reading from stdin, `zizmor` automatically infers the input type
+    (workflow, action, or Dependabot config).
+    
+    !!! note
+    
+        `-` cannot be combined with other inputs, and `--fix` is not
+        supported with stdin input.
 
 `zizmor` can audit multiple inputs in the same run, and different input
 sources can be mixed and matched:
@@ -946,7 +944,7 @@ can't infer anything about what `matrix.something` might expand to.
 
 `zizmor` audits workflow and action _definitions_ only. That means the
 contents of `foo.yml` (for your workflow definitions) or `action.yml` (for your
-composite action definitions).
+composite or Docker action definitions).
 
 In practice, this means that `zizmor` does **not** analyze other files
 referenced by workflow and action definitions. For example:


### PR DESCRIPTION
Fixes #1964.

We were already parsing these, but not exposing them to the auditing layer. 

This adds an `Audit::audit_docker_action` API that audits can use. ~~I still need to figure out the best way to wire this into the rest of `unpinned-images`, however.~~