### PR TITLE
Add `deno` as a known Dependabot ecosystem

### DIFF
--- a/crates/github-actions-models/src/dependabot/v2.rs
+++ b/crates/github-actions-models/src/dependabot/v2.rs
@@ -366,6 +366,8 @@ pub enum PackageEcosystem {
     Composer,
     /// `conda`
     Conda,
+    /// `deno`
+    Deno,
     /// `devcontainers`
     Devcontainers,
     /// `docker`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -60,6 +60,8 @@ of `zizmor`.
 
 * The [archived-uses] audit now detects more archived actions (#1978)
 
+* `deno` is now recognized as a `package-ecosystem` in `dependabot.yml` (#1991)
+
 ### Bug Fixes 🐛
 
 * Fixed a crash in the [template-injection] audit when a workflow uses


### PR DESCRIPTION
Per #1986. Seemingly not publicly released by GH yet.