### PR TITLE
Match dependabot.yaml files in language server

### DIFF
--- a/crates/zizmor/src/lsp.rs
+++ b/crates/zizmor/src/lsp.rs
@@ -267,7 +267,7 @@ impl Backend {
                 params.text,
                 InputKey::local("lsp".into(), path, None),
             )?)
-        } else if matches!(path.file_name(), Some("dependabot.yml")) {
+        } else if matches!(path.file_name(), Some("dependabot.yml" | "dependabot.yaml")) {
             AuditInput::from(Dependabot::from_string(
                 params.text,
                 InputKey::local("lsp".into(), path, None),

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,13 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where zizmor's LSP would not recognize `dependabot.yaml` files in its
+  default configuration (#2026)
+
+    Many thanks to @fionn for implementing this fix!
+
 ## 1.25.2
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
The language server understands that Dependabot files match `**/.github/dependabot.{yml,yaml}`, however later on we check for `dependabot.yml` explicitly, thus excluding `dependabot.yaml` files.

We add `dependabot.yaml` as a file name to match against in the same manner as our matches for `action.yml` or `action.yaml`.

This has been tested in Neovim with the standard `nvim-lspconfig` settings, using
```lua
vim.lsp.config("zizmor", {
    cmd = {"/path/to/zizmor/target/debug/zizmor", "--lsp"}
})
```
to override the executable.

Closes: #2025

---

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.