### PR TITLE
fix: replace `--fix=unsafe` with `--fix=unsafe-only` in suggestion

### DIFF
--- a/crates/zizmor/src/output/fix.rs
+++ b/crates/zizmor/src/output/fix.rs
@@ -50,7 +50,7 @@ pub fn apply_fixes(
     if fixes_by_input.is_empty() {
         if total_fixes > 0 {
             let suggestion = match fix_mode {
-                FixMode::Safe => Some("Use --fix=unsafe or --fix=all to apply unsafe fixes."),
+                FixMode::Safe => Some("Use --fix=unsafe-only or --fix=all to apply unsafe fixes."),
                 FixMode::UnsafeOnly => Some("Use --fix=safe or --fix=all to apply safe fixes."),
                 FixMode::All => None,
             };

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,10 @@ of `zizmor`.
   `release` events as exempt from cache usage findings when filtered by a
   tag condition (#2004)
 
+* Fixed a typo when suggesting `--fix` flags for findings (#2010)
+
+    Many thanks to @0xdea for implementing this fix!
+
 ## 1.25.0
 
 ### New Features 🌈


### PR DESCRIPTION

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first). -> yes

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy. -> no AI was used

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Just a super-quick fix for https://github.com/zizmorcore/zizmor/issues/2006.
