### PR TITLE
feat(shellcheck): add shellcheck wrapper audit rule

### DIFF
--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod ref_version_mismatch;
 pub(crate) mod secrets_inherit;
 pub(crate) mod secrets_outside_env;
 pub(crate) mod self_hosted_runner;
+pub(crate) mod shellcheck;
 pub(crate) mod stale_action_refs;
 pub(crate) mod superfluous_actions;
 pub(crate) mod template_injection;

--- a/crates/zizmor/src/audit/shellcheck.rs
+++ b/crates/zizmor/src/audit/shellcheck.rs
@@ -198,14 +198,25 @@ impl ShellcheckAudit {
                 vec![]
             });
 
-        tracing::debug!("shellcheck diagnostics: {diagnostics:#?}");
+        let run_location = step.location().primary().with_keys(["run".into()]);
+
+        // Determine the indentation offset of the run: block.
+        // It will be used to calculate the exact offset of findings below.
+        let run_point = run_location
+            .clone()
+            .concretize(step.document())
+            .map_err(Self::err)?
+            .concrete
+            .location
+            .start_point;
 
         diagnostics
             .into_iter()
             .map(|diagnostic| {
+                // find the code fragment inside the inspected shell script
                 let offset = Self::diagnostic_span(run, &diagnostic);
                 let end_offset = if diagnostic.end_line == diagnostic.line {
-                    let line_start = offset - diagnostic.column.saturating_sub(1);
+                    let line_start = offset.saturating_sub(diagnostic.column.saturating_sub(1));
                     line_start + diagnostic.end_column.saturating_sub(1)
                 } else {
                     run[offset..].find('\n').map_or(run.len(), |n| offset + n)
@@ -213,14 +224,19 @@ impl ShellcheckAudit {
                 let end_offset = end_offset.min(run.len());
                 let fragment = &run[offset..end_offset];
 
-                let location = step.location().primary().with_keys(["run".into()]);
+                // shellcheck findings columns don't take YAML indentation into account.
+                // Adjust the diagnostic offset using the position of the run block within the YAML document,
+                // so that the correct occurrence of the fragment is found in the raw YAML text.
+                let after =
+                    (diagnostic.line.saturating_sub(1) * run_point.column).saturating_add(offset);
 
                 let location = if !fragment.is_empty() {
-                    location
-                        .subfeature(Subfeature::new(offset, fragment))
+                    run_location
+                        .clone()
+                        .subfeature(Subfeature::new(after, fragment))
                         .annotated(format!("SC{}: {}", diagnostic.code, diagnostic.message))
                 } else {
-                    location.annotated(format!(
+                    run_location.clone().annotated(format!(
                         "SC{} at line {}, column {}: {}",
                         diagnostic.code, diagnostic.line, diagnostic.column, diagnostic.message
                     ))

--- a/crates/zizmor/src/audit/shellcheck.rs
+++ b/crates/zizmor/src/audit/shellcheck.rs
@@ -1,0 +1,289 @@
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+use anyhow::anyhow;
+use serde::Deserialize;
+use subfeature::Subfeature;
+
+use crate::{
+    audit::{Audit, AuditError, AuditLoadError, audit_meta},
+    config::Config,
+    finding::{Confidence, Finding, Persona, Severity},
+    models::{StepBodyCommon, StepCommon, action::CompositeStep, workflow::Step},
+    state::AuditState,
+    utils,
+};
+
+pub(crate) struct ShellcheckAudit {
+    executable: String,
+}
+
+audit_meta!(
+    ShellcheckAudit,
+    "shellcheck",
+    "shellcheck finding in shell run block"
+);
+
+#[derive(Debug, Deserialize)]
+struct ShellcheckOutput {
+    comments: Vec<ShellcheckDiagnostic>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ShellcheckDiagnostic {
+    line: usize,
+    column: usize,
+    end_line: usize,
+    end_column: usize,
+    level: String,
+    code: usize,
+    message: String,
+}
+
+impl ShellcheckAudit {
+    fn supported_shell(shell: &str) -> bool {
+        matches!(shell, "sh" | "bash" | "dash" | "ksh" | "zsh")
+    }
+
+    fn known_non_posix_shell(shell: &str) -> bool {
+        matches!(shell, "pwsh" | "powershell" | "cmd")
+    }
+
+    fn shellcheck_shell(shell: &str) -> &str {
+        match shell {
+            // shellcheck doesn't support zsh mode directly; bash is the closest mode.
+            "zsh" => "bash",
+            other => other,
+        }
+    }
+
+    fn severity_for_level(level: &str) -> Severity {
+        match level {
+            "error" => Severity::Medium,
+            "warning" => Severity::Low,
+            "info" | "style" => Severity::Informational,
+            _ => Severity::Low,
+        }
+    }
+
+    /// Convert shellcheck's 1-based line/column into a byte offset within
+    /// the script content.
+    fn diagnostic_span(script: &str, diagnostic: &ShellcheckDiagnostic) -> usize {
+        let mut offset = 0usize;
+        for (i, line) in script.lines().enumerate() {
+            if i + 1 == diagnostic.line {
+                return offset + diagnostic.column.saturating_sub(1);
+            }
+            offset += line.len() + 1;
+        }
+        0
+    }
+
+    fn resolved_shell<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+        config: &Config,
+    ) -> Option<(
+        String,
+        Option<crate::finding::location::SymbolicLocation<'doc>>,
+    )> {
+        let detected = step.shell();
+
+        let Some((shell, shell_location)) = detected else {
+            if !config.shellcheck_config.check_unknown_shells {
+                tracing::debug!(
+                    "skipping shellcheck on run block: shell is unknown (not statically resolvable) and check-unknown-shells is disabled"
+                );
+                return None;
+            }
+
+            return Some(("bash".to_string(), None));
+        };
+
+        let normalized = utils::normalize_shell(shell);
+        if Self::supported_shell(normalized) {
+            return Some((
+                Self::shellcheck_shell(normalized).to_string(),
+                Some(shell_location),
+            ));
+        }
+
+        if Self::known_non_posix_shell(normalized) {
+            tracing::debug!(
+                "skipping shellcheck on run block: shell '{normalized}' is a known non-POSIX shell not supported by shellcheck"
+            );
+            return None;
+        }
+
+        if !config.shellcheck_config.check_unknown_shells {
+            tracing::debug!(
+                "skipping shellcheck on run block: shell '{normalized}' is unknown and check-unknown-shells is disabled"
+            );
+            return None;
+        }
+
+        Some((
+            "bash".to_string(),
+            Some(shell_location.annotated("unknown shell treated as bash")),
+        ))
+    }
+
+    fn run_shellcheck(
+        &self,
+        shell: &str,
+        script: &str,
+    ) -> Result<Vec<ShellcheckDiagnostic>, AuditError> {
+        let mut child = Command::new(&self.executable)
+            // SC2296 errors are caused by templating syntax ${{ ... }} that shellcheck doesn't understand.
+            .args(["--format", "json1", "--shell", shell, "-", "-e", "SC2296"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(Self::err)?;
+
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(script.as_bytes()).map_err(Self::err)?;
+        }
+
+        let output = child.wait_with_output().map_err(Self::err)?;
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        if !output.status.success() && exit_code != 1 {
+            tracing::debug!(
+                "shellcheck returned non-diagnostic exit code {exit_code}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Ok(vec![]);
+        }
+
+        if output.stdout.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let parsed: ShellcheckOutput = match serde_json::from_slice(&output.stdout) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::debug!(
+                    "failed to parse shellcheck output: {error}; stderr: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                return Ok(vec![]);
+            }
+        };
+
+        Ok(parsed.comments)
+    }
+
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+        config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let StepBodyCommon::Run { run, .. } = step.body() else {
+            return Ok(vec![]);
+        };
+
+        let Some((shellcheck_shell, shell_location)) = self.resolved_shell(step, config) else {
+            return Ok(vec![]);
+        };
+
+        let diagnostics = self
+            .run_shellcheck(&shellcheck_shell, run)
+            .unwrap_or_else(|error| {
+                tracing::debug!("shellcheck failed to run: {error}");
+                vec![]
+            });
+
+        tracing::debug!("shellcheck diagnostics: {diagnostics:#?}");
+
+        diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                let offset = Self::diagnostic_span(run, &diagnostic);
+                let end_offset = if diagnostic.end_line == diagnostic.line {
+                    let line_start = offset - diagnostic.column.saturating_sub(1);
+                    line_start + diagnostic.end_column.saturating_sub(1)
+                } else {
+                    run[offset..].find('\n').map_or(run.len(), |n| offset + n)
+                };
+                let end_offset = end_offset.min(run.len());
+                let fragment = &run[offset..end_offset];
+
+                let location = step.location().primary().with_keys(["run".into()]);
+
+                let location = if !fragment.is_empty() {
+                    location
+                        .subfeature(Subfeature::new(offset, fragment))
+                        .annotated(format!("SC{}: {}", diagnostic.code, diagnostic.message))
+                } else {
+                    location.annotated(format!(
+                        "SC{} at line {}, column {}: {}",
+                        diagnostic.code, diagnostic.line, diagnostic.column, diagnostic.message
+                    ))
+                };
+
+                let mut builder = Self::finding()
+                    .severity(Self::severity_for_level(&diagnostic.level))
+                    .confidence(Confidence::High)
+                    .persona(Persona::Regular)
+                    .add_location(location);
+
+                if let Some(shell_location) = shell_location.clone() {
+                    builder = builder.add_location(shell_location.key_only());
+                }
+
+                builder
+                    .tip(format!(
+                        "shellcheck rule reference: https://www.shellcheck.net/wiki/SC{}",
+                        diagnostic.code
+                    ))
+                    .build(step)
+            })
+            .collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl Audit for ShellcheckAudit {
+    fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
+    where
+        Self: Sized,
+    {
+        let executable = "shellcheck".into();
+
+        match Command::new(&executable)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+        {
+            Ok(status) if status.success() => Ok(Self { executable }),
+            Ok(status) => Err(AuditLoadError::Skip(anyhow!(
+                "`{executable} --version` exited with {status}"
+            ))),
+            Err(error) => Err(AuditLoadError::Skip(anyhow!(
+                "`{executable}` unavailable ({error})"
+            ))),
+        }
+    }
+
+    async fn audit_step<'doc>(
+        &self,
+        step: &Step<'doc>,
+        config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        self.process_step(step, config)
+    }
+
+    async fn audit_composite_step<'doc>(
+        &self,
+        step: &CompositeStep<'doc>,
+        config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        self.process_step(step, config)
+    }
+}

--- a/crates/zizmor/src/audit/shellcheck.rs
+++ b/crates/zizmor/src/audit/shellcheck.rs
@@ -44,6 +44,30 @@ struct ShellcheckDiagnostic {
 }
 
 impl ShellcheckAudit {
+
+    fn sanitize_shellcheck_script(script: &str) -> String {
+        // Removes template expressions like ${{ ... }} from the script.
+        // Replaces them with whitespace of the same length,
+        // so that the offsets of the remaining code are unchanged for accurate diagnostics.
+        let mut sanitized = String::with_capacity(script.len());
+        let mut cursor = 0;
+
+        for (_, span) in utils::extract_fenced_expressions(script) {
+            if span.start > cursor {
+                sanitized.push_str(&script[cursor..span.start]);
+            }
+            
+            sanitized.push_str(&"_".repeat(span.end - span.start));
+            cursor = span.end;
+        }
+
+        if cursor < script.len() {
+            sanitized.push_str(&script[cursor..]);
+        }
+
+        sanitized
+    }
+
     fn supported_shell(shell: &str) -> bool {
         matches!(shell, "sh" | "bash" | "dash" | "ksh" | "zsh")
     }
@@ -191,8 +215,10 @@ impl ShellcheckAudit {
             return Ok(vec![]);
         };
 
+        let shellcheck_script = Self::sanitize_shellcheck_script(run);
+
         let diagnostics = self
-            .run_shellcheck(&shellcheck_shell, run)
+            .run_shellcheck(&shellcheck_shell, &shellcheck_script)
             .unwrap_or_else(|error| {
                 tracing::debug!("shellcheck failed to run: {error}");
                 vec![]

--- a/crates/zizmor/src/audit/shellcheck.rs
+++ b/crates/zizmor/src/audit/shellcheck.rs
@@ -161,8 +161,7 @@ impl ShellcheckAudit {
         script: &str,
     ) -> Result<Vec<ShellcheckDiagnostic>, AuditError> {
         let mut child = Command::new(&self.executable)
-            // SC2296 errors are caused by templating syntax ${{ ... }} that shellcheck doesn't understand.
-            .args(["--format", "json1", "--shell", shell, "-", "-e", "SC2296"])
+            .args(["--format", "json1", "--shell", shell, "-"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/zizmor/src/config/mod.rs
+++ b/crates/zizmor/src/config/mod.rs
@@ -22,7 +22,8 @@ use crate::{
     App, CollectionOptions,
     audit::{
         AuditCore, dependabot_cooldown::DependabotCooldown, forbidden_uses::ForbiddenUses,
-        secrets_outside_env::SecretsOutsideEnvironment, unpinned_uses::UnpinnedUses,
+        secrets_outside_env::SecretsOutsideEnvironment, shellcheck::ShellcheckAudit,
+        unpinned_uses::UnpinnedUses,
     },
     finding::{Finding, Severity},
     github::{Client, ClientError},
@@ -280,6 +281,16 @@ pub(crate) struct SecretsOutsideEnvConfig {
     pub(crate) allow: Vec<String>,
 }
 
+/// Configuration for the `shellcheck` audit.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub(crate) struct ShellcheckConfig {
+    /// Assume that workflow steps with runtime-derived runner labels use a bash-compatible shell.
+    pub(crate) check_unknown_shells: bool,
+}
+
 /// Policy to evaluate secrets references
 #[derive(Clone, Debug)]
 pub(crate) struct SecretsOutsideEnvPolicy {
@@ -480,6 +491,7 @@ pub(crate) struct Config {
     pub(crate) dependabot_cooldown_config: DependabotCooldownConfig,
     pub(crate) forbidden_uses_config: Option<ForbiddenUsesConfig>,
     pub(crate) secrets_outside_env_policy: SecretsOutsideEnvPolicy,
+    pub(crate) shellcheck_config: ShellcheckConfig,
     pub(crate) unpinned_uses_policies: UnpinnedUsesPolicies,
 }
 
@@ -500,6 +512,10 @@ impl Config {
             .map(Into::into)
             .unwrap_or_default();
 
+        let shellcheck_config = raw
+            .rule_config(ShellcheckAudit::ident())?
+            .unwrap_or_default();
+
         let unpinned_uses_policies = {
             if let Some(unpinned_uses_config) =
                 raw.rule_config::<UnpinnedUsesConfig>(UnpinnedUses::ident())?
@@ -515,6 +531,7 @@ impl Config {
             dependabot_cooldown_config,
             forbidden_uses_config,
             secrets_outside_env_policy,
+            shellcheck_config,
             unpinned_uses_policies,
         })
     }

--- a/crates/zizmor/src/config/schema.rs
+++ b/crates/zizmor/src/config/schema.rs
@@ -13,7 +13,7 @@ use schemars::JsonSchema;
 
 use super::{
     DependabotCooldownConfig, ForbiddenUsesConfig, RemapConfig, SecretsOutsideEnvConfig,
-    UnpinnedUsesConfig, WorkflowRule,
+    ShellcheckConfig, UnpinnedUsesConfig, WorkflowRule,
 };
 
 /// Base configuration for all audit rules.
@@ -74,6 +74,17 @@ struct UnpinnedUsesRuleConfig {
     config: UnpinnedUsesConfig,
 }
 
+/// Configuration for the `shellcheck` audit.
+#[derive(Debug, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ShellcheckRuleConfig {
+    #[serde(flatten)]
+    base: BaseRuleConfig,
+
+    #[serde(default)]
+    config: ShellcheckConfig,
+}
+
 macro_rules! define_audit_rules {
     (
         $( $field:ident ),* $(,)?
@@ -130,6 +141,7 @@ define_audit_rules! {
     [DependabotCooldownRuleConfig] dependabot_cooldown,
     [ForbiddenUsesRuleConfig] forbidden_uses,
     [SecretsOutsideEnvRuleConfig] secrets_outside_env,
+    [ShellcheckRuleConfig] shellcheck,
     [UnpinnedUsesRuleConfig] unpinned_uses,
 }
 

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -80,6 +80,7 @@ impl AuditRegistry {
         register_audit!(audit::superfluous_actions::SuperfluousActions);
         register_audit!(audit::github_app::GitHubApp);
         register_audit!(audit::unpinned_tools::UnpinnedTools);
+        register_audit!(audit::shellcheck::ShellcheckAudit);
 
         Ok(registry)
     }

--- a/crates/zizmor/tests/integration/audit/mod.rs
+++ b/crates/zizmor/tests/integration/audit/mod.rs
@@ -25,6 +25,7 @@ mod ref_version_mismatch;
 mod secrets_inherit;
 mod secrets_outside_env;
 mod self_hosted_runner;
+mod shellcheck;
 mod stale_action_refs;
 mod superfluous_actions;
 mod template_injection;

--- a/crates/zizmor/tests/integration/audit/shellcheck.rs
+++ b/crates/zizmor/tests/integration/audit/shellcheck.rs
@@ -136,3 +136,116 @@ fn test_shellcheck_check_unknown_shells_config() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_shellcheck_with_template_expressions() -> Result<()> {
+    if !shellcheck_available() {
+        return Ok(());
+    }
+
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "shellcheck/template-in-run.yml"
+            ))
+            .setenv("PATH", &inherited_path())
+            .run()?,
+        @r#"
+    error[template-injection]: code injection via template expansion
+      --> @@INPUT@@:13:27
+       |
+    12 |         run: |
+       |         --- this run block
+    13 |           echo "hello ${{ github.actor }}"
+       |                           ^^^^^^^^^^^^ may expand into attacker-controllable code
+       |
+       = note: audit confidence → High
+       = note: this finding has an auto-fix
+
+    3 findings (2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_shellcheck_multiple_findings() -> Result<()> {
+    if !shellcheck_available() {
+        return Ok(());
+    }
+
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "shellcheck/multiple-issues.yml"
+            ))
+            .setenv("PATH", &inherited_path())
+            .run()?,
+        @"
+    error[template-injection]: code injection via template expansion
+      --> @@INPUT@@:14:20
+       |
+    12 |         run: |
+       |         --- this run block
+    13 |           cd $UNQUOTED_DIR
+    14 |           echo ${{ github.ref }}
+       |                    ^^^^^^^^^^ may expand into attacker-controllable code
+       |
+       = note: audit confidence → High
+       = note: this finding has an auto-fix
+
+    error[template-injection]: code injection via template expansion
+      --> @@INPUT@@:15:20
+       |
+    12 |         run: |
+       |         --- this run block
+    ...
+    15 |           echo ${{ github.actor }}
+       |                    ^^^^^^^^^^^^ may expand into attacker-controllable code
+       |
+       = note: audit confidence → High
+       = note: this finding has an auto-fix
+
+    help[shellcheck]: shellcheck finding in shell run block
+      --> @@INPUT@@:13:11
+       |
+     9 |     runs-on: ubuntu-latest
+       |     ------- shell implied by runner
+    ...
+    13 |           cd $UNQUOTED_DIR
+       |           ^^^^^^^^^^^^^^^^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+       |
+       = note: audit confidence → High
+       = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2164
+
+    info[shellcheck]: shellcheck finding in shell run block
+      --> @@INPUT@@:13:14
+       |
+     9 |     runs-on: ubuntu-latest
+       |     ------- shell implied by runner
+    ...
+    13 |           cd $UNQUOTED_DIR
+       |              ^^^^^^^^^^^^^ SC2086: Double quote to prevent globbing and word splitting.
+       |
+       = note: audit confidence → High
+       = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2086
+
+    warning[shellcheck]: shellcheck finding in shell run block
+      --> @@INPUT@@:16:14
+       |
+     9 |     runs-on: ubuntu-latest
+       |     ------- shell implied by runner
+    ...
+    16 |           if $@; then
+       |              ^^ SC2068: Double quote array expansions to avoid re-splitting elements.
+       |
+       = note: audit confidence → High
+       = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2068
+
+    7 findings (2 suppressed, 2 unsafe fixes): 1 informational, 1 low, 1 medium, 2 high
+    "
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/audit/shellcheck.rs
+++ b/crates/zizmor/tests/integration/audit/shellcheck.rs
@@ -1,0 +1,138 @@
+use std::process::Command;
+
+use anyhow::Result;
+
+use crate::common::{input_under_test, zizmor};
+
+fn inherited_path() -> String {
+    std::env::var("PATH").unwrap_or_default()
+}
+
+fn shellcheck_available() -> bool {
+    Command::new("shellcheck")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+#[test]
+fn test_shellcheck_not_in_path() -> Result<()> {
+    let output = zizmor()
+        .input(input_under_test("shellcheck/positive.yml"))
+        .setenv("PATH", "")
+        .run()?;
+
+    assert!(
+        !output.contains("[shellcheck]"),
+        "unexpected shellcheck finding while binary is missing: {output}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_shellcheck_ignores_non_shell_run_steps() -> Result<()> {
+    let output = zizmor()
+        .input(input_under_test("shellcheck/non-shell.yml"))
+        .setenv("PATH", &inherited_path())
+        .run()?;
+
+    assert!(
+        !output.contains("[shellcheck]"),
+        "unexpected shellcheck finding for non-shell run step: {output}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_shellcheck_reports_when_available() -> Result<()> {
+    if !shellcheck_available() {
+        return Ok(());
+    }
+
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "shellcheck/positive.yml"
+            ))
+            .setenv("PATH", &inherited_path())
+            .run()?,
+        @"
+    info[shellcheck]: shellcheck finding in shell run block
+      --> @@INPUT@@:17:19
+       |
+    14 |     runs-on: ubuntu-latest
+       |     ------- shell implied by runner
+    ...
+    17 |         run: echo $FOO
+       |                   ^^^^ SC2086: Double quote to prevent globbing and word splitting.
+       |
+       = note: audit confidence → High
+       = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2086
+
+    1 finding: 1 informational, 0 low, 0 medium, 0 high
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_shellcheck_ignore_unknown_shells() -> Result<()> {
+    if !shellcheck_available() {
+        return Ok(());
+    }
+
+    insta::assert_snapshot!(
+        zizmor()
+        .input(input_under_test("shellcheck/unknown-shell.yml"))
+        .setenv("PATH", &inherited_path())
+        .run()?,
+        @"No findings to report. Good job!"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_shellcheck_check_unknown_shells_config() -> Result<()> {
+    if !shellcheck_available() {
+        return Ok(());
+    }
+
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "shellcheck/unknown-shell.yml"
+            ))
+            .config(
+                input_under_test("shellcheck/configs/check-unknown-shells.yml")
+            )
+            .setenv("PATH", &inherited_path())
+            .run()?,
+        @"
+    info[shellcheck]: shellcheck finding in shell run block
+      --> @@INPUT@@:17:19
+       |
+    17 |         run: echo $FOO
+       |                   ^^^^ SC2086: Double quote to prevent globbing and word splitting.
+       |
+       = note: audit confidence → High
+       = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2086
+
+    info[shellcheck]: shellcheck finding in shell run block
+      --> @@INPUT@@:24:19
+       |
+    24 |         run: echo $FOO
+       |                   ^^^^ SC2086: Double quote to prevent globbing and word splitting.
+       |
+       = note: audit confidence → High
+       = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2086
+
+    2 findings: 2 informational, 0 low, 0 medium, 0 high
+    "
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/shellcheck/configs/check-unknown-shells.yml
+++ b/crates/zizmor/tests/integration/test-data/shellcheck/configs/check-unknown-shells.yml
@@ -1,0 +1,4 @@
+rules:
+  shellcheck:
+    config:
+      check-unknown-shells: true

--- a/crates/zizmor/tests/integration/test-data/shellcheck/multiple-issues.yml
+++ b/crates/zizmor/tests/integration/test-data/shellcheck/multiple-issues.yml
@@ -1,0 +1,19 @@
+name: shellcheck-multiple-templates
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: multiple templates then shell issue
+        run: |
+          cd $UNQUOTED_DIR
+          echo ${{ github.ref }}
+          echo ${{ github.actor }}
+          if $@; then
+            echo "This will cause a shellcheck error due to the unquoted variable."
+          fi
+

--- a/crates/zizmor/tests/integration/test-data/shellcheck/non-shell.yml
+++ b/crates/zizmor/tests/integration/test-data/shellcheck/non-shell.yml
@@ -1,0 +1,10 @@
+name: shellcheck-non-shell
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: windows-latest
+    steps:
+      - name: windows shell default
+        run: Write-Output "$env:FOO"

--- a/crates/zizmor/tests/integration/test-data/shellcheck/positive.yml
+++ b/crates/zizmor/tests/integration/test-data/shellcheck/positive.yml
@@ -1,0 +1,17 @@
+name: shellcheck-positive
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.base_ref == main }}
+
+jobs:
+  shellcheck:
+    name: Shellcheck True Positive
+    runs-on: ubuntu-latest
+    steps:
+      - name: unquoted variable
+        run: echo $FOO

--- a/crates/zizmor/tests/integration/test-data/shellcheck/template-in-run.yml
+++ b/crates/zizmor/tests/integration/test-data/shellcheck/template-in-run.yml
@@ -1,0 +1,13 @@
+name: shellcheck-template-in-run
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: template then unquoted variable
+        run: |
+          echo "hello ${{ github.actor }}"

--- a/crates/zizmor/tests/integration/test-data/shellcheck/unknown-shell.yml
+++ b/crates/zizmor/tests/integration/test-data/shellcheck/unknown-shell.yml
@@ -1,0 +1,24 @@
+name: shellcheck-unknown-shell
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.base_ref == main }}
+
+jobs:
+  shellcheck-unknown-runner:
+    name: shellcheck should default to bash when runner type is not recognized
+    runs-on: ${{ vars.RUNNER }}
+    steps:
+      - name: unknown runner should default to bash
+        run: echo $FOO
+  shellcheck-unknown-shell:
+    name: shellcheck should default to bash when shell is not recognized
+    runs-on: ubuntu-latest
+    steps:
+      - name: unknown shell should default to bash
+        shell: ${{ vars.SHELL }}
+        run: echo $FOO

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1551,7 +1551,7 @@ there are steps you can take to minimize their risk:
 
 | Type     | Examples                | Introduced in | Works offline  | Auto-fixes available | Configurable |
 |----------|-------------------------|---------------|----------------|--------------------|--------------|
-| Workflow, Action | N/A            | v1.25.0       | ✅             | ❌                 | ❌           |
+| Workflow, Action | N/A            | v1.26.0       | ✅             | ❌                 | ✅           |
 
 Runs [ShellCheck] against `#!yaml run:` blocks that resolve to POSIX/Bourne-family shells.
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1547,6 +1547,36 @@ there are steps you can take to minimize their risk:
 
 [ephemeral ("just-in-time") runners]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-just-in-time-runners
 
+## `shellcheck`
+
+| Type     | Examples                | Introduced in | Works offline  | Auto-fixes available | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------|--------------|
+| Workflow, Action | N/A            | v1.25.0       | ✅             | ❌                 | ❌           |
+
+Runs [ShellCheck] against `#!yaml run:` blocks that resolve to POSIX/Bourne-family shells.
+
+This audit currently runs on `sh`, `bash`, `dash`, `ksh`, and `zsh` run blocks.
+`cmd`, `pwsh` are skipped. Unknown or expression-derived shells are skipped, unless
+`rules.shellcheck.config.check-unknown-shells` is set to `true`.
+
+!!! note
+
+    This audit depends on the `shellcheck` binary being available in `PATH`.
+    If `shellcheck` is unavailable, this audit is skipped.
+
+    [Error SC2296](https://www.shellcheck.net/wiki/SC2296) that triggers when
+    using templating syntax `${{ ... }}` is ignored to avoid false positives.
+
+### Remediation
+
+Address the reported ShellCheck diagnostics in your `run:` scripts. Typical fixes include:
+
+* Quoting variable expansions (for example, changing `echo $FOO` to `echo "$FOO"`).
+* Avoiding fragile globbing and word splitting patterns.
+* Using more robust shell constructs suggested by ShellCheck.
+
+[ShellCheck]: https://www.shellcheck.net/
+
 ## `stale-action-refs`
 
 | Type     | Examples                | Introduced in | Works offline  | Auto-fixes available | Configurable |


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create one first). #1595

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. AI tool was used to generate part of the code, which I then manually reviewed, cleaned from slop and improved.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

This audit rule runs `shellcheck` on `run:` blocks that are considered to contain shell scripts, as discussed in #1595.

[Shellcheck](https://www.shellcheck.net/) is the de-facto open-source SAST tool for shell scripts. It can detect a large range of security/quality/readability issues.

Such shell scripts are embedded into YAML syntax, so it is difficult to "extract" them then run them trough SAST without using proper tools. `zizmor` is a good candidate for such tools since it is already a dedicated SAST for GitHub Actions.

Implementing the same checks and rules that `shellcheck` already supports into `zizmor`  would be inneficient and a duplication of efforts.

Note that `actionlint` already wraps shellcheck. The reporting of found issues, however, is less readable than those produced using this PR, which points to the exact location of the issue:

```
info[shellcheck]: shellcheck finding in shell run block
  --> crates/zizmor/tests/integration/test-data/shellcheck/positive.yml:17:19
   |
14 |     runs-on: ubuntu-latest
   |     ------- shell implied by runner
...
17 |         run: echo $FOO
   |                   ^^^^ SC2086: Double quote to prevent globbing and word splitting.
   |
   = note: audit confidence → High
   = tip: shellcheck rule reference: https://www.shellcheck.net/wiki/SC2086

1 finding: 1 informational, 0 low, 0 medium, 0 high
```

The main difficulty is to make sure that shellcheck is ran only on shell scripts and nothing else. Since the shell is often implicitly derived from the configured `run-on:` parameter, we cannot always assume that the shell is bash.
So by default, shells that are not explicitly set to bash or bash compatible are ignored and this audit is skipped.
A config option `check-unknown-shell` is available to consider unknown shell as bash, thus triggering the shellcheck rule.
Explicitly setting a `shell: bash` for each job is another good option (or a [default run shell](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell) is a good approach, may be worth another audit?

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

Added specific test cases for `shellcheck`:
- if shellcheck is not available in PATH, rule is not triggered
- if shellsheck is available, check that it is correctly triggered and findings are appropriately reported
- 2 test cases with unknown (var-derived) shells, with and without config option `check-unknown-shell`
