### PR TITLE
deps: migrate from deprecated serde_yaml to yaml_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,8 +1036,8 @@ dependencies = [
  "insta",
  "self_cell",
  "serde",
- "serde_yaml",
  "tracing",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -1615,6 +1615,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "line-index"
@@ -2789,19 +2795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,12 +3550,6 @@ name = "unit-prefix"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4375,6 +4362,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "yamlpatch"
 version = "1.24.1"
 dependencies = [
@@ -4384,9 +4384,9 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "serde_yaml",
  "subfeature",
  "thiserror 2.0.18",
+ "yaml_serde",
  "yamlpath",
 ]
 
@@ -4397,11 +4397,11 @@ dependencies = [
  "line-index",
  "self_cell",
  "serde",
- "serde_yaml",
  "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-iter",
  "tree-sitter-yaml",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -4554,7 +4554,6 @@ dependencies = [
  "serde-sarif",
  "serde_json",
  "serde_json_path",
- "serde_yaml",
  "subfeature",
  "tar",
  "terminal-link",
@@ -4568,6 +4567,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-powershell",
+ "yaml_serde",
  "yamlpatch",
  "yamlpath",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde-sarif = "0.8.0"
 serde_json = "1.0.149"
 serde_json_path = "0.7.2"
-serde_yaml = "0.9.34"
+serde_yaml = { package = "yaml_serde", version = "0.10" }
 tar = "0.4.45"
 terminal-link = "0.1.0"
 thiserror = "2.0.18"


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

## Summary

Replaces the deprecated/unmaintained `serde_yaml` 0.9.34 with `yaml_serde` 0.10.4,
the official YAML Organization fork maintained by the YAML organization.

- Uses Cargo package renaming (`serde_yaml = { package = "yaml_serde", version = "0.10" }`)
  so all existing `serde_yaml::` references compile unchanged
- Swaps the `unsafe-libyaml` backend for `libyaml-rs` (safe Rust)
- Zero source code changes; only `Cargo.toml` and `Cargo.lock` are modified

Closes #1976.

## Test Plan

- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --workspace --all-targets --all-features` introduces no new warnings