### PR TITLE
Add opt-in warning mode for inaccessible GitHub repos

### DIFF
--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -224,6 +224,13 @@ impl AuditError {
     pub(crate) fn ident(&self) -> &'static str {
         self.ident
     }
+
+    pub(crate) fn is_repo_missing_or_private(&self) -> bool {
+        self.source.chain().any(|err| {
+            err.downcast_ref::<crate::github::ClientError>()
+                .is_some_and(crate::github::ClientError::is_repo_missing_or_private)
+        })
+    }
 }
 
 /// Auditing trait.
@@ -395,5 +402,34 @@ pub(crate) trait Audit: AuditCore {
         results.extend(self.audit_raw(input, config).await?);
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AuditError;
+
+    #[test]
+    fn audit_error_detects_missing_or_private_repo_source() {
+        let err = AuditError::new(
+            "test-audit",
+            crate::github::ClientError::ListTags {
+                source: Box::new(crate::github::ClientError::RepoMissingOrPrivate {
+                    owner: "octo-org".into(),
+                    repo: "private-action".into(),
+                }),
+                owner: "octo-org".into(),
+                repo: "private-action".into(),
+            },
+        );
+
+        assert!(err.is_repo_missing_or_private());
+    }
+
+    #[test]
+    fn audit_error_rejects_unrelated_sources() {
+        let err = AuditError::new("test-audit", anyhow::anyhow!("ordinary failure"));
+
+        assert!(!err.is_repo_missing_or_private());
     }
 }

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -159,6 +159,19 @@ pub(crate) enum ClientError {
     Inner(#[from] Arc<ClientError>),
 }
 
+impl ClientError {
+    pub(crate) fn is_repo_missing_or_private(&self) -> bool {
+        match self {
+            Self::RepoMissingOrPrivate { .. } => true,
+            Self::ListBranches { source, .. } | Self::ListTags { source, .. } => {
+                source.is_repo_missing_or_private()
+            }
+            Self::Inner(source) => source.is_repo_missing_or_private(),
+            _ => false,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 enum CacheType {
     File,

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -183,6 +183,10 @@ struct AuditArgs {
     /// Don't honor ignore comments or ignore rules in configuration.
     #[arg(long)]
     no_ignores: bool,
+
+    /// Warn instead of failing when online audits cannot access a referenced GitHub repository.
+    #[arg(long)]
+    warn_on_github_api_failures: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1008,13 +1012,26 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
             }
 
             while let Some(findings) = completion_stream.next().await {
-                let findings = findings.map_err(|err| Error::Audit {
-                    ident: err.ident(),
-                    source: err,
-                    input: input.key().to_string(),
-                })?;
-
-                results.extend(findings);
+                match findings {
+                    Ok(findings) => results.extend(findings),
+                    Err(err)
+                        if app.audit.warn_on_github_api_failures
+                            && err.is_repo_missing_or_private() =>
+                    {
+                        warn!(
+                            "continuing after GitHub API failure in '{}' audit on {} due to --warn-on-github-api-failures: {err:#}",
+                            err.ident(),
+                            input.key(),
+                        );
+                    }
+                    Err(err) => {
+                        return Err(Error::Audit {
+                            ident: err.ident(),
+                            source: err,
+                            input: input.key().to_string(),
+                        });
+                    }
+                }
 
                 Span::current().pb_inc(1);
             }

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -558,6 +558,35 @@ fn issue_1286() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for #1350.
+///
+/// Ensures that `--warn-on-github-api-failures` lets audits continue when
+/// an online audit can't access a private (or missing) referenced repository.
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
+fn issue_1350_warn_on_github_api_failures() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(false)
+            .args(["--warn-on-github-api-failures"])
+            .input(input_under_test("issue-1286.yml"))
+            .run()?,
+        @"
+    error[unpinned-uses]: unpinned action reference
+      --> @@INPUT@@:19:15
+       |
+    19 |         uses: woodruffw-experiments/this-does-not-exist@v1.0.0
+       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
+       |
+       = note: audit confidence → High
+
+    1 finding: 0 informational, 0 low, 0 medium, 1 high
+    "
+    );
+
+    Ok(())
+}
+
 /// Regression test for #1300.
 ///
 /// Ensures that we produce a useful error when a user specifies


### PR DESCRIPTION
## Summary

Closes #1350.

This adds an opt-in `--warn-on-github-api-failures` audit option for private-repo deployments where online audits encounter referenced GitHub repositories that are missing or inaccessible to the configured token.

Behavior is intentionally narrow: the new option downgrades only audit failures caused by `RepoMissingOrPrivate` into warnings, then lets the remaining audits continue. Other GitHub/API failures still fail normally, so transient outages, rate limits, and unrelated client errors are not hidden.

## Validation

- `cargo fmt --check`
- `cargo test -p zizmor audit::tests::audit_error`
- `cargo clippy -p zizmor --bin zizmor -- -D warnings`
- `cargo test -p zizmor test_stdin_workflow`
- `cargo test -p zizmor warn_on_min_severity_unknown`
- `GH_TOKEN=$(gh auth token) cargo test -p zizmor issue_1286 --features gh-token-tests`
- `GH_TOKEN=$(gh auth token) cargo test -p zizmor issue_1350_warn_on_github_api_failures --features gh-token-tests`
- Manual repro: `GH_TOKEN=$(gh auth token) cargo run -p zizmor -- --no-progress --show-audit-urls=never --warn-on-github-api-failures /Users/user/project/4dollor/zizmor/crates/zizmor/tests/integration/test-data/issue-1286.yml`

Disclosure: this PR was prepared with AI assistance, then manually reviewed and tested before submission.
