### PR TITLE
unpinned-tools: fix trivy action being detected

### DIFF
--- a/crates/zizmor/src/audit/unpinned_tools.rs
+++ b/crates/zizmor/src/audit/unpinned_tools.rs
@@ -13,7 +13,7 @@ use crate::utils::ExtractedExpr;
 use super::AuditLoadError;
 
 static KNOWN_UNPINNED_TOOLS_ACTIONS: &[&str] =
-    &["aquasecurity/trivy-action", "1password/load-secrets-action"];
+    &["aquasecurity/setup-trivy", "1password/load-secrets-action"];
 
 pub(crate) struct UnpinnedTools;
 

--- a/crates/zizmor/tests/integration/audit/unpinned_tools.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_tools.rs
@@ -6,16 +6,16 @@ fn test_regular_persona() -> anyhow::Result<()> {
     warning[unpinned-tools]: action installs an unpinned external tool
       --> @@INPUT@@:16:15
        |
-    16 |       - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action implicitly uses an unpinned latest version
+    16 |       - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action implicitly uses an unpinned latest version
        |
        = note: audit confidence → High
 
     warning[unpinned-tools]: action installs an unpinned external tool
       --> @@INPUT@@:19:11
        |
-    17 |       - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-       |               ------------------------------------------------------------------ this action
+    17 |       - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+       |               ----------------------------------------------------------------- this action
     18 |         with:
     19 |           version: latest
        |           ^^^^^^^^^^^^^^^ specifies `version: latest` which is unpinned
@@ -44,8 +44,8 @@ fn test_regular_persona() -> anyhow::Result<()> {
     warning[unpinned-tools]: action installs an unpinned external tool
       --> @@INPUT@@:26:11
        |
-    24 |       - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-       |               ------------------------------------------------------------------ this action
+    24 |       - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+       |               ----------------------------------------------------------------- this action
     25 |         with:
     26 |           version: ${{ inputs.trivy-version }}
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ specifies `version` dynamically, which may be unpinned

--- a/crates/zizmor/tests/integration/test-data/unpinned-tools.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-tools.yml
@@ -13,14 +13,14 @@ jobs:
     name: artipacked
     runs-on: ubuntu-latest
     steps:
-      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+      - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+      - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
         with:
           version: latest
       - uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
       - uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           version: latest
-      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+      - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
         with:
           version: ${{ inputs.trivy-version }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,12 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where the [unpinned-tools] audit would incorrectly flag the
+  @aquasecurity/trivy-action action as installing an unpinned tool version,
+  rather than @aquasecurity/setup-trivy (#2018)
+
 ## 1.25.1
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
Closes #2007. Closes #2017.