### PR TITLE
fix(ci): correct typw=raw typo in release-docker.yml

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -135,7 +135,7 @@ jobs:
           images: "${{ env.ZIZMOR_IMAGE }}"
           tags: |
             type=raw,value=${{ github.event.inputs.version }}
-            typw=raw,value=latest,enable=${{ github.event.inputs.latest }}
+            type=raw,value=latest,enable=${{ github.event.inputs.latest }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).
  - Apologies for skipping this, but there's no option for project internal issues, and filing a full bug report seemed overkill for this. (No option to skip the template either).
- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary
The `latest` tag entry in `release-docker.yml` had `typw=raw` instead of `type=raw`. This does not appear to be a functional issue; `docker/metadata-action` ignores unknown attributes and defaults a typeless line to raw, so the `:latest` tag was still emitted correctly when `inputs.latest` was true. Fixing just for consistency, but I this should be a no-op.

## Test Plan
N/A