### PR TITLE
Support a private cargo registry

### DIFF
--- a/crates/github-actions-models/src/dependabot/v2.rs
+++ b/crates/github-actions-models/src/dependabot/v2.rs
@@ -43,6 +43,11 @@ pub struct MultiEcosystemGroup {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 pub enum Registry {
+    CargoRegistry {
+        url: String,
+        registry: String,
+        token: String,
+    },
     ComposerRepository {
         url: String,
         username: Option<String>,

--- a/crates/github-actions-models/tests/sample-dependabot/v2/private-cargo-registry.yml
+++ b/crates/github-actions-models/tests/sample-dependabot/v2/private-cargo-registry.yml
@@ -1,0 +1,31 @@
+version: 2
+
+registries:
+  private-rust:
+    type: "cargo-registry"
+    registry: "Private_Rust"
+    url: "https://pkgs.dev.azure.com/company-name/_packaging/Private_Rust/Cargo/index/"
+    token: "${{secrets.PRIVATE_RUST_TOKEN_B64}}"
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    registries:
+      - "private-rust"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates: # Group 1: Security updates grouped, major versions excluded
+        applies-to: security-updates
+        update-types:
+          - "patch"
+          - "minor"
+      minor-and-patch: # Group 2: Minor and patch version updates grouped, major versions excluded
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+      major: # Group 3: Major updates only
+        applies-to: version-updates
+        update-types:
+          - "major"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -85,7 +85,7 @@ of `zizmor`.
     Many thanks to @reubenwong97 for implementing this fix!
 
 * Fixed a bug where `dependabot.yml` files containing a private cargo
-  repository couldn't be parsed.
+  repository couldn't be parsed (#1976)
 
 ## 1.24.1
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -84,6 +84,9 @@ of `zizmor`.
 
     Many thanks to @reubenwong97 for implementing this fix!
 
+* Fixed a bug where `dependabot.yml` files containing a private cargo
+  repository couldn't be parsed.
+
 ## 1.24.1
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

support private cargo registries in dependabot.yml, see issue #1973 

## Test Plan

test file for dependabot added