### PR TITLE
impostor-commit: handle tag SHAs properly

### DIFF
--- a/crates/zizmor/src/audit/impostor_commit.rs
+++ b/crates/zizmor/src/audit/impostor_commit.rs
@@ -44,6 +44,18 @@ audit_meta!(
     "commit with no history in referenced repository"
 );
 
+/// An intermediate result type for the impostor check. This is used to
+/// encode our fallthroughs from fastest -> fast -> slow paths for
+/// impostor checks.
+enum IntermediateDetermination {
+    /// Definitely an impostor.
+    NotImpostor,
+    /// Definitely not an impostor.
+    Impostor,
+    /// Not sure yet.
+    Indeterminate,
+}
+
 impl ImpostorCommit {
     async fn named_ref_contains_commit(
         &self,
@@ -70,46 +82,146 @@ impl ImpostorCommit {
         )
     }
 
+    /// Our "fastest path" impostor check: iterate through the remote's tags and branches
+    /// and see if any of them point directly at `candidate_sha`. This is fast for two reasons:
+    ///
+    /// 1. We expect the majority of users to be on the happy path where their hash-pin
+    ///    is directly at the tip of some tag or branch.
+    /// 2. Internally, listing refs is very cheap within zizmor (since we GitHub's
+    ///    Git backend directly, not the REST API), at least compared to a REST API roundtrip.
+    async fn fastest_path_impostor_check(
+        &self,
+        tags: &[github::Tag],
+        branches: &[github::Branch],
+        candidate_sha: &str,
+    ) -> Result<IntermediateDetermination, AuditError> {
+        for tag in tags {
+            if tag.commit.sha == candidate_sha {
+                return Ok(IntermediateDetermination::NotImpostor);
+            }
+        }
+
+        for branch in branches {
+            if branch.commit.sha == candidate_sha {
+                return Ok(IntermediateDetermination::NotImpostor);
+            }
+        }
+
+        Ok(IntermediateDetermination::Indeterminate)
+    }
+
+    /// Our second fastest impostor check: we use GitHub's undocumented
+    /// `branch_commits` API, which is what GitHub's own frontend uses to
+    /// perform a fast check for which tags and/or branches a commit SHA
+    /// appears on.
+    ///
+    /// TODO: Benchmark this more; this might actually be faster than listing refs?
+    /// We currently assume this is slower because it's through the REST API.
+    async fn fast_path_impostor_check(
+        &self,
+        uses: &RepositoryUses,
+        candidate_sha: &str,
+    ) -> IntermediateDetermination {
+        match self
+            .client
+            .branch_commits(uses.owner(), uses.repo(), candidate_sha)
+            .await
+        {
+            Ok(branch_commits) => {
+                if branch_commits.is_empty() {
+                    IntermediateDetermination::Impostor
+                } else {
+                    IntermediateDetermination::NotImpostor
+                }
+            }
+            Err(e) => {
+                tracing::warn!("fast path impostor check failed for {uses}: {e}");
+                IntermediateDetermination::Indeterminate
+            }
+        }
+    }
+
+    /// Perform both our fastest path and fast path impostor check on the candidate SHA.
+    async fn combined_fast_paths_impostor_check(
+        &self,
+        uses: &RepositoryUses,
+        tags: &[github::Tag],
+        branches: &[github::Branch],
+        candidate_sha: &str,
+    ) -> Result<IntermediateDetermination, AuditError> {
+        match self
+            .fastest_path_impostor_check(tags, branches, candidate_sha)
+            .await?
+        {
+            IntermediateDetermination::Indeterminate => {
+                Ok(self.fast_path_impostor_check(uses, candidate_sha).await)
+            }
+            determination => Ok(determination),
+        }
+    }
+
+    /// Our slow path for impostor checks: we use GitHub's comparison API
+    /// to see whether any tag or branch in the repo has the candidate SHA
+    /// in its history.
+    ///
+    /// This is ludicrously slow, both because this endpoint is slow
+    /// and because in the worst case it requires pathological numbers
+    /// of requests (thousands for repos with thousands of branches or tags).
+    async fn slow_path_impostor_check(
+        &self,
+        uses: &RepositoryUses,
+        tags: &[github::Tag],
+        branches: &[github::Branch],
+        candidate_sha: &str,
+    ) -> Result<IntermediateDetermination, AuditError> {
+        for branch in branches {
+            if self
+                .named_ref_contains_commit(
+                    uses,
+                    &format!("refs/heads/{}", &branch.name),
+                    candidate_sha,
+                )
+                .await?
+            {
+                return Ok(IntermediateDetermination::NotImpostor);
+            }
+        }
+
+        for tag in tags {
+            if self
+                .named_ref_contains_commit(uses, &format!("refs/tags/{}", &tag.name), candidate_sha)
+                .await?
+            {
+                return Ok(IntermediateDetermination::NotImpostor);
+            }
+        }
+
+        // At this point we pretty much know it's an impostor commit,
+        // but we don't make that classification here.
+        Ok(IntermediateDetermination::Indeterminate)
+    }
+
     /// Returns a boolean indicating whether or not this commit is an "impostor",
     /// i.e. resolves due to presence in GitHub's fork network but is not actually
     /// present in any of the specified `owner/repo`'s tags or branches.
     async fn impostor(&self, uses: &RepositoryUses) -> Result<bool, AuditError> {
         // If there's no ref or the ref is not a commit, there's nothing to impersonate.
-        let Some(head_ref) = uses.commit_ref() else {
+        let Some(initial_candidate_sha) = uses.commit_ref() else {
             return Ok(false);
         };
 
-        // `head_ref` might actually been the object ID for a tag,
-        // or even further indirected (e.g. an annotated tag), so we
-        // need to peel it to find the real underlying commit SHA
-        // for the checks below.
-        // TODO: We really shouldn't block the fast paths below
-        // on this, since it's a relatively uncommon case.
-        let head_ref: Cow<'_, str> = match self
-            .client
-            .tag_sha_to_commit_sha(uses.owner(), uses.repo(), head_ref)
-            .await
-            .map_err(Self::err)?
-        {
-            Some(sha) => sha.into(),
-            None => head_ref.into(),
-        };
+        // Our logic is a little nuanced here: we have two fast paths, and we want to try
+        // both fast paths on the commit SHA before we fall back to the slow path.
+        // So what we do is first try the fast paths while *assuming* that the user has
+        // hash-pinned to a commit SHA. If that fails we then treat their hash-pin
+        // as a tag SHA, try the fast paths again, and then only fall through
+        // to the slow path after that.
 
-        // Fastest path: almost all commit refs will be at the tip of
-        // the branch or tag's history, so check those first.
-        // Check tags before branches, since in practice version tags
-        // are more commonly pinned.
         let tags = self
             .client
             .list_tags(uses.owner(), uses.repo())
             .await
             .map_err(Self::err)?;
-
-        for tag in &tags {
-            if tag.commit.sha == head_ref {
-                return Ok(false);
-            }
-        }
 
         let branches = self
             .client
@@ -117,48 +229,54 @@ impl ImpostorCommit {
             .await
             .map_err(Self::err)?;
 
-        for branch in &branches {
-            if branch.commit.sha == head_ref {
-                return Ok(false);
-            }
-        }
-
-        // Fast path: attempt to use GitHub's undocumented `branch_commits`
-        // API to see if the commit is present in any branch/tag.
-        // There are no stabilitiy guarantees for this API, so we fall back
-        // to the slow(er) paths if it fails.
         match self
-            .client
-            .branch_commits(uses.owner(), uses.repo(), &head_ref)
-            .await
+            .combined_fast_paths_impostor_check(uses, &tags, &branches, initial_candidate_sha)
+            .await?
         {
-            Ok(branch_commits) => return Ok(branch_commits.is_empty()),
-            Err(e) => tracing::warn!("fast path impostor check failed for {uses}: {e}"),
-        }
-
-        // Slow path: use GitHub's comparison API to check each branch and tag's
-        // history for presence of the commit.
-        for branch in &branches {
-            if self
-                .named_ref_contains_commit(uses, &format!("refs/heads/{}", &branch.name), &head_ref)
-                .await?
-            {
-                return Ok(false);
+            IntermediateDetermination::NotImpostor => return Ok(false),
+            IntermediateDetermination::Impostor => return Ok(true),
+            IntermediateDetermination::Indeterminate => {
+                // Fall through.
             }
         }
 
-        for tag in &tags {
-            if self
-                .named_ref_contains_commit(uses, &format!("refs/tags/{}", &tag.name), &head_ref)
+        // If our first set of fast paths didn't work then `initial_candidate_sha`
+        // might actually be a tag SHA, so we need to peel it to find the real
+        // underlying commit SHA for the checks below.
+        let final_candidate_sha: Cow<'_, str> = match self
+            .client
+            .tag_sha_to_commit_sha(uses.owner(), uses.repo(), initial_candidate_sha)
+            .await
+            .map_err(Self::err)?
+        {
+            Some(sha) => sha.into(),
+            None => initial_candidate_sha.into(),
+        };
+
+        // At this point we definitely have a commit SHA, so try the fast
+        // paths again if the SHA has changed.
+        if initial_candidate_sha != final_candidate_sha {
+            match self
+                .combined_fast_paths_impostor_check(uses, &tags, &branches, &final_candidate_sha)
                 .await?
             {
-                return Ok(false);
+                IntermediateDetermination::NotImpostor => return Ok(false),
+                IntermediateDetermination::Impostor => return Ok(true),
+                IntermediateDetermination::Indeterminate => {
+                    // Fall through.
+                }
             }
         }
 
-        // If we've made it here, the commit isn't present in any commit or tag's history,
-        // strongly suggesting that it's an impostor.
-        Ok(true)
+        match self
+            .slow_path_impostor_check(uses, &tags, &branches, &final_candidate_sha)
+            .await?
+        {
+            IntermediateDetermination::NotImpostor => Ok(false),
+            // If we've made it here, the commit isn't present in any commit or tag's history,
+            // strongly suggesting that it's an impostor.
+            _ => Ok(true),
+        }
     }
 
     /// Return the highest semantically versioned tag in the repository.

--- a/crates/zizmor/src/audit/impostor_commit.rs
+++ b/crates/zizmor/src/audit/impostor_commit.rs
@@ -5,6 +5,8 @@
 //!
 //! [`clank`]: https://github.com/chainguard-dev/clank
 
+use std::borrow::Cow;
+
 use anyhow::anyhow;
 use github_actions_models::common::{RepositoryUses, Uses};
 use subfeature::Subfeature;
@@ -77,6 +79,22 @@ impl ImpostorCommit {
             return Ok(false);
         };
 
+        // `head_ref` might actually been the object ID for a tag,
+        // or even further indirected (e.g. an annotated tag), so we
+        // need to peel it to find the real underlying commit SHA
+        // for the checks below.
+        // TODO: We really shouldn't block the fast paths below
+        // on this, since it's a relatively uncommon case.
+        let head_ref: Cow<'_, str> = match self
+            .client
+            .tag_sha_to_commit_sha(uses.owner(), uses.repo(), head_ref)
+            .await
+            .map_err(Self::err)?
+        {
+            Some(sha) => sha.into(),
+            None => head_ref.into(),
+        };
+
         // Fastest path: almost all commit refs will be at the tip of
         // the branch or tag's history, so check those first.
         // Check tags before branches, since in practice version tags
@@ -111,7 +129,7 @@ impl ImpostorCommit {
         // to the slow(er) paths if it fails.
         match self
             .client
-            .branch_commits(uses.owner(), uses.repo(), head_ref)
+            .branch_commits(uses.owner(), uses.repo(), &head_ref)
             .await
         {
             Ok(branch_commits) => return Ok(branch_commits.is_empty()),
@@ -122,7 +140,7 @@ impl ImpostorCommit {
         // history for presence of the commit.
         for branch in &branches {
             if self
-                .named_ref_contains_commit(uses, &format!("refs/heads/{}", &branch.name), head_ref)
+                .named_ref_contains_commit(uses, &format!("refs/heads/{}", &branch.name), &head_ref)
                 .await?
             {
                 return Ok(false);
@@ -131,7 +149,7 @@ impl ImpostorCommit {
 
         for tag in &tags {
             if self
-                .named_ref_contains_commit(uses, &format!("refs/tags/{}", &tag.name), head_ref)
+                .named_ref_contains_commit(uses, &format!("refs/tags/{}", &tag.name), &head_ref)
                 .await?
             {
                 return Ok(false);

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -555,6 +555,76 @@ impl Client {
         Ok(None)
     }
 
+    /// Map a tag SHA to its corresponding commit SHA.
+    ///
+    /// This API "unpeels" annotated tags (of which there may be more than one)
+    /// until the final tag referent is a commit object rather than a tag object.
+    #[instrument(skip(self))]
+    pub(crate) async fn tag_sha_to_commit_sha(
+        &self,
+        owner: &str,
+        repo: &str,
+        maybe_tag_sha: &str,
+    ) -> Result<Option<String>, ClientError> {
+        #[derive(Deserialize)]
+        struct TagLookup {
+            /// The object the tag refers to.
+            object: TagReferent,
+            /// The tag's name.
+            tag: String,
+        }
+
+        #[derive(Deserialize)]
+        struct TagReferent {
+            sha: String,
+            r#type: ReferentType,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum ReferentType {
+            /// The tag points to a commit.
+            Commit,
+            /// The tag points to another tag.
+            Tag,
+        }
+
+        let mut next_tag_sha = maybe_tag_sha.to_string();
+        loop {
+            let url = format!(
+                "{api_base}/repos/{owner}/{repo}/git/tags/{tag_sha}",
+                api_base = self.api_base,
+                owner = owner,
+                repo = repo,
+                tag_sha = next_tag_sha
+            );
+
+            match self.api_client.get(url).send().await?.error_for_status() {
+                Ok(resp) => {
+                    let lookup: TagLookup = resp.json().await?;
+
+                    match lookup.object.r#type {
+                        // Our tag is pointing directly at a commit.
+                        ReferentType::Commit => return Ok(Some(lookup.object.sha)),
+                        // Our tag is pointing at another tag; continue.
+                        ReferentType::Tag => {
+                            tracing::trace!(
+                                "{next_tag_sha} points to {next} ({next_tag})",
+                                next = lookup.object.sha,
+                                next_tag = lookup.tag
+                            );
+                            next_tag_sha = lookup.object.sha;
+                        }
+                    }
+                }
+                // Tag lookup failed; this either means that the SHA doesn't exist at all
+                // *or* the user gave us a commit SHA, which this endpoint doesn't accept.
+                Err(e) if e.status() == Some(StatusCode::NOT_FOUND) => return Ok(None),
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
     #[instrument(skip(self))]
     pub(crate) async fn longest_tag_for_commit(
         &self,
@@ -953,7 +1023,7 @@ pub(crate) struct File {
 
 #[cfg(test)]
 mod tests {
-    use crate::github::{GitHubHost, GitHubToken};
+    use crate::github::{Client, GitHubHost, GitHubToken};
 
     #[test]
     fn test_github_host() {
@@ -986,5 +1056,75 @@ mod tests {
         for token in ["", " ", "\r", "\n", "\t", "     "] {
             assert!(GitHubToken::new(token).is_err());
         }
+    }
+
+    #[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+    #[tokio::test]
+    async fn test_tag_sha_to_commit_sha() {
+        let client = Client::new(
+            &GitHubHost::default(),
+            &GitHubToken::new(&std::env::var("GH_TOKEN").unwrap()).unwrap(),
+            "/tmp".into(),
+        )
+        .unwrap();
+
+        // No hop: 3fdd4fca8fc76b254cefefca92381c41b28d1f0d is already a
+        // commit SHA, so we get `Ok(None)`.
+        assert_eq!(
+            client
+                .tag_sha_to_commit_sha(
+                    "woodruffw-experiments",
+                    "zizmor-recursive-tags",
+                    "3fdd4fca8fc76b254cefefca92381c41b28d1f0d"
+                )
+                .await
+                .unwrap(),
+            None
+        );
+
+        // One hop: 06f9d47abf340b709b412900a7b3ce33557d32b5 (v1.0.0) points directly
+        // at commit 3fdd4fca8fc76b254cefefca92381c41b28d1f0d.
+        assert_eq!(
+            client
+                .tag_sha_to_commit_sha(
+                    "woodruffw-experiments",
+                    "zizmor-recursive-tags",
+                    "06f9d47abf340b709b412900a7b3ce33557d32b5"
+                )
+                .await
+                .unwrap(),
+            Some("3fdd4fca8fc76b254cefefca92381c41b28d1f0d".into())
+        );
+
+        // Two hops: bcb36f3d551340e11b88c376e74e8ae77fc6cf0b (v1.0) points at
+        // 06f9d47abf340b709b412900a7b3ce33557d32b5 (v1.0.0), which points at
+        // 3fdd4fca8fc76b254cefefca92381.
+        assert_eq!(
+            client
+                .tag_sha_to_commit_sha(
+                    "woodruffw-experiments",
+                    "zizmor-recursive-tags",
+                    "bcb36f3d551340e11b88c376e74e8ae77fc6cf0b"
+                )
+                .await
+                .unwrap(),
+            Some("3fdd4fca8fc76b254cefefca92381c41b28d1f0d".into())
+        );
+
+        // Three hops: 1accca34bff60347d96faaf713d328ca1250d37b (v1) points at
+        // bcb36f3d551340e11b88c376e74e8ae77fc6cf0b (v1.0), which points at
+        // 06f9d47abf340b709b412900a7b3ce33557d32b5 (v1.0.0), which points at
+        // 3fdd4fca8fc76b254cefefca92381c41b.
+        assert_eq!(
+            client
+                .tag_sha_to_commit_sha(
+                    "woodruffw-experiments",
+                    "zizmor-recursive-tags",
+                    "1accca34bff60347d96faaf713d328ca1250d37b"
+                )
+                .await
+                .unwrap(),
+            Some("3fdd4fca8fc76b254cefefca92381c41b28d1f0d".into())
+        );
     }
 }

--- a/crates/zizmor/tests/integration/audit/impostor_commit.rs
+++ b/crates/zizmor/tests/integration/audit/impostor_commit.rs
@@ -29,3 +29,20 @@ fn test_regular_persona() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Test for #1997: if a user does something like `uses: foo/bar@sha`
+/// where `sha` is a tag SHA, then we should correctly "peel" that tag
+/// back to its original commit SHA rather than emitting a false positive.
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
+fn test_peels_tag_sha_to_commit_sha() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+    zizmor()
+        .input(input_under_test("impostor-commit/sha-is-tag.yml"))
+        .offline(false)
+        .run()?,
+    @"No findings to report. Good job! (3 suppressed)"
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/impostor-commit/sha-is-tag.yml
+++ b/crates/zizmor/tests/integration/test-data/impostor-commit/sha-is-tag.yml
@@ -1,0 +1,17 @@
+name: example
+on: [push]
+
+permissions: {}
+
+jobs:
+  commit:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      # OK: 1accca34bff60347d96faaf713d328ca1250d37b is the object ID of a legitimate tag (v1),
+      # which points to a legitimate commit. `impostor-commit` should resolve this back to its
+      # underlying commit and not produce a finding, while also not taking the slow path.
+      - uses: woodruffw-experiments/zizmor-recursive-tags@1accca34bff60347d96faaf713d328ca1250d37b
+      - shell: bash
+        run: |
+          echo 'hello world!'

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -62,6 +62,12 @@ of `zizmor`.
 
 * `deno` is now recognized as a `package-ecosystem` in `dependabot.yml` (#1991)
 
+### Performance Improvements 🚄
+
+* The [impostor-commit] audit is now significantly faster (in addition to being
+  more correct) when the user has pinned their action to a tag SHA instead of
+  a commit SHA (#1998)
+
 ### Bug Fixes 🐛
 
 * Fixed a crash in the [template-injection] audit when a workflow uses
@@ -93,6 +99,10 @@ of `zizmor`.
 
 * Fixed a bug where zizmor's input validation warnings lacked
   a mention of which files failed to validate (#1980)
+
+* Fixed a bug where the [impostor-commit] audit would falsely indicate
+  impostor commits if an action was pinned to a tag SHA instead of a commit SHA
+  (#1998)
 
 ## 1.24.1
 


### PR DESCRIPTION
Closes #1997.

This fixes the _core_ of #1997, which is that if a user hash-pinned with a tag SHA instead of a commit SHA we'd (1) miss all of our fast paths, and (2) incorrectly flag it as an impostor since we'd end up doing branch comparisons with the tag SHA rather than a commit SHA.

~~I still need to optimize this more -- the downside to this approach is that we now do at least one (and in the worst case several) GitHub API calls before we ever take the fast paths, which exist primarily to avoid GitHub's slow publishing REST APIs.~~ Okay, this is now roughly as fast as it was before.