### PR TITLE
chore: drop `serde_yaml` rename

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# chore(deps): drop serde_yaml rename, use yaml_serde directly
+d706f97cf294e09f4a3d22c2dc8b32a54a2fe508

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde-sarif = "0.8.0"
 serde_json = "1.0.149"
 serde_json_path = "0.7.2"
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 tar = "0.4.45"
 terminal-link = "0.1.0"
 thiserror = "2.0.18"

--- a/crates/github-actions-models/Cargo.toml
+++ b/crates/github-actions-models/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 indexmap.workspace = true
 self_cell.workspace = true
 serde.workspace = true
-serde_yaml.workspace = true
+yaml_serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/github-actions-models/src/action.rs
+++ b/crates/github-actions-models/src/action.rs
@@ -213,10 +213,10 @@ mod tests {
 
     #[test]
     fn test_docker_action_uses_deserialization() {
-        let uses: DockerActionUses = serde_yaml::from_str("Dockerfile").unwrap();
+        let uses: DockerActionUses = yaml_serde::from_str("Dockerfile").unwrap();
         assert!(matches!(uses, DockerActionUses::Dockerfile));
 
-        let uses: DockerActionUses = serde_yaml::from_str("ubuntu:latest").unwrap();
+        let uses: DockerActionUses = yaml_serde::from_str("ubuntu:latest").unwrap();
         assert!(matches!(uses, DockerActionUses::Image(_)));
     }
 }

--- a/crates/github-actions-models/src/common.rs
+++ b/crates/github-actions-models/src/common.rs
@@ -585,13 +585,13 @@ mod tests {
     #[test]
     fn test_permissions() {
         assert_eq!(
-            serde_yaml::from_str::<Permissions>("read-all").unwrap(),
+            yaml_serde::from_str::<Permissions>("read-all").unwrap(),
             Permissions::Base(BasePermission::ReadAll)
         );
 
         let perm = "security-events: write";
         assert_eq!(
-            serde_yaml::from_str::<Permissions>(perm).unwrap(),
+            yaml_serde::from_str::<Permissions>(perm).unwrap(),
             Permissions::Explicit(IndexMap::from([(
                 "security-events".into(),
                 Permission::Write
@@ -603,7 +603,7 @@ mod tests {
     fn test_env_empty_value() {
         let env = "foo:";
         assert_eq!(
-            serde_yaml::from_str::<Env>(env).unwrap()["foo"],
+            yaml_serde::from_str::<Env>(env).unwrap()["foo"],
             EnvValue::String("".into())
         );
     }
@@ -999,7 +999,7 @@ mod tests {
         struct Dummy(#[serde(deserialize_with = "reusable_step_uses")] Uses);
 
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 "octo-org/this-repo/.github/workflows/workflow-1.yml@172239021f7ba04fe7327647b213799853a9eb89"
             )
             .map(|d| d.0)
@@ -1023,7 +1023,7 @@ mod tests {
         );
 
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 "octo-org/this-repo/.github/workflows/workflow-1.yml@notahash"
             ).map(|d| d.0).unwrap(),
             @r#"
@@ -1045,7 +1045,7 @@ mod tests {
         );
 
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 "octo-org/this-repo/.github/workflows/workflow-1.yml@abcd"
             ).map(|d| d.0).unwrap(),
             @r#"
@@ -1068,7 +1068,7 @@ mod tests {
 
         // Invalid: remote reusable workflow without ref
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 "octo-org/this-repo/.github/workflows/workflow-1.yml"
             ).map(|d| d.0).unwrap_err(),
             @r#"Error("malformed `uses` ref: missing `@<ref>` in octo-org/this-repo/.github/workflows/workflow-1.yml")"#
@@ -1076,7 +1076,7 @@ mod tests {
 
         // Invalid: local reusable workflow with ref
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 "./.github/workflows/workflow-1.yml@172239021f7ba04fe7327647b213799853a9eb89"
             ).map(|d| d.0).unwrap_err(),
             @r#"Error("local reusable workflow reference can't specify `@<ref>`")"#
@@ -1084,7 +1084,7 @@ mod tests {
 
         // Invalid: no ref at all
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 ".github/workflows/workflow-1.yml"
             ).map(|d| d.0).unwrap_err(),
             @r#"Error("malformed `uses` ref: missing `@<ref>` in .github/workflows/workflow-1.yml")"#
@@ -1092,7 +1092,7 @@ mod tests {
 
         // Invalid: missing user/repo
         insta::assert_debug_snapshot!(
-            serde_yaml::from_str::<Dummy>(
+            yaml_serde::from_str::<Dummy>(
                 "workflow-1.yml@172239021f7ba04fe7327647b213799853a9eb89"
             ).map(|d| d.0).unwrap_err(),
             @r#"Error("malformed `uses` ref: owner/repo slug is too short: workflow-1.yml@172239021f7ba04fe7327647b213799853a9eb89")"#

--- a/crates/github-actions-models/src/common/expr.rs
+++ b/crates/github-actions-models/src/common/expr.rs
@@ -104,7 +104,7 @@ mod tests {
 
         for case in cases {
             let case = format!("\"{case}\"");
-            assert!(serde_yaml::from_str::<ExplicitExpr>(&case).is_err());
+            assert!(yaml_serde::from_str::<ExplicitExpr>(&case).is_err());
         }
     }
 
@@ -119,7 +119,7 @@ mod tests {
             ("${{    foo     }}", "foo"),
         ] {
             let case = format!("\"{case}\"");
-            let expr: ExplicitExpr = serde_yaml::from_str(&case).unwrap();
+            let expr: ExplicitExpr = yaml_serde::from_str(&case).unwrap();
             assert_eq!(expr.as_bare(), *expected);
         }
     }
@@ -128,20 +128,20 @@ mod tests {
     fn test_loe() {
         let lit = "\"normal string\"";
         assert_eq!(
-            serde_yaml::from_str::<LoE<String>>(lit).unwrap(),
+            yaml_serde::from_str::<LoE<String>>(lit).unwrap(),
             LoE::Literal("normal string".to_string())
         );
 
         let expr = "\"${{ expr }}\"";
         assert!(matches!(
-            serde_yaml::from_str::<LoE<String>>(expr).unwrap(),
+            yaml_serde::from_str::<LoE<String>>(expr).unwrap(),
             LoE::Expr(_)
         ));
 
         // Invalid expr deserializes as string.
         let invalid = "\"${{ invalid \"";
         assert_eq!(
-            serde_yaml::from_str::<LoE<String>>(invalid).unwrap(),
+            yaml_serde::from_str::<LoE<String>>(invalid).unwrap(),
             LoE::Literal("${{ invalid ".to_string())
         );
     }

--- a/crates/github-actions-models/src/workflow/event.rs
+++ b/crates/github-actions-models/src/workflow/event.rs
@@ -358,7 +358,7 @@ pull_request:
 workflow_dispatch:
 issue_comment:";
 
-        let events = serde_yaml::from_str::<super::Events>(events).unwrap();
+        let events = yaml_serde::from_str::<super::Events>(events).unwrap();
         assert_eq!(events.count(), 4);
     }
 }

--- a/crates/github-actions-models/src/workflow/job.rs
+++ b/crates/github-actions-models/src/workflow/job.rs
@@ -2,7 +2,7 @@
 
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use crate::common::expr::{BoE, LoE};
 use crate::common::{DockerUses, Env, If, Permissions, Uses, custom_error};
@@ -218,12 +218,12 @@ mod tests {
     #[test]
     fn test_secrets() {
         assert_eq!(
-            serde_yaml::from_str::<Secrets>("inherit").unwrap(),
+            yaml_serde::from_str::<Secrets>("inherit").unwrap(),
             Secrets::Inherit
         );
 
         let secrets = "foo-secret: bar";
-        let Secrets::Env(secrets) = serde_yaml::from_str::<Secrets>(secrets).unwrap() else {
+        let Secrets::Env(secrets) = yaml_serde::from_str::<Secrets>(secrets).unwrap() else {
             panic!("unexpected secrets variant");
         };
         assert_eq!(secrets["foo-secret"], EnvValue::String("bar".into()));
@@ -235,7 +235,7 @@ mod tests {
         let Strategy {
             matrix: Some(LoE::Expr(expr)),
             ..
-        } = serde_yaml::from_str::<Strategy>(strategy).unwrap()
+        } = yaml_serde::from_str::<Strategy>(strategy).unwrap()
         else {
             panic!("unexpected matrix variant");
         };
@@ -255,7 +255,7 @@ matrix:
                     dimensions: LoE::Literal(dims),
                 })),
             ..
-        } = serde_yaml::from_str::<Strategy>(strategy).unwrap()
+        } = yaml_serde::from_str::<Strategy>(strategy).unwrap()
         else {
             panic!("unexpected matrix variant");
         };
@@ -268,7 +268,7 @@ matrix:
         let runson = "group: \nlabels: []";
 
         assert_eq!(
-            serde_yaml::from_str::<RunsOn>(runson)
+            yaml_serde::from_str::<RunsOn>(runson)
                 .unwrap_err()
                 .to_string(),
             "runs-on must provide either `group` or one or more `labels`"

--- a/crates/github-actions-models/src/workflow/mod.rs
+++ b/crates/github-actions-models/src/workflow/mod.rs
@@ -122,11 +122,11 @@ mod tests {
     #[test]
     fn test_concurrency() {
         let bare = "foo";
-        let concurrency: Concurrency = serde_yaml::from_str(bare).unwrap();
+        let concurrency: Concurrency = yaml_serde::from_str(bare).unwrap();
         assert!(matches!(concurrency, Concurrency::Bare(_)));
 
         let rich = "group: foo\ncancel-in-progress: true";
-        let concurrency: Concurrency = serde_yaml::from_str(rich).unwrap();
+        let concurrency: Concurrency = yaml_serde::from_str(rich).unwrap();
         assert!(matches!(
             concurrency,
             Concurrency::Rich {
@@ -151,7 +151,7 @@ mod tests {
   pull_request_target:
         ";
 
-        let trigger: Trigger = serde_yaml::from_str(on).unwrap();
+        let trigger: Trigger = yaml_serde::from_str(on).unwrap();
         let Trigger::Events(events) = trigger else {
             panic!("wrong trigger type");
         };

--- a/crates/github-actions-models/tests/test_action.rs
+++ b/crates/github-actions-models/tests/test_action.rs
@@ -10,7 +10,7 @@ fn load_action(name: &str) -> Action {
         .join("tests/sample-actions")
         .join(name);
     let action_contents = std::fs::read_to_string(action_path).unwrap();
-    serde_yaml::from_str(&action_contents).unwrap()
+    yaml_serde::from_str(&action_contents).unwrap()
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn test_load_all() {
     for sample_action in std::fs::read_dir(sample_actions).unwrap() {
         let sample_action = sample_action.unwrap().path();
         let action_contents = std::fs::read_to_string(sample_action).unwrap();
-        serde_yaml::from_str::<Action>(&action_contents).unwrap();
+        yaml_serde::from_str::<Action>(&action_contents).unwrap();
     }
 }
 

--- a/crates/github-actions-models/tests/test_dependabot_v2.rs
+++ b/crates/github-actions-models/tests/test_dependabot_v2.rs
@@ -9,11 +9,11 @@ fn sample_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/sample-dependabot/v2")
 }
 
-fn load_dependabot_result(name: &str) -> Result<Dependabot, serde_yaml::Error> {
+fn load_dependabot_result(name: &str) -> Result<Dependabot, yaml_serde::Error> {
     let workflow_path = sample_dir().join(name);
     let dependabot_contents = std::fs::read_to_string(&workflow_path)
         .unwrap_or_else(|err| panic!("failed to read {}: {err}", workflow_path.display()));
-    serde_yaml::from_str(&dependabot_contents)
+    yaml_serde::from_str(&dependabot_contents)
 }
 
 fn load_dependabot(name: &str) -> Dependabot {

--- a/crates/github-actions-models/tests/test_workflow.rs
+++ b/crates/github-actions-models/tests/test_workflow.rs
@@ -17,7 +17,7 @@ fn load_workflow(name: &str) -> Workflow {
         .join("tests/sample-workflows")
         .join(name);
     let workflow_contents = std::fs::read_to_string(workflow_path).unwrap();
-    serde_yaml::from_str(&workflow_contents).unwrap()
+    yaml_serde::from_str(&workflow_contents).unwrap()
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn test_load_all() {
         let sample_workflow = sample_workflow.unwrap().path();
         let workflow_contents = std::fs::read_to_string(&sample_workflow).unwrap();
 
-        let wf = serde_yaml::from_str::<Workflow>(&workflow_contents);
+        let wf = yaml_serde::from_str::<Workflow>(&workflow_contents);
         assert!(wf.is_ok(), "failed to parse {sample_workflow:?}");
     }
 }

--- a/crates/yamlpatch/Cargo.toml
+++ b/crates/yamlpatch/Cargo.toml
@@ -21,7 +21,7 @@ indexmap.workspace = true
 line-index.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-serde_yaml.workspace = true
+yaml_serde.workspace = true
 subfeature.workspace = true
 thiserror.workspace = true
 yamlpath.workspace = true

--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -10,7 +10,7 @@ pub enum Error {
     #[error("YAML query error: {0}")]
     Query(#[from] yamlpath::QueryError),
     #[error("YAML serialization error: {0}")]
-    Serialization(#[from] serde_yaml::Error),
+    Serialization(#[from] yaml_serde::Error),
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
 }
@@ -157,7 +157,7 @@ pub enum Op<'doc> {
     /// if none exists.
     EmplaceComment { new: Cow<'doc, str> },
     /// Replace the value at the given path
-    Replace(serde_yaml::Value),
+    Replace(yaml_serde::Value),
     /// Add a new key-value pair at the given path.
     ///
     /// The route should point to a mapping.
@@ -169,14 +169,14 @@ pub enum Op<'doc> {
     /// - The key must not already exist in the targeted mapping.
     Add {
         key: String,
-        value: serde_yaml::Value,
+        value: yaml_serde::Value,
     },
     /// Update a mapping at the given path.
     ///
     /// If the mapping does not already exist, it will be created.
     MergeInto {
         key: String,
-        updates: indexmap::IndexMap<String, serde_yaml::Value>,
+        updates: indexmap::IndexMap<String, yaml_serde::Value>,
     },
     /// Remove the key at the given path
     #[allow(dead_code)]
@@ -184,7 +184,7 @@ pub enum Op<'doc> {
     /// Append a new item to a sequence at the given path.
     ///
     /// The sequence must be a block sequence; flow sequences are not supported.
-    Append { value: serde_yaml::Value },
+    Append { value: yaml_serde::Value },
 }
 
 /// Apply a sequence of YAML patch operations to a YAML document.
@@ -449,7 +449,7 @@ fn apply_single_patch(
                     }
 
                     // NOTE: We need to extract the original mapping with
-                    // leading whitespace so that serde_yaml can parse it;
+                    // leading whitespace so that yaml_serde can parse it;
                     // otherwise something like:
                     //
                     // ```yaml
@@ -466,7 +466,7 @@ fn apply_single_patch(
                     // ```
                     let existing_content =
                         document.extract_with_leading_whitespace(&existing_feature);
-                    let existing_mapping = serde_yaml::from_str::<serde_yaml::Mapping>(
+                    let existing_mapping = yaml_serde::from_str::<yaml_serde::Mapping>(
                         existing_content,
                     )
                     .map_err(|e| {
@@ -517,7 +517,7 @@ fn apply_single_patch(
                             route: patch.route.clone(),
                             operation: Op::Add {
                                 key: key.clone(),
-                                value: serde_yaml::to_value(updates.clone())?,
+                                value: yaml_serde::to_value(updates.clone())?,
                             },
                         },
                     );
@@ -608,35 +608,35 @@ pub fn route_to_feature_exact<'a>(
     doc.query_exact(route).map_err(Error::from)
 }
 
-/// Serialize a serde_yaml::Value to a YAML string, handling different types appropriately
-fn serialize_yaml_value(value: &serde_yaml::Value) -> Result<String, Error> {
-    let yaml_str = serde_yaml::to_string(value)?;
+/// Serialize a yaml_serde::Value to a YAML string, handling different types appropriately
+fn serialize_yaml_value(value: &yaml_serde::Value) -> Result<String, Error> {
+    let yaml_str = yaml_serde::to_string(value)?;
     Ok(yaml_str.trim_end().to_string()) // Remove trailing newline
 }
 
-/// Serialize a [`serde_yaml::Value`] to a YAML string in flow layout.
+/// Serialize a [`yaml_serde::Value`] to a YAML string in flow layout.
 ///
 /// This serializes only a restricted subset of YAML: tags are not
 /// supported, and mapping keys must be strings.
-pub fn serialize_flow(value: &serde_yaml::Value) -> Result<String, Error> {
+pub fn serialize_flow(value: &yaml_serde::Value) -> Result<String, Error> {
     let mut buf = String::new();
-    fn serialize_inner(value: &serde_yaml::Value, buf: &mut String) -> Result<(), Error> {
+    fn serialize_inner(value: &yaml_serde::Value, buf: &mut String) -> Result<(), Error> {
         match value {
-            serde_yaml::Value::Null => {
-                // serde_yaml puts a trailing newline on this for some reasons
+            yaml_serde::Value::Null => {
+                // yaml_serde puts a trailing newline on this for some reasons
                 // so we do it manually.
                 buf.push_str("null");
                 Ok(())
             }
-            serde_yaml::Value::Bool(b) => {
+            yaml_serde::Value::Bool(b) => {
                 buf.push_str(if *b { "true" } else { "false" });
                 Ok(())
             }
-            serde_yaml::Value::Number(n) => {
+            yaml_serde::Value::Number(n) => {
                 buf.push_str(&n.to_string());
                 Ok(())
             }
-            serde_yaml::Value::String(s) => {
+            yaml_serde::Value::String(s) => {
                 // Note: there are other plain-scalar-safe chars, but this is fine
                 // for a first approximation.
                 if s.chars()
@@ -644,7 +644,7 @@ pub fn serialize_flow(value: &serde_yaml::Value) -> Result<String, Error> {
                 {
                     buf.push_str(s);
                 } else {
-                    // Dumb hack: serde_yaml will always produce a reasonable-enough
+                    // Dumb hack: yaml_serde will always produce a reasonable-enough
                     // single-line string scalar for us.
                     buf.push_str(
                         &serde_json::to_string(s)
@@ -654,7 +654,7 @@ pub fn serialize_flow(value: &serde_yaml::Value) -> Result<String, Error> {
 
                 Ok(())
             }
-            serde_yaml::Value::Sequence(values) => {
+            yaml_serde::Value::Sequence(values) => {
                 // Serialize sequence in flow style: [item1, item2, item3]
                 buf.push('[');
                 for (i, item) in values.iter().enumerate() {
@@ -666,14 +666,14 @@ pub fn serialize_flow(value: &serde_yaml::Value) -> Result<String, Error> {
                 buf.push(']');
                 Ok(())
             }
-            serde_yaml::Value::Mapping(mapping) => {
+            yaml_serde::Value::Mapping(mapping) => {
                 // Serialize mapping in flow style: { key1: value1, key2: value2 }
                 buf.push_str("{ ");
                 for (i, (key, value)) in mapping.iter().enumerate() {
                     if i > 0 {
                         buf.push_str(", ");
                     }
-                    if !matches!(key, serde_yaml::Value::String(_)) {
+                    if !matches!(key, yaml_serde::Value::String(_)) {
                         return Err(Error::InvalidOperation(format!(
                             "mapping keys must be strings, found: {key:?}"
                         )));
@@ -681,7 +681,7 @@ pub fn serialize_flow(value: &serde_yaml::Value) -> Result<String, Error> {
                     serialize_inner(key, buf)?;
 
                     buf.push_str(": ");
-                    if !matches!(value, serde_yaml::Value::Null) {
+                    if !matches!(value, yaml_serde::Value::Null) {
                         // Skip the null part of `key: null`, since `key: `
                         // is more idiomatic.
                         serialize_inner(value, buf)?;
@@ -690,7 +690,7 @@ pub fn serialize_flow(value: &serde_yaml::Value) -> Result<String, Error> {
                 buf.push_str(" }");
                 Ok(())
             }
-            serde_yaml::Value::Tagged(tagged_value) => Err(Error::InvalidOperation(format!(
+            yaml_serde::Value::Tagged(tagged_value) => Err(Error::InvalidOperation(format!(
                 "cannot serialize tagged value: {tagged_value:?}"
             ))),
         }
@@ -824,10 +824,10 @@ fn handle_block_mapping_addition(
     doc: &yamlpath::Document,
     feature: &yamlpath::Feature,
     key: &str,
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
 ) -> Result<String, Error> {
     // Convert the new value to YAML string for block style handling
-    let new_value_str = if matches!(value, serde_yaml::Value::Sequence(_)) {
+    let new_value_str = if matches!(value, yaml_serde::Value::Sequence(_)) {
         // For sequences, use flow-aware serialization to maintain consistency
         serialize_flow(value)?
     } else {
@@ -839,7 +839,7 @@ fn handle_block_mapping_addition(
     let indent = " ".repeat(extract_leading_indentation_for_block_item(doc, feature));
 
     // Format the new entry
-    let mut final_entry = if let serde_yaml::Value::Mapping(mapping) = &value {
+    let mut final_entry = if let yaml_serde::Value::Mapping(mapping) = &value {
         if mapping.is_empty() {
             // For empty mappings, format inline
             format!("\n{indent}{key}: {new_value_str}")
@@ -910,13 +910,13 @@ fn handle_block_mapping_addition(
 fn handle_block_sequence_append(
     doc: &yamlpath::Document,
     feature: &yamlpath::Feature,
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
 ) -> Result<String, Error> {
     let feature_content = doc.extract(feature);
     let indent = extract_leading_whitespace(doc, feature);
 
     // Use flow-style for nested sequences to produce more idiomatic YAML
-    let value_str = if matches!(value, serde_yaml::Value::Sequence(_)) {
+    let value_str = if matches!(value, yaml_serde::Value::Sequence(_)) {
         serialize_flow(value)?
     } else {
         serialize_yaml_value(value)?
@@ -964,7 +964,7 @@ fn handle_block_sequence_append(
 fn handle_flow_mapping_addition(
     feature_content: &str,
     key: &str,
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
 ) -> Result<String, Error> {
     // Our strategy for flow mappings is to deserialize the existing feature,
     // add the new key-value pair, and then serialize it back.
@@ -976,12 +976,12 @@ fn handle_flow_mapping_addition(
     // line flow mappings can't contain comments or (much) other user
     // significant formatting.
 
-    let mut existing_mapping = serde_yaml::from_str::<serde_yaml::Mapping>(feature_content)
+    let mut existing_mapping = yaml_serde::from_str::<yaml_serde::Mapping>(feature_content)
         .map_err(Error::Serialization)?;
 
     existing_mapping.insert(key.into(), value.clone());
 
-    let updated_content = serialize_flow(&serde_yaml::Value::Mapping(existing_mapping))?;
+    let updated_content = serialize_flow(&yaml_serde::Value::Mapping(existing_mapping))?;
 
     Ok(updated_content)
 }
@@ -1014,7 +1014,7 @@ pub fn find_content_end(feature: &yamlpath::Feature, doc: &yamlpath::Document) -
 fn apply_value_replacement(
     feature: &yamlpath::Feature,
     doc: &yamlpath::Document,
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
     support_multiline_literals: bool,
 ) -> Result<String, Error> {
     // Extract the current content to see what we're replacing
@@ -1054,7 +1054,7 @@ fn apply_value_replacement(
 
             if is_multiline_literal {
                 // Check if this is a multiline string value
-                if let serde_yaml::Value::String(string_content) = value
+                if let yaml_serde::Value::String(string_content) = value
                     && string_content.contains('\n')
                 {
                     // For multiline literal blocks, use the raw string content
@@ -1105,7 +1105,7 @@ fn handle_flow_mapping_value_replacement(
     _start_byte: usize,
     _end_byte: usize,
     current_content: &str,
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
 ) -> Result<String, Error> {
     let val_str = serialize_yaml_value(value)?;
     let val_str = val_str.trim();

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -25,11 +25,11 @@ foo:
 flow: [1, 2, 3, {more: 456, evenmore: "abc\ndef"}]
 "#;
 
-    let value: serde_yaml::Value = serde_yaml::from_str(doc).unwrap();
+    let value: yaml_serde::Value = yaml_serde::from_str(doc).unwrap();
     let serialized = serialize_flow(&value).unwrap();
 
     // serialized is valid YAML
-    assert!(serde_yaml::from_str::<serde_yaml::Value>(&serialized).is_ok());
+    assert!(yaml_serde::from_str::<yaml_serde::Value>(&serialized).is_ok());
 
     insta::assert_snapshot!(format_patch(&serialized), @r#"
     --- PATCH ---
@@ -215,10 +215,10 @@ foo:
 
     let content = doc.extract_with_leading_whitespace(&feature);
 
-    let reparsed = serde_yaml::from_str::<serde_yaml::Mapping>(content).unwrap();
+    let reparsed = yaml_serde::from_str::<yaml_serde::Mapping>(content).unwrap();
     assert_eq!(
-        reparsed.get(serde_yaml::Value::String("a".to_string())),
-        Some(&serde_yaml::Value::String("b".to_string()))
+        reparsed.get(yaml_serde::Value::String("a".to_string())),
+        Some(&yaml_serde::Value::String("b".to_string()))
     );
 }
 
@@ -832,7 +832,7 @@ foo:
 
     let operations = vec![Patch {
         route: route!("foo", "bar"),
-        operation: Op::Replace(serde_yaml::Value::String("abc".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("abc".to_string())),
     }];
 
     let result = apply_yaml_patches(&document, &operations).unwrap();
@@ -857,7 +857,7 @@ fn test_replace_empty_flow_value() {
 
     let patches = vec![Patch {
         route: route!("foo", "bar"),
-        operation: Op::Replace(serde_yaml::Value::String("abc".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("abc".to_string())),
     }];
 
     let result = apply_yaml_patches(&document, &patches).unwrap();
@@ -882,7 +882,7 @@ fn test_replace_empty_flow_value_no_colon() {
 
     let patches = vec![Patch {
         route: route!("foo", "bar"),
-        operation: Op::Replace(serde_yaml::Value::String("abc".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("abc".to_string())),
     }];
 
     let result = apply_yaml_patches(&document, &patches).unwrap();
@@ -951,7 +951,7 @@ jobs:
 
     let operations = vec![Patch {
         route: route!("permissions", "contents"),
-        operation: Op::Replace(serde_yaml::Value::String("write".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("write".to_string())),
     }];
 
     let result = apply_yaml_patches(&document, &operations).unwrap();
@@ -991,7 +991,7 @@ fn test_add_rejects_duplicate_key() {
         route: route!("foo"),
         operation: Op::Add {
             key: "bar".to_string(),
-            value: serde_yaml::Value::String("def".to_string()),
+            value: yaml_serde::Value::String("def".to_string()),
         },
     }];
 
@@ -1019,7 +1019,7 @@ permissions:
         route: route!("permissions"),
         operation: Op::Add {
             key: "issues".to_string(),
-            value: serde_yaml::Value::String("read".to_string()),
+            value: yaml_serde::Value::String("read".to_string()),
         },
     }];
 
@@ -1048,7 +1048,7 @@ foo: { bar: abc }
         route: route!("foo"),
         operation: Op::Add {
             key: "baz".to_string(),
-            value: serde_yaml::Value::String("qux".to_string()),
+            value: yaml_serde::Value::String("qux".to_string()),
         },
     }];
 
@@ -1115,13 +1115,13 @@ jobs:
     let operations = vec![
         Patch {
             route: route!("permissions", "contents"),
-            operation: Op::Replace(serde_yaml::Value::String("write".to_string())),
+            operation: Op::Replace(yaml_serde::Value::String("write".to_string())),
         },
         Patch {
             route: route!("permissions"),
             operation: Op::Add {
                 key: "issues".to_string(),
-                value: serde_yaml::Value::String("write".to_string()),
+                value: yaml_serde::Value::String("write".to_string()),
             },
         },
     ];
@@ -1320,13 +1320,13 @@ jobs:
     let operations = vec![
         Patch {
             route: route!("permissions", "contents"),
-            operation: Op::Replace(serde_yaml::Value::String("write".to_string())),
+            operation: Op::Replace(yaml_serde::Value::String("write".to_string())),
         },
         Patch {
             route: route!("permissions"),
             operation: Op::Add {
                 key: "packages".to_string(),
-                value: serde_yaml::Value::String("read".to_string()),
+                value: yaml_serde::Value::String("read".to_string()),
             },
         },
     ];
@@ -1369,12 +1369,12 @@ jobs:
     runs-on: ubuntu-latest"#;
 
     // Test empty mapping formatting
-    let empty_mapping = serde_yaml::Mapping::new();
+    let empty_mapping = yaml_serde::Mapping::new();
     let operations = vec![Patch {
         route: route!("jobs", "test"),
         operation: Op::Add {
             key: "permissions".to_string(),
-            value: serde_yaml::Value::Mapping(empty_mapping),
+            value: yaml_serde::Value::Mapping(empty_mapping),
         },
     }];
 
@@ -1410,7 +1410,7 @@ jobs:
         route: route!("jobs", "test"),
         operation: Op::Add {
             key: "permissions".to_string(),
-            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            value: yaml_serde::Value::Mapping(yaml_serde::Mapping::new()),
         },
     }];
 
@@ -1500,11 +1500,11 @@ fn test_step_insertion_with_comments() {
         route: route!("steps", 0),
         operation: Op::Add {
             key: "with".to_string(),
-            value: serde_yaml::Value::Mapping({
-                let mut map = serde_yaml::Mapping::new();
+            value: yaml_serde::Value::Mapping({
+                let mut map = yaml_serde::Mapping::new();
                 map.insert(
-                    serde_yaml::Value::String("persist-credentials".to_string()),
-                    serde_yaml::Value::Bool(false),
+                    yaml_serde::Value::String("persist-credentials".to_string()),
+                    yaml_serde::Value::Bool(false),
                 );
                 map
             }),
@@ -1622,7 +1622,7 @@ jobs:
         route: route!(),
         operation: Op::Add {
             key: "permissions".to_string(),
-            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            value: yaml_serde::Value::Mapping(yaml_serde::Mapping::new()),
         },
     }];
 
@@ -1659,7 +1659,7 @@ jobs:
         route: route!(),
         operation: Op::Add {
             key: "permissions".to_string(),
-            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            value: yaml_serde::Value::Mapping(yaml_serde::Mapping::new()),
         },
     }];
 
@@ -1695,11 +1695,11 @@ fn test_step_content_end_detection() {
         route: route!("steps", 0),
         operation: Op::Add {
             key: "with".to_string(),
-            value: serde_yaml::Value::Mapping({
-                let mut map = serde_yaml::Mapping::new();
+            value: yaml_serde::Value::Mapping({
+                let mut map = yaml_serde::Mapping::new();
                 map.insert(
-                    serde_yaml::Value::String("persist-credentials".to_string()),
-                    serde_yaml::Value::Bool(false),
+                    yaml_serde::Value::String("persist-credentials".to_string()),
+                    yaml_serde::Value::Bool(false),
                 );
                 map
             }),
@@ -1742,7 +1742,7 @@ fn test_merge_into_new_key() {
             key: "env".to_string(),
             updates: indexmap::IndexMap::from_iter([(
                 "TEST_VAR".to_string(),
-                serde_yaml::Value::String("test_value".to_string()),
+                yaml_serde::Value::String("test_value".to_string()),
             )]),
         },
     }];
@@ -1782,7 +1782,7 @@ fn test_merge_into_existing_key() {
             key: "env".to_string(),
             updates: indexmap::IndexMap::from_iter([(
                 "NEW_VAR".to_string(),
-                serde_yaml::Value::String("new_value".to_string()),
+                yaml_serde::Value::String("new_value".to_string()),
             )]),
         },
     }];
@@ -1826,7 +1826,7 @@ fn test_merge_into_prevents_duplicate_keys() {
             key: "env".to_string(),
             updates: indexmap::IndexMap::from_iter([(
                 "NEW_VAR".to_string(),
-                serde_yaml::Value::String("new_value".to_string()),
+                yaml_serde::Value::String("new_value".to_string()),
             )]),
         },
     }];
@@ -1870,7 +1870,7 @@ fn test_merge_into_with_unicode() {
             key: "env".to_string(),
             updates: indexmap::IndexMap::from_iter([(
                 "TEST_VAR".to_string(),
-                serde_yaml::Value::String("new_value".to_string()),
+                yaml_serde::Value::String("new_value".to_string()),
             )]),
         },
     }];
@@ -1966,7 +1966,7 @@ fn test_debug_indentation_issue() {
         route: route!("jobs", "build", "steps", 0),
         operation: Op::Add {
             key: "shell".to_string(),
-            value: serde_yaml::Value::String("bash".to_string()),
+            value: yaml_serde::Value::String("bash".to_string()),
         },
     }];
 
@@ -2017,9 +2017,9 @@ jobs:
         assert!(env_content.contains("IDENTITY: ${{ secrets.IDENTITY }}"));
 
         // Try to parse it as YAML and verify structure
-        match serde_yaml::from_str::<serde_yaml::Value>(env_content) {
+        match yaml_serde::from_str::<yaml_serde::Value>(env_content) {
             Ok(value) => {
-                if let serde_yaml::Value::Mapping(outer_mapping) = value {
+                if let yaml_serde::Value::Mapping(outer_mapping) = value {
                     // Assert that the mapping contains expected keys
                     assert!(
                         !outer_mapping.is_empty(),
@@ -2028,13 +2028,13 @@ jobs:
 
                     // The extracted content includes the "env:" key, so we need to look inside it
                     if let Some(env_value) =
-                        outer_mapping.get(serde_yaml::Value::String("env".to_string()))
+                        outer_mapping.get(yaml_serde::Value::String("env".to_string()))
                     {
-                        if let serde_yaml::Value::Mapping(env_mapping) = env_value {
+                        if let yaml_serde::Value::Mapping(env_mapping) = env_value {
                             // Verify that we can iterate over the env mapping
                             let mut found_identity = false;
                             for (k, _v) in env_mapping {
-                                if let serde_yaml::Value::String(key_str) = k {
+                                if let yaml_serde::Value::String(key_str) = k {
                                     if key_str == "IDENTITY" {
                                         found_identity = true;
                                     }
@@ -2066,7 +2066,7 @@ jobs:
     // Test the MergeInto operation
     let new_env = indexmap::IndexMap::from_iter([(
         "STEPS_META_OUTPUTS_TAGS".to_string(),
-        serde_yaml::Value::String("${{ steps.meta.outputs.tags }}".to_string()),
+        yaml_serde::Value::String("${{ steps.meta.outputs.tags }}".to_string()),
     )]);
 
     let operations = vec![Patch {
@@ -2118,7 +2118,7 @@ fn test_merge_into_complex_env_mapping() {
 
     let new_env = indexmap::IndexMap::from_iter([(
         "STEPS_META_OUTPUTS_TAGS".to_string(),
-        serde_yaml::Value::String("${{ steps.meta.outputs.tags }}".to_string()),
+        yaml_serde::Value::String("${{ steps.meta.outputs.tags }}".to_string()),
     )]);
 
     let operations = vec![Patch {
@@ -2171,7 +2171,7 @@ fn test_merge_into_reuses_existing_key_no_duplicates() {
             key: "env".to_string(),
             updates: indexmap::IndexMap::from_iter([(
                 "NEW_VAR".to_string(),
-                serde_yaml::Value::String("new_value".to_string()),
+                yaml_serde::Value::String("new_value".to_string()),
             )]),
         },
     }];
@@ -2218,7 +2218,7 @@ fn test_merge_into_with_mapping_merge_behavior() {
                 key: "env".to_string(),
                 updates: indexmap::IndexMap::from_iter([(
                     "NEW_VAR_1".to_string(),
-                    serde_yaml::Value::String("new_value_1".to_string()),
+                    yaml_serde::Value::String("new_value_1".to_string()),
                 )]),
             },
         },
@@ -2228,7 +2228,7 @@ fn test_merge_into_with_mapping_merge_behavior() {
                 key: "env".to_string(),
                 updates: indexmap::IndexMap::from_iter([(
                     "NEW_VAR_2".to_string(),
-                    serde_yaml::Value::String("new_value_2".to_string()),
+                    yaml_serde::Value::String("new_value_2".to_string()),
                 )]),
             },
         },
@@ -2292,9 +2292,9 @@ jobs:
         route: route!("on", "pull_request"),
         operation: Op::Add {
             key: "types".to_string(),
-            value: serde_yaml::Value::Sequence(vec![
-                serde_yaml::Value::String("opened".to_string()),
-                serde_yaml::Value::String("synchronize".to_string()),
+            value: yaml_serde::Value::Sequence(vec![
+                yaml_serde::Value::String("opened".to_string()),
+                yaml_serde::Value::String("synchronize".to_string()),
             ]),
         },
     }];
@@ -2349,7 +2349,7 @@ jobs:
 
     let operations = vec![Patch {
         route: route!("jobs", "test", "steps", 0, "with", "timeout"),
-        operation: Op::Replace(serde_yaml::Value::Number(serde_yaml::Number::from(600))),
+        operation: Op::Replace(yaml_serde::Value::Number(yaml_serde::Number::from(600))),
     }];
 
     let result =
@@ -2383,7 +2383,7 @@ foo:
         route: route!("foo", "bar"),
         operation: Op::Add {
             key: "qux".to_string(),
-            value: serde_yaml::Value::String("xyz".to_string()),
+            value: yaml_serde::Value::String("xyz".to_string()),
         },
     }];
 
@@ -2419,7 +2419,7 @@ matrix:
         route: route!("matrix", "include", 0),
         operation: Op::Add {
             key: "arch".to_string(),
-            value: serde_yaml::Value::String("x64".to_string()),
+            value: yaml_serde::Value::String("x64".to_string()),
         },
     }];
 
@@ -2456,7 +2456,7 @@ matrix:
         route: route!("matrix", "include", 0),
         operation: Op::Add {
             key: "arch".to_string(),
-            value: serde_yaml::Value::String("x64".to_string()),
+            value: yaml_serde::Value::String("x64".to_string()),
         },
     }];
 
@@ -2492,7 +2492,7 @@ strategy:
         route: route!("strategy", "matrix", "include", 0),
         operation: Op::Add {
             key: "arch".to_string(),
-            value: serde_yaml::Value::String("x64".to_string()),
+            value: yaml_serde::Value::String("x64".to_string()),
         },
     }];
 
@@ -2525,7 +2525,7 @@ jobs:
         route: route!("jobs", "test", "env"),
         operation: Op::Add {
             key: "LOG_LEVEL".to_string(),
-            value: serde_yaml::Value::String("info".to_string()),
+            value: yaml_serde::Value::String("info".to_string()),
         },
     }];
 
@@ -2557,7 +2557,7 @@ jobs:
         route: route!("jobs", "test", "env"),
         operation: Op::Add {
             key: "LOG_LEVEL".to_string(),
-            value: serde_yaml::Value::String("info".to_string()),
+            value: yaml_serde::Value::String("info".to_string()),
         },
     }];
 
@@ -2594,7 +2594,7 @@ jobs:
         route: route!("jobs", "test", "env"),
         operation: Op::Add {
             key: "LOG_LEVEL".to_string(),
-            value: serde_yaml::Value::String("info".to_string()),
+            value: yaml_serde::Value::String("info".to_string()),
         },
     }];
 
@@ -2630,7 +2630,7 @@ jobs:
         route: route!("jobs", "test", "env"),
         operation: Op::Add {
             key: "LOG_LEVEL".to_string(),
-            value: serde_yaml::Value::String("info".to_string()),
+            value: yaml_serde::Value::String("info".to_string()),
         },
     }];
 
@@ -2663,7 +2663,7 @@ permissions:
         route: route!("permissions", "actions"),
         operation: Op::Add {
             key: "delete".to_string(),
-            value: serde_yaml::Value::Bool(true),
+            value: yaml_serde::Value::Bool(true),
         },
     }];
 
@@ -2696,7 +2696,7 @@ on:
         route: route!("on", "push"),
         operation: Op::Add {
             key: "tags".to_string(),
-            value: serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("v*".to_string())]),
+            value: yaml_serde::Value::Sequence(vec![yaml_serde::Value::String("v*".to_string())]),
         },
     }];
 
@@ -2732,7 +2732,7 @@ jobs:
         route: route!("jobs", "test", "env"),
         operation: Op::Add {
             key: "NODE_ENV".to_string(),
-            value: serde_yaml::Value::String("test".to_string()),
+            value: yaml_serde::Value::String("test".to_string()),
         },
     }];
 
@@ -2768,7 +2768,7 @@ fn test_merge_into_preserves_comments_in_env_block() {
 
     let new_env = indexmap::IndexMap::from_iter([(
         "INPUTS_SCRIPT".to_string(),
-        serde_yaml::Value::String("${{ inputs.script }}".to_string()),
+        yaml_serde::Value::String("${{ inputs.script }}".to_string()),
     )]);
 
     let operations = vec![Patch {
@@ -2825,11 +2825,11 @@ jobs:
             updates: indexmap::IndexMap::from_iter([
                 (
                     "persist-credentials".to_string(),
-                    serde_yaml::Value::Bool(false),
+                    yaml_serde::Value::Bool(false),
                 ),
                 (
                     "another-key".to_string(),
-                    serde_yaml::Value::String("some-value".to_string()),
+                    yaml_serde::Value::String("some-value".to_string()),
                 ),
             ]),
         },
@@ -2873,7 +2873,7 @@ jobs:
             key: "with".to_string(),
             updates: indexmap::IndexMap::from_iter([(
                 "persist-credentials".to_string(),
-                serde_yaml::Value::Bool(false),
+                yaml_serde::Value::Bool(false),
             )]),
         },
     }];
@@ -2912,11 +2912,11 @@ updates:
         route: route!("updates", 0),
         operation: Op::Add {
             key: "cooldown".to_string(),
-            value: serde_yaml::Value::Mapping({
-                let mut map = serde_yaml::Mapping::new();
+            value: yaml_serde::Value::Mapping({
+                let mut map = yaml_serde::Mapping::new();
                 map.insert(
-                    serde_yaml::Value::String("default-days".to_string()),
-                    serde_yaml::Value::Number(7.into()),
+                    yaml_serde::Value::String("default-days".to_string()),
+                    yaml_serde::Value::Number(7.into()),
                 );
                 map
             }),
@@ -2953,7 +2953,7 @@ version: 1.0
 
     let operations = vec![Patch {
         route: route!("version"),
-        operation: Op::Replace(serde_yaml::Value::String("2.0".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("2.0".to_string())),
     }];
 
     let result =
@@ -3032,7 +3032,7 @@ key: value
         route: route!(),
         operation: Op::Add {
             key: "newkey".to_string(),
-            value: serde_yaml::Value::String("newvalue".to_string()),
+            value: yaml_serde::Value::String("newvalue".to_string()),
         },
     }];
 
@@ -3061,7 +3061,7 @@ fn test_preserve_trailing_newline_replace_nested_at_end() {
 
     let operations = vec![Patch {
         route: route!("jobs", "test", "env", "VAR"),
-        operation: Op::Replace(serde_yaml::Value::String("new".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("new".to_string())),
     }];
 
     let result =
@@ -3093,7 +3093,7 @@ fn test_preserve_trailing_newline_add_to_nested_mapping_at_end() {
         route: route!("jobs", "test", "steps", 0),
         operation: Op::Add {
             key: "name".to_string(),
-            value: serde_yaml::Value::String("Test step".to_string()),
+            value: yaml_serde::Value::String("Test step".to_string()),
         },
     }];
 
@@ -3123,7 +3123,7 @@ fn test_preserve_trailing_newline_replace_multiline_at_end() {
 
     let operations = vec![Patch {
         route: route!("description"),
-        operation: Op::Replace(serde_yaml::Value::String("New description".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("New description".to_string())),
     }];
 
     let result =
@@ -3149,7 +3149,7 @@ key: value"#;
 
     let operations = vec![Patch {
         route: route!("key"),
-        operation: Op::Replace(serde_yaml::Value::String("newvalue".to_string())),
+        operation: Op::Replace(yaml_serde::Value::String("newvalue".to_string())),
     }];
 
     let result =
@@ -3175,7 +3175,7 @@ items:
     let operations = vec![Patch {
         route: route!("items"),
         operation: Op::Append {
-            value: serde_yaml::Value::String("third".to_string()),
+            value: yaml_serde::Value::String("third".to_string()),
         },
     }];
 
@@ -3203,28 +3203,28 @@ databases:
     readonly: false
 "#;
 
-    let mut new_database = serde_yaml::Mapping::new();
+    let mut new_database = yaml_serde::Mapping::new();
     new_database.insert(
-        serde_yaml::Value::String("name".to_string()),
-        serde_yaml::Value::String("analytics".to_string()),
+        yaml_serde::Value::String("name".to_string()),
+        yaml_serde::Value::String("analytics".to_string()),
     );
     new_database.insert(
-        serde_yaml::Value::String("host".to_string()),
-        serde_yaml::Value::String("db2.example.com".to_string()),
+        yaml_serde::Value::String("host".to_string()),
+        yaml_serde::Value::String("db2.example.com".to_string()),
     );
     new_database.insert(
-        serde_yaml::Value::String("port".to_string()),
-        serde_yaml::Value::Number(5433.into()),
+        yaml_serde::Value::String("port".to_string()),
+        yaml_serde::Value::Number(5433.into()),
     );
     new_database.insert(
-        serde_yaml::Value::String("readonly".to_string()),
-        serde_yaml::Value::Bool(true),
+        yaml_serde::Value::String("readonly".to_string()),
+        yaml_serde::Value::Bool(true),
     );
 
     let operations = vec![Patch {
         route: route!("databases"),
         operation: Op::Append {
-            value: serde_yaml::Value::Mapping(new_database),
+            value: yaml_serde::Value::Mapping(new_database),
         },
     }];
 
@@ -3259,20 +3259,20 @@ jobs:
         run: echo "second"
 "#;
 
-    let mut new_step = serde_yaml::Mapping::new();
+    let mut new_step = yaml_serde::Mapping::new();
     new_step.insert(
-        serde_yaml::Value::String("name".to_string()),
-        serde_yaml::Value::String("Third step".to_string()),
+        yaml_serde::Value::String("name".to_string()),
+        yaml_serde::Value::String("Third step".to_string()),
     );
     new_step.insert(
-        serde_yaml::Value::String("run".to_string()),
-        serde_yaml::Value::String("echo \"third\"".to_string()),
+        yaml_serde::Value::String("run".to_string()),
+        yaml_serde::Value::String("echo \"third\"".to_string()),
     );
 
     let operations = vec![Patch {
         route: route!("jobs", "test", "steps"),
         operation: Op::Append {
-            value: serde_yaml::Value::Mapping(new_step),
+            value: yaml_serde::Value::Mapping(new_step),
         },
     }];
 
@@ -3307,24 +3307,24 @@ servers:
     port: 8443
 "#;
 
-    let mut new_server = serde_yaml::Mapping::new();
+    let mut new_server = yaml_serde::Mapping::new();
     new_server.insert(
-        serde_yaml::Value::String("name".to_string()),
-        serde_yaml::Value::String("dev".to_string()),
+        yaml_serde::Value::String("name".to_string()),
+        yaml_serde::Value::String("dev".to_string()),
     );
     new_server.insert(
-        serde_yaml::Value::String("host".to_string()),
-        serde_yaml::Value::String("localhost".to_string()),
+        yaml_serde::Value::String("host".to_string()),
+        yaml_serde::Value::String("localhost".to_string()),
     );
     new_server.insert(
-        serde_yaml::Value::String("port".to_string()),
-        serde_yaml::Value::Number(8080.into()),
+        yaml_serde::Value::String("port".to_string()),
+        yaml_serde::Value::Number(8080.into()),
     );
 
     let operations = vec![Patch {
         route: route!("servers"),
         operation: Op::Append {
-            value: serde_yaml::Value::Mapping(new_server),
+            value: yaml_serde::Value::Mapping(new_server),
         },
     }];
 
@@ -3363,7 +3363,7 @@ ports:
     let operations = vec![Patch {
         route: route!("ports"),
         operation: Op::Append {
-            value: serde_yaml::Value::Number(8082.into()),
+            value: yaml_serde::Value::Number(8082.into()),
         },
     }];
 
@@ -3390,7 +3390,7 @@ configs:
     let operations = vec![Patch {
         route: route!("configs"),
         operation: Op::Append {
-            value: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            value: yaml_serde::Value::Mapping(yaml_serde::Mapping::new()),
         },
     }];
 
@@ -3414,31 +3414,31 @@ services:
     port: 8080
 "#;
 
-    let mut new_service = serde_yaml::Mapping::new();
+    let mut new_service = yaml_serde::Mapping::new();
     new_service.insert(
-        serde_yaml::Value::String("name".to_string()),
-        serde_yaml::Value::String("worker".to_string()),
+        yaml_serde::Value::String("name".to_string()),
+        yaml_serde::Value::String("worker".to_string()),
     );
     new_service.insert(
-        serde_yaml::Value::String("port".to_string()),
-        serde_yaml::Value::Number(9090.into()),
+        yaml_serde::Value::String("port".to_string()),
+        yaml_serde::Value::Number(9090.into()),
     );
 
-    let mut config = serde_yaml::Mapping::new();
+    let mut config = yaml_serde::Mapping::new();
     config.insert(
-        serde_yaml::Value::String("replicas".to_string()),
-        serde_yaml::Value::Number(3.into()),
+        yaml_serde::Value::String("replicas".to_string()),
+        yaml_serde::Value::Number(3.into()),
     );
 
     new_service.insert(
-        serde_yaml::Value::String("config".to_string()),
-        serde_yaml::Value::Mapping(config),
+        yaml_serde::Value::String("config".to_string()),
+        yaml_serde::Value::Mapping(config),
     );
 
     let operations = vec![Patch {
         route: route!("services"),
         operation: Op::Append {
-            value: serde_yaml::Value::Mapping(new_service),
+            value: yaml_serde::Value::Mapping(new_service),
         },
     }];
 
@@ -3468,7 +3468,7 @@ config:
     let operations = vec![Patch {
         route: route!("config"),
         operation: Op::Append {
-            value: serde_yaml::Value::String("item".to_string()),
+            value: yaml_serde::Value::String("item".to_string()),
         },
     }];
 
@@ -3496,13 +3496,13 @@ tasks:
         Patch {
             route: route!("tasks"),
             operation: Op::Append {
-                value: serde_yaml::Value::String("task2".to_string()),
+                value: yaml_serde::Value::String("task2".to_string()),
             },
         },
         Patch {
             route: route!("tasks"),
             operation: Op::Append {
-                value: serde_yaml::Value::String("task3".to_string()),
+                value: yaml_serde::Value::String("task3".to_string()),
             },
         },
     ];
@@ -3534,20 +3534,20 @@ jobs:
         run: npm test
 "#;
 
-    let mut new_step = serde_yaml::Mapping::new();
+    let mut new_step = yaml_serde::Mapping::new();
     new_step.insert(
-        serde_yaml::Value::String("name".to_string()),
-        serde_yaml::Value::String("Upload coverage".to_string()),
+        yaml_serde::Value::String("name".to_string()),
+        yaml_serde::Value::String("Upload coverage".to_string()),
     );
     new_step.insert(
-        serde_yaml::Value::String("uses".to_string()),
-        serde_yaml::Value::String("codecov/codecov-action@v3".to_string()),
+        yaml_serde::Value::String("uses".to_string()),
+        yaml_serde::Value::String("codecov/codecov-action@v3".to_string()),
     );
 
     let operations = vec![Patch {
         route: route!("jobs", "test", "steps"),
         operation: Op::Append {
-            value: serde_yaml::Value::Mapping(new_step),
+            value: yaml_serde::Value::Mapping(new_step),
         },
     }];
 
@@ -3578,14 +3578,14 @@ foo:
   - abc
 "#;
 
-    let mut nested_sequence = serde_yaml::Sequence::new();
-    nested_sequence.push(serde_yaml::Value::String("def".to_string()));
-    nested_sequence.push(serde_yaml::Value::String("ghi".to_string()));
+    let mut nested_sequence = yaml_serde::Sequence::new();
+    nested_sequence.push(yaml_serde::Value::String("def".to_string()));
+    nested_sequence.push(yaml_serde::Value::String("ghi".to_string()));
 
     let operations = vec![Patch {
         route: route!("foo"),
         operation: Op::Append {
-            value: serde_yaml::Value::Sequence(nested_sequence),
+            value: yaml_serde::Value::Sequence(nested_sequence),
         },
     }];
 

--- a/crates/yamlpath/Cargo.toml
+++ b/crates/yamlpath/Cargo.toml
@@ -24,4 +24,4 @@ tree-sitter-iter = { workspace = true }
 tree-sitter-yaml = { workspace = true }
 
 [dev-dependencies]
-serde_yaml.workspace = true
+yaml_serde.workspace = true

--- a/crates/yamlpath/tests/integration_test.rs
+++ b/crates/yamlpath/tests/integration_test.rs
@@ -32,7 +32,7 @@ struct TestcaseQuery {
 #[derive(Deserialize)]
 struct Testcase {
     #[serde(rename = "testcase")]
-    _testcase: serde_yaml::Value,
+    _testcase: yaml_serde::Value,
     queries: Vec<TestcaseQuery>,
 }
 
@@ -53,7 +53,7 @@ impl<'a> From<&'a TestcaseQuery> for Route<'a> {
 
 fn run_testcase(path: &Path) {
     let raw_testcase = std::fs::read_to_string(path).unwrap();
-    let testcase = serde_yaml::from_str::<Testcase>(&raw_testcase).unwrap();
+    let testcase = yaml_serde::from_str::<Testcase>(&raw_testcase).unwrap();
 
     for q in &testcase.queries {
         let document = Document::new(raw_testcase.clone()).unwrap();

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -63,7 +63,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde-sarif.workspace = true
 serde_json.workspace = true
-serde_yaml.workspace = true
+yaml_serde.workspace = true
 subfeature.workspace = true
 tar.workspace = true
 terminal-link.workspace = true

--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -264,7 +264,7 @@ impl Artipacked {
                     key: "with".to_string(),
                     updates: indexmap::IndexMap::from_iter([(
                         "persist-credentials".to_string(),
-                        serde_yaml::Value::Bool(false),
+                        yaml_serde::Value::Bool(false),
                     )]),
                 },
             }],

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -492,14 +492,14 @@ impl CachePoisoning {
             } => {
                 let (field_value, title, _description) = match (toggle, field_type) {
                     (Toggle::OptOut, ControlFieldType::Boolean) => (
-                        serde_yaml::Value::Bool(true),
+                        yaml_serde::Value::Bool(true),
                         format!("Set {field_name}: true to disable caching"),
                         format!(
                             "Set '{field_name}' to 'true' to disable cache writes in this publishing workflow."
                         ),
                     ),
                     (Toggle::OptIn, ControlFieldType::Boolean) => (
-                        serde_yaml::Value::Bool(false),
+                        yaml_serde::Value::Bool(false),
                         format!("Set {field_name}: false to disable caching"),
                         format!(
                             "Set '{field_name}' to 'false' to disable caching in this publishing workflow."

--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -25,7 +25,7 @@ impl DependabotCooldown {
                 route: update.location().route.with_keys(["cooldown".into()]),
                 operation: Op::Add {
                     key: "default-days".to_string(),
-                    value: serde_yaml::Value::Number(7.into()),
+                    value: yaml_serde::Value::Number(7.into()),
                 },
             }],
         }
@@ -44,7 +44,7 @@ impl DependabotCooldown {
                     .location()
                     .route
                     .with_keys(["cooldown".into(), "default-days".into()]),
-                operation: Op::Replace(serde_yaml::Value::Number(7.into())),
+                operation: Op::Replace(yaml_serde::Value::Number(7.into())),
             }],
         }
     }
@@ -59,11 +59,11 @@ impl DependabotCooldown {
                 route: update.location().route,
                 operation: Op::Add {
                     key: "cooldown".to_string(),
-                    value: serde_yaml::Value::Mapping({
-                        let mut map = serde_yaml::Mapping::new();
+                    value: yaml_serde::Value::Mapping({
+                        let mut map = yaml_serde::Mapping::new();
                         map.insert(
-                            serde_yaml::Value::String("default-days".to_string()),
-                            serde_yaml::Value::Number(7.into()),
+                            yaml_serde::Value::String("default-days".to_string()),
+                            yaml_serde::Value::Number(7.into()),
                         );
                         map
                     }),

--- a/crates/zizmor/src/audit/dependabot_execution.rs
+++ b/crates/zizmor/src/audit/dependabot_execution.rs
@@ -26,7 +26,7 @@ impl DependabotExecution {
                     .location()
                     .route
                     .with_keys(["insecure-external-code-execution".into()]),
-                operation: Op::Replace(serde_yaml::Value::String("deny".to_string())),
+                operation: Op::Replace(yaml_serde::Value::String("deny".to_string())),
             }],
         }
     }

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -348,7 +348,7 @@ impl TemplateInjection {
                     key: "env".to_string(),
                     updates: indexmap::IndexMap::from_iter([(
                         env_var.clone(),
-                        serde_yaml::Value::String(raw.as_raw().into()),
+                        yaml_serde::Value::String(raw.as_raw().into()),
                     )]),
                 },
             });

--- a/crates/zizmor/src/config/mod.rs
+++ b/crates/zizmor/src/config/mod.rs
@@ -54,11 +54,11 @@ pub(crate) enum ConfigErrorInner {
 
     /// The overall configuration file is syntactically invalid.
     #[error("invalid configuration syntax")]
-    Syntax(#[source] serde_yaml::Error),
+    Syntax(#[source] yaml_serde::Error),
 
     /// A specific audit's configuration is syntactically invalid.
     #[error("invalid syntax for audit `{1}`")]
-    AuditSyntax(#[source] serde_yaml::Error, &'static str),
+    AuditSyntax(#[source] yaml_serde::Error, &'static str),
 
     /// The `unpinned-uses` config is semantically invalid.
     #[error("invalid `unpinned-uses` config")]
@@ -180,7 +180,7 @@ pub(crate) struct AuditRuleConfig {
     ignore: Vec<WorkflowRule>,
     /// Rule-specific configuration.
     #[serde(default)]
-    config: Option<serde_yaml::Mapping>,
+    config: Option<yaml_serde::Mapping>,
     /// Remapping configuration.
     #[serde(default)]
     remap: Option<RemapConfig>,
@@ -198,7 +198,7 @@ struct RawConfig {
 
 impl RawConfig {
     fn load(contents: &str) -> Result<Self, ConfigErrorInner> {
-        serde_yaml::from_str(contents).map_err(ConfigErrorInner::Syntax)
+        yaml_serde::from_str(contents).map_err(ConfigErrorInner::Syntax)
     }
 
     fn rule_config<T>(&self, ident: &'static str) -> Result<Option<T>, ConfigErrorInner>
@@ -208,7 +208,7 @@ impl RawConfig {
         self.rules
             .get(ident)
             .and_then(|rule_config| rule_config.config.as_ref())
-            .map(|policy| serde_yaml::from_value::<T>(serde_yaml::Value::Mapping(policy.clone())))
+            .map(|policy| yaml_serde::from_value::<T>(yaml_serde::Value::Mapping(policy.clone())))
             .transpose()
             .map_err(|e| ConfigErrorInner::AuditSyntax(e, ident))
     }
@@ -251,7 +251,7 @@ pub(crate) struct ForbiddenUsesConfig(
     // mapping with an explicit key discriminant (i.e. `allow:` or `deny:`)
     // rather than a YAML tag. We could work around this by using serde's
     // `untagged` instead, but this produces suboptimal user-facing error messages.
-    #[serde(with = "serde_yaml::with::singleton_map")] pub(crate) ForbiddenUsesConfigInner,
+    #[serde(with = "yaml_serde::with::singleton_map")] pub(crate) ForbiddenUsesConfigInner,
 );
 
 impl Deref for ForbiddenUsesConfig {

--- a/crates/zizmor/src/config/schema.rs
+++ b/crates/zizmor/src/config/schema.rs
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_empty_rules() {
         let empty = "rules: {}";
-        let instance = serde_yaml::from_str::<serde_json::Value>(empty).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(empty).unwrap();
 
         SCHEMA_VALIDATOR
             .validate(&instance)
@@ -181,7 +181,7 @@ mod tests {
           unpinned-uses:
             disable: false
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(disabled).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(disabled).unwrap();
 
         SCHEMA_VALIDATOR
             .validate(&instance)
@@ -198,7 +198,7 @@ mod tests {
               - foo.yml:10
               - foo.yml:10:20
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(ignore).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(ignore).unwrap();
 
         SCHEMA_VALIDATOR
             .validate(&instance)
@@ -211,7 +211,7 @@ mod tests {
             ignore:
               - foo.yml:invalid
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(invalid_ignore).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(invalid_ignore).unwrap();
         let errors = SCHEMA_VALIDATOR.iter_errors(&instance).into_errors();
         insta::assert_snapshot!(errors, @r#"
         Validation errors:
@@ -226,7 +226,7 @@ mod tests {
           this-audit-does-not-exist:
             disable: false
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(unknown_audit).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(unknown_audit).unwrap();
 
         let result = SCHEMA_VALIDATOR.validate(&instance);
         assert!(result.is_err(), "unknown audit should be invalid");
@@ -243,7 +243,7 @@ mod tests {
                 - actions/setup-node@v3
                 - foo/*
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(forbidden_uses_allow).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(forbidden_uses_allow).unwrap();
 
         SCHEMA_VALIDATOR
             .validate(&instance)
@@ -258,7 +258,7 @@ mod tests {
                 - actions/setup-node@v1
                 - foo/*
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(forbidden_uses_deny).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(forbidden_uses_deny).unwrap();
 
         SCHEMA_VALIDATOR
             .validate(&instance)
@@ -276,7 +276,7 @@ mod tests {
                 - ALSO_NOT_SO_SECRET
         "#;
 
-        let instance = serde_yaml::from_str::<serde_json::Value>(secrets_allow).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(secrets_allow).unwrap();
         SCHEMA_VALIDATOR
             .validate(&instance)
             .expect("secrets-outside-env allow config should be valid");
@@ -294,7 +294,7 @@ mod tests {
               - foo.yml
         "#;
 
-        let instance = serde_yaml::from_str::<serde_json::Value>(secrets_allow).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(secrets_allow).unwrap();
         SCHEMA_VALIDATOR
             .validate(&instance)
             .expect("secrets-outside-env allow config with base config should be valid");
@@ -309,7 +309,7 @@ mod tests {
               policies:
                 actions/checkout: hash-pin
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(valid).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(valid).unwrap();
         SCHEMA_VALIDATOR
             .validate(&instance)
             .expect("unpinned uses config should be valid");
@@ -321,7 +321,7 @@ mod tests {
               policies:
                 actions/checkout: unknown-policy
         "#;
-        let instance = serde_yaml::from_str::<serde_json::Value>(unknown_policy).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(unknown_policy).unwrap();
         let errors = SCHEMA_VALIDATOR.iter_errors(&instance).into_errors();
         insta::assert_snapshot!(errors, @r#"
         Validation errors:
@@ -333,7 +333,7 @@ mod tests {
     fn test_remap_severity() {
         for sev in ["informational", "low", "medium", "high"] {
             let yaml = format!("rules:\n  artipacked:\n    remap:\n      severity: {sev}");
-            let instance = serde_yaml::from_str::<serde_json::Value>(&yaml).unwrap();
+            let instance = yaml_serde::from_str::<serde_json::Value>(&yaml).unwrap();
             SCHEMA_VALIDATOR
                 .validate(&instance)
                 .unwrap_or_else(|_| panic!("severity '{sev}' should be valid in remap"));
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn test_remap_invalid_severity() {
         let invalid = "rules:\n  artipacked:\n    remap:\n      severity: Ultra";
-        let instance = serde_yaml::from_str::<serde_json::Value>(invalid).unwrap();
+        let instance = yaml_serde::from_str::<serde_json::Value>(invalid).unwrap();
         assert!(
             SCHEMA_VALIDATOR.validate(&instance).is_err(),
             "unknown severity 'Ultra' should be invalid"

--- a/crates/zizmor/src/models/workflow/matrix.rs
+++ b/crates/zizmor/src/models/workflow/matrix.rs
@@ -131,7 +131,7 @@ impl<'doc> Expansions<'doc> {
     }
 
     fn expand_explicit_rows(
-        include: &IndexMap<String, serde_yaml::Value>,
+        include: &IndexMap<String, yaml_serde::Value>,
         base: SymbolicLocation<'doc>,
     ) -> Vec<Expansion<'doc>> {
         let normalized = include
@@ -143,7 +143,7 @@ impl<'doc> Expansions<'doc> {
     }
 
     fn expand_dimensions(
-        dimensions: &IndexMap<String, LoE<Vec<serde_yaml::Value>>>,
+        dimensions: &IndexMap<String, LoE<Vec<yaml_serde::Value>>>,
         base: SymbolicLocation<'doc>,
     ) -> Vec<Expansion<'doc>> {
         let normalized = dimensions

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -35,7 +35,7 @@ pub(crate) enum CollectionError {
     /// The input couldn't be converted into the expected model.
     /// This typically indicates a bug in `github-actions-models`.
     #[error("couldn't turn input into a an appropriate model")]
-    Model(#[from] serde_yaml::Error),
+    Model(#[from] yaml_serde::Error),
 
     /// The input couldn't be loaded into an internal yamlpath document.
     /// This typically indicates a bug in `yamlpath`.

--- a/crates/zizmor/src/utils.rs
+++ b/crates/zizmor/src/utils.rs
@@ -333,7 +333,7 @@ fn parse_validation_errors(errors: Vec<ErrorEntry<'_>>) -> Error {
     anyhow!(message)
 }
 
-/// Like `serde_yaml::from_str`, but with a JSON schema validator
+/// Like `yaml_serde::from_str`, but with a JSON schema validator
 /// and an error type that distinguishes between syntax and semantic
 /// errors.
 pub(crate) fn from_str_with_validation<'de, T>(
@@ -343,33 +343,33 @@ pub(crate) fn from_str_with_validation<'de, T>(
 where
     T: serde::Deserialize<'de>,
 {
-    match serde_yaml::from_str::<T>(contents) {
+    match yaml_serde::from_str::<T>(contents) {
         Ok(value) => Ok(value),
         Err(e) => {
             // Something a little wonky happens here: we want
             // to distinguish between syntax and semantic errors,
             // but serde-yaml doesn't give us an API to do that.
             // To approximate it, we re-parse the input as a
-            // `serde_yaml::Mapping`, then convert that `serde_yaml::Mapping`
+            // `yaml_serde::Mapping`, then convert that `yaml_serde::Mapping`
             // into a `serde_json::Value` and use it as an oracle -- a successful
             // re-parse indicates that the input is valid YAML and
             // that our error is semantic, while a failed re-parse
             // indicates a syntax error.
             //
-            // We need to round-trip through a `serde_yaml::Mapping` to ensure that
+            // We need to round-trip through a `yaml_serde::Mapping` to ensure that
             // all of YAML's validity rules are preserved -- directly deserializing
             // into a `serde_json::Value` would miss some YAML-specific checks,
             // like duplicate keys within mappings. See #1395 for an example of this.
             //
             // We do this in a nested fashion to avoid re-parsing
             // the input twice if we can help it, and because the
-            // more obvious trick (`serde_yaml::from_value`) doesn't
+            // more obvious trick (`yaml_serde::from_value`) doesn't
             // work due to a lack of referential transparency.
             //
             // See: https://github.com/dtolnay/serde-yaml/issues/170
             // See: https://github.com/dtolnay/serde-yaml/issues/395
 
-            match serde_yaml::from_str::<serde_yaml::Mapping>(contents) {
+            match yaml_serde::from_str::<yaml_serde::Mapping>(contents) {
                 // We know we have valid YAML, so one of two things happened here:
                 // 1. The input is semantically valid, but we have a bug in
                 //    `github-actions-models`.


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes #2014.

Note: I ignored the commit in the `.git-blame-ignore-revs` file, because it touches many files and creates unnecessary diffs and blames. I recommend merging the PR without squashing it to preserve the commit SHA in that file.

## Test Plan

Locally verified before pushing:

- `cargo check --workspace --all-targets --all-features` — passes.
- `cargo fmt --all -- --check` — passes.
- `cargo test -p github-actions-models -p yamlpath -p yamlpatch --all-features` — all unit, integration, and doc tests pass.
- `GH_TOKEN=<fake> cargo test -p zizmor` — 245 passed, 25 ignored, 0 failed. Network-dependent tests require a token to exercise the code path that constructs `github::Client`; once the token is present they all pass.