### PR TITLE
Remove dependency on serde-sarif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +153,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -424,7 +414,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -657,7 +647,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -932,7 +922,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1743,7 +1733,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2042,7 +2032,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2153,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2297,7 +2287,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2571,33 +2561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemafy_core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemafy_lib"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "schemafy_core",
- "serde",
- "serde_derive",
- "serde_json",
- "syn 1.0.109",
- "uriparse",
-]
-
-[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,7 +2582,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2674,26 +2637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-sarif"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "schemafy_lib",
- "serde",
- "serde_json",
- "strum",
- "strum_macros",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "typed-builder",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,7 +2653,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2721,7 +2664,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2785,7 +2728,7 @@ checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2927,24 +2870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "subfeature"
 version = "1.25.2"
 dependencies = [
@@ -2958,17 +2883,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2998,7 +2912,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3110,7 +3024,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3121,7 +3035,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3232,7 +3146,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3380,7 +3294,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3499,26 +3413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typed-builder"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,16 +3477,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "uriparse"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
-dependencies = [
- "fnv",
- "lazy_static",
-]
 
 [[package]]
 name = "url"
@@ -3776,7 +3660,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3949,7 +3833,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3960,7 +3844,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4308,7 +4192,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4324,7 +4208,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4457,7 +4341,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4478,7 +4362,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4498,7 +4382,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4538,7 +4422,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4578,7 +4462,6 @@ dependencies = [
  "reqwest-middleware",
  "schemars",
  "serde",
- "serde-sarif",
  "serde_json",
  "serde_json_path",
  "subfeature",
@@ -4598,6 +4481,15 @@ dependencies = [
  "yaml_serde",
  "yamlpatch",
  "yamlpath",
+ "zizmor-sarif",
+]
+
+[[package]]
+name = "zizmor-sarif"
+version = "1.25.2"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "zizmor-sarif"
-version = "0.0.1"
+version = "1.25.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "zizmor-sarif"
-version = "1.25.2"
+version = "0.0.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ subfeature = { path = "crates/subfeature", version = "1.25.2" }
 tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.25.2" }
 yamlpath = { path = "crates/yamlpath", version = "1.25.2" }
 yamlpatch = { path = "crates/yamlpatch", version = "1.25.2" }
-zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.25.2" }
+zizmor-sarif = { path = "crates/zizmor-sarif", version = "0.0.1" }
 
 anyhow = "1.0.102"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/yamlpatch",
     "crates/yamlpath",
     "crates/zizmor",
+    "crates/zizmor-sarif",
 ]
 
 [workspace.package]
@@ -26,6 +27,7 @@ subfeature = { path = "crates/subfeature", version = "1.25.2" }
 tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.25.2" }
 yamlpath = { path = "crates/yamlpath", version = "1.25.2" }
 yamlpatch = { path = "crates/yamlpatch", version = "1.25.2" }
+zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.25.2" }
 
 anyhow = "1.0.102"
 itertools = "0.14.0"
@@ -63,7 +65,6 @@ reqwest-middleware = "0.5.1"
 self_cell = "1"
 schemars = "1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-serde-sarif = "0.8.0"
 serde_json = "1.0.149"
 serde_json_path = "0.7.2"
 yaml_serde = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ subfeature = { path = "crates/subfeature", version = "1.25.2" }
 tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.25.2" }
 yamlpath = { path = "crates/yamlpath", version = "1.25.2" }
 yamlpatch = { path = "crates/yamlpatch", version = "1.25.2" }
-zizmor-sarif = { path = "crates/zizmor-sarif", version = "0.0.1" }
+zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.25.2" }
 
 anyhow = "1.0.102"
 itertools = "0.14.0"

--- a/crates/README.md
+++ b/crates/README.md
@@ -12,6 +12,7 @@ See the table and each subdirectory for more details on each crate.
 | [`github-actions-models`][github-actions-models-dir] | [![Crates.io](https://img.shields.io/crates/v/github-actions-models)][github-actions-models-crates] | [![docs.rs](https://img.shields.io/docsrs/github-actions-models)][github-actions-models-docs] | Unofficial, high-quality data models for GitHub Actions workflows, actions, and related components. |
 | [`github-actions-expressions`][github-actions-expressions-dir] | [![Crates.io](https://img.shields.io/crates/v/github-actions-expressions)][github-actions-expressions-crates] | [![docs.rs](https://img.shields.io/docsrs/github-actions-expressions)][github-actions-expressions-docs] | Parser and library for GitHub Actions expressions. |
 | [`tree-sitter-iter`][tree-sitter-iter-dir] | [![Crates.io](https://img.shields.io/crates/v/tree-sitter-iter)][tree-sitter-iter-crates] | [![docs.rs](https://img.shields.io/docsrs/tree-sitter-iter)][tree-sitter-iter-docs] | A very simple pre-order iterator for tree-sitter CSTs. |
+| [`zizmor-sarif`][zizmor-sarif-dir] | [![Crates.io](https://img.shields.io/crates/v/zizmor-sarif)][zizmor-sarif-crates] | [![docs.rs](https://img.shields.io/docsrs/zizmor-sarif)][zizmor-sarif-docs] | Minimal SARIF 2.1.0 data models used by `zizmor`. |
 
 [zizmor-dir]: ./zizmor
 [zizmor-crates]: https://crates.io/crates/zizmor
@@ -40,3 +41,7 @@ See the table and each subdirectory for more details on each crate.
 [tree-sitter-iter-dir]: ./tree-sitter-iter
 [tree-sitter-iter-crates]: https://crates.io/crates/tree-sitter-iter
 [tree-sitter-iter-docs]: https://docs.rs/tree-sitter-iter
+
+[zizmor-sarif-dir]: ./zizmor-sarif
+[zizmor-sarif-crates]: https://crates.io/crates/zizmor-sarif
+[zizmor-sarif-docs]: https://docs.rs/zizmor-sarif

--- a/crates/zizmor-sarif/Cargo.toml
+++ b/crates/zizmor-sarif/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "zizmor-sarif"
+description = "Minimal SARIF 2.1.0 data models used by zizmor"
+repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/zizmor-sarif"
+readme = "README.md"
+
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/crates/zizmor-sarif/Cargo.toml
+++ b/crates/zizmor-sarif/Cargo.toml
@@ -4,8 +4,7 @@ description = "Minimal SARIF 2.1.0 data models used by zizmor"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/zizmor-sarif"
 readme = "README.md"
 
-version = "0.0.1"
-# version.workspace = true
+version.workspace = true
 authors.workspace = true
 homepage.workspace = true
 edition.workspace = true

--- a/crates/zizmor-sarif/Cargo.toml
+++ b/crates/zizmor-sarif/Cargo.toml
@@ -4,7 +4,8 @@ description = "Minimal SARIF 2.1.0 data models used by zizmor"
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/zizmor-sarif"
 readme = "README.md"
 
-version.workspace = true
+version = "0.0.1"
+# version.workspace = true
 authors.workspace = true
 homepage.workspace = true
 edition.workspace = true

--- a/crates/zizmor-sarif/README.md
+++ b/crates/zizmor-sarif/README.md
@@ -1,0 +1,13 @@
+# `zizmor-sarif`
+
+Minimal in-tree data models for [SARIF 2.1.0] — covering only the
+fields that [`zizmor`] currently emits as output.
+
+This crate is workspace-internal: it is not intended to be a general
+SARIF library and only models the subset of the specification needed
+to produce zizmor's `--format=sarif` output. If you need a complete
+SARIF crate for parsing or generation outside zizmor, use one of the
+existing community crates (e.g. `serde-sarif`).
+
+[SARIF 2.1.0]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+[`zizmor`]: https://github.com/zizmorcore/zizmor

--- a/crates/zizmor-sarif/README.md
+++ b/crates/zizmor-sarif/README.md
@@ -1,13 +1,23 @@
-# `zizmor-sarif`
+# zizmor-sarif
 
-Minimal in-tree data models for [SARIF 2.1.0] — covering only the
-fields that [`zizmor`] currently emits as output.
+[![zizmor](https://img.shields.io/badge/%F0%9F%8C%88-zizmor-white?labelColor=white)](https://zizmor.sh/)
+[![CI](https://github.com/zizmorcore/zizmor/actions/workflows/ci.yml/badge.svg)](https://github.com/zizmorcore/zizmor/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/zizmor-sarif)](https://crates.io/crates/zizmor-sarif)
+[![docs.rs](https://img.shields.io/docsrs/zizmor-sarif)](https://docs.rs/zizmor-sarif)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/woodruffw?style=flat&logo=githubsponsors&labelColor=white&color=white)](https://github.com/sponsors/woodruffw)
+[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/PGU3zGZuGG)
 
-This crate is workspace-internal: it is not intended to be a general
-SARIF library and only models the subset of the specification needed
-to produce zizmor's `--format=sarif` output. If you need a complete
-SARIF crate for parsing or generation outside zizmor, use one of the
-existing community crates (e.g. `serde-sarif`).
+Minimal data models for [SARIF 2.1.0], covering only the fields that
+[zizmor] currently emits as output.
+
+This crate is part of [zizmor].
+
+If you need a more complete SARIF crate, consider [`serde-sarif`].
+
+## License
+
+MIT License.
 
 [SARIF 2.1.0]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
-[`zizmor`]: https://github.com/zizmorcore/zizmor
+[zizmor]: https://zizmor.sh
+[`serde-sarif`]: https://crates.io/crates/serde-sarif

--- a/crates/zizmor-sarif/src/lib.rs
+++ b/crates/zizmor-sarif/src/lib.rs
@@ -1,0 +1,311 @@
+//! Minimal in-tree data models for [SARIF 2.1.0].
+//!
+//! Only the subset of SARIF that `zizmor` actually emits is modelled.
+//!
+//! [SARIF 2.1.0]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// Top-level SARIF log object (SARIF §3.13).
+#[derive(Debug, Clone, Serialize)]
+pub struct Sarif {
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    pub runs: Vec<Run>,
+    pub version: String,
+}
+
+/// A single tool invocation's results (SARIF §3.14).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Run {
+    pub invocations: Vec<Invocation>,
+    pub results: Vec<Result>,
+    pub tool: Tool,
+}
+
+/// Tool metadata wrapper (SARIF §3.18).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Tool {
+    pub driver: ToolComponent,
+}
+
+/// Tool driver metadata (SARIF §3.19).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolComponent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub download_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub information_uri: Option<String>,
+    pub name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<ReportingDescriptor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// Invocation describing the tool execution (SARIF §3.20).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Invocation {
+    pub execution_successful: bool,
+}
+
+/// A reporting descriptor, i.e. a rule definition (SARIF §3.49).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportingDescriptor {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<MultiformatMessageString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_uri: Option<String>,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<PropertyBag>,
+}
+
+/// Plain-text + markdown message (SARIF §3.12).
+#[derive(Debug, Clone, Serialize)]
+pub struct MultiformatMessageString {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub markdown: Option<String>,
+    pub text: String,
+}
+
+/// Property bag (SARIF §3.8).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PropertyBag {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(flatten)]
+    pub additional_properties: BTreeMap<String, serde_json::Value>,
+}
+
+/// A single finding within a run (SARIF §3.27).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Result {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub code_flows: Vec<CodeFlow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ResultKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<ResultLevel>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub locations: Vec<Location>,
+    pub message: Message,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<PropertyBag>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
+}
+
+/// A human-readable message (SARIF §3.11).
+#[derive(Debug, Clone, Serialize)]
+pub struct Message {
+    pub text: String,
+}
+
+/// A location (SARIF §3.28).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Location {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub logical_locations: Vec<LogicalLocation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_location: Option<PhysicalLocation>,
+}
+
+/// A logical location (SARIF §3.33).
+#[derive(Debug, Clone, Serialize)]
+pub struct LogicalLocation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<PropertyBag>,
+}
+
+/// A physical location (SARIF §3.29).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PhysicalLocation {
+    pub artifact_location: ArtifactLocation,
+    pub region: Region,
+}
+
+/// Pointer to a single artifact (SARIF §3.4).
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactLocation {
+    pub uri: String,
+}
+
+/// A region within an artifact (SARIF §3.30).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Region {
+    pub end_column: i64,
+    pub end_line: i64,
+    pub snippet: ArtifactContent,
+    pub source_language: String,
+    pub start_column: i64,
+    pub start_line: i64,
+}
+
+/// The literal contents of a region (SARIF §3.3).
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactContent {
+    pub text: String,
+}
+
+/// A code flow (SARIF §3.36) — a sequence of [`ThreadFlow`]s.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodeFlow {
+    pub thread_flows: Vec<ThreadFlow>,
+}
+
+/// A thread flow (SARIF §3.37).
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreadFlow {
+    pub locations: Vec<ThreadFlowLocation>,
+}
+
+/// A location within a thread flow (SARIF §3.38).
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreadFlowLocation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub importance: Option<ThreadFlowLocationImportance>,
+    pub location: Location,
+}
+
+/// Classification of a result (SARIF §3.27.9). Serialized as a lowercase
+/// string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResultKind {
+    NotApplicable,
+    Pass,
+    Fail,
+    Review,
+    Open,
+    Informational,
+}
+
+/// Severity of a result (SARIF §3.27.10).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResultLevel {
+    None,
+    Note,
+    Warning,
+    Error,
+}
+
+/// Importance of a thread-flow location (SARIF §3.38.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThreadFlowLocationImportance {
+    Essential,
+    Important,
+    Unimportant,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ArtifactContent, ArtifactLocation, Invocation, Location, Message, PhysicalLocation,
+        PropertyBag, Region, ReportingDescriptor, Result, ResultKind, ResultLevel, Run, Sarif,
+        ThreadFlowLocationImportance, Tool, ToolComponent,
+    };
+
+    /// Minimal end-to-end serialization.
+    #[test]
+    fn serializes_minimal_document_in_expected_shape() {
+        let sarif = Sarif {
+            schema: Some("https://example/schema".into()),
+            runs: vec![Run {
+                invocations: vec![Invocation {
+                    execution_successful: true,
+                }],
+                results: vec![Result {
+                    code_flows: vec![],
+                    kind: Some(ResultKind::Fail),
+                    level: Some(ResultLevel::Error),
+                    locations: vec![Location {
+                        id: None,
+                        logical_locations: vec![],
+                        message: Some(Message {
+                            text: "primary".into(),
+                        }),
+                        physical_location: Some(PhysicalLocation {
+                            artifact_location: ArtifactLocation {
+                                uri: "wf.yml".into(),
+                            },
+                            region: Region {
+                                end_column: 2,
+                                end_line: 3,
+                                snippet: ArtifactContent { text: "x".into() },
+                                source_language: "yaml".into(),
+                                start_column: 1,
+                                start_line: 2,
+                            },
+                        }),
+                    }],
+                    message: Message { text: "msg".into() },
+                    properties: None,
+                    rule_id: Some("zizmor/example".into()),
+                }],
+                tool: Tool {
+                    driver: ToolComponent {
+                        download_uri: None,
+                        information_uri: None,
+                        name: "zizmor".into(),
+                        rules: vec![ReportingDescriptor {
+                            help: None,
+                            help_uri: None,
+                            id: "zizmor/example".into(),
+                            name: Some("example".into()),
+                            properties: Some(PropertyBag {
+                                tags: vec!["security".into()],
+                                additional_properties: Default::default(),
+                            }),
+                        }],
+                        semantic_version: None,
+                        version: None,
+                    },
+                },
+            }],
+            version: "2.1.0".into(),
+        };
+
+        // Use compact serialization for the assertion so we test key order
+        // independent of pretty-printer whitespace.
+        let json = serde_json::to_string(&sarif).expect("serialization failed");
+        let expected = r#"{"$schema":"https://example/schema","runs":[{"invocations":[{"executionSuccessful":true}],"results":[{"kind":"fail","level":"error","locations":[{"message":{"text":"primary"},"physicalLocation":{"artifactLocation":{"uri":"wf.yml"},"region":{"endColumn":2,"endLine":3,"snippet":{"text":"x"},"sourceLanguage":"yaml","startColumn":1,"startLine":2}}}],"message":{"text":"msg"},"ruleId":"zizmor/example"}],"tool":{"driver":{"name":"zizmor","rules":[{"id":"zizmor/example","name":"example","properties":{"tags":["security"]}}]}}}],"version":"2.1.0"}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn importance_serializes_as_lowercase_string() {
+        assert_eq!(
+            serde_json::to_string(&ThreadFlowLocationImportance::Essential)
+                .expect("serialization failed"),
+            "\"essential\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ThreadFlowLocationImportance::Important)
+                .expect("serialization failed"),
+            "\"important\""
+        );
+    }
+}

--- a/crates/zizmor-sarif/src/lib.rs
+++ b/crates/zizmor-sarif/src/lib.rs
@@ -1,6 +1,6 @@
-//! Minimal in-tree data models for [SARIF 2.1.0].
+//! Minimal, zizmor-specialized data models for [SARIF 2.1.0].
 //!
-//! Only the subset of SARIF that `zizmor` actually emits is modelled.
+//! Only the subset of SARIF that `zizmor` actually needs is modelled.
 //!
 //! [SARIF 2.1.0]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
 

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -61,7 +61,6 @@ reqwest = { workspace = true, features = ["json", "query", "rustls"] }
 reqwest-middleware = { workspace = true, features = ["query"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde-sarif.workspace = true
 serde_json.workspace = true
 yaml_serde.workspace = true
 subfeature.workspace = true
@@ -79,6 +78,7 @@ tree-sitter-powershell.workspace = true
 typomania.workspace = true
 yamlpath.workspace = true
 yamlpatch.workspace = true
+zizmor-sarif.workspace = true
 
 [target.'cfg(not(any(target_family = "windows", target_os = "openbsd")))'.dependencies]
 tikv-jemallocator.workspace = true

--- a/crates/zizmor/src/output/sarif.rs
+++ b/crates/zizmor/src/output/sarif.rs
@@ -1,12 +1,12 @@
 //! SARIF output.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
-use serde_sarif::sarif::{
+use zizmor_sarif::{
     ArtifactContent, ArtifactLocation, CodeFlow, Invocation, Location as SarifLocation,
     LogicalLocation, Message, MultiformatMessageString, PhysicalLocation, PropertyBag, Region,
     ReportingDescriptor, Result as SarifResult, ResultKind, ResultLevel, Run, Sarif, ThreadFlow,
-    ThreadFlowLocation, Tool, ToolComponent,
+    ThreadFlowLocation, ThreadFlowLocationImportance, Tool, ToolComponent,
 };
 
 use crate::finding::{Finding, Severity, location::Location};
@@ -35,35 +35,34 @@ impl From<Severity> for ResultLevel {
 }
 
 pub(crate) fn build(findings: &[Finding]) -> Sarif {
-    Sarif::builder()
-        .version("2.1.0")
-        .schema("https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json")
-        .runs([build_run(findings)])
-        .build()
+    Sarif {
+        schema: Some(
+            "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
+                .into(),
+        ),
+        runs: vec![build_run(findings)],
+        version: "2.1.0".into(),
+    }
 }
 
 fn build_run(findings: &[Finding]) -> Run {
-    Run::builder()
-        .tool(
-            Tool::builder()
-                .driver(
-                    ToolComponent::builder()
-                        .name(env!("CARGO_CRATE_NAME"))
-                        .version(env!("CARGO_PKG_VERSION"))
-                        .semantic_version(env!("CARGO_PKG_VERSION"))
-                        .download_uri(env!("CARGO_PKG_REPOSITORY"))
-                        .information_uri(env!("CARGO_PKG_HOMEPAGE"))
-                        .rules(build_rules(findings))
-                        .build(),
-                )
-                .build(),
-        )
-        .results(build_results(findings))
-        .invocations([Invocation::builder()
+    Run {
+        invocations: vec![Invocation {
             // We only produce results on successful executions.
-            .execution_successful(true)
-            .build()])
-        .build()
+            execution_successful: true,
+        }],
+        results: build_results(findings),
+        tool: Tool {
+            driver: ToolComponent {
+                download_uri: Some(env!("CARGO_PKG_REPOSITORY").into()),
+                information_uri: Some(env!("CARGO_PKG_HOMEPAGE").into()),
+                name: env!("CARGO_CRATE_NAME").into(),
+                rules: build_rules(findings),
+                semantic_version: Some(env!("CARGO_PKG_VERSION").into()),
+                version: Some(env!("CARGO_PKG_VERSION").into()),
+            },
+        },
+    }
 }
 
 fn build_rules(findings: &[Finding]) -> Vec<ReportingDescriptor> {
@@ -77,18 +76,19 @@ fn build_rules(findings: &[Finding]) -> Vec<ReportingDescriptor> {
 }
 
 fn build_rule(finding: &Finding) -> ReportingDescriptor {
-    ReportingDescriptor::builder()
-        .id(format!("zizmor/{id}", id = finding.ident))
-        .name(finding.ident)
-        .help_uri(finding.url)
-        .help(
-            MultiformatMessageString::builder()
-                .text(finding.desc)
-                .markdown(finding.to_markdown())
-                .build(),
-        )
-        .properties(PropertyBag::builder().tags(["security".into()]).build())
-        .build()
+    ReportingDescriptor {
+        help: Some(MultiformatMessageString {
+            markdown: Some(finding.to_markdown()),
+            text: finding.desc.into(),
+        }),
+        help_uri: Some(finding.url.into()),
+        id: format!("zizmor/{id}", id = finding.ident),
+        name: Some(finding.ident.into()),
+        properties: Some(PropertyBag {
+            tags: vec!["security".into()],
+            additional_properties: BTreeMap::new(),
+        }),
+    }
 }
 
 fn build_results(findings: &[Finding]) -> Vec<SarifResult> {
@@ -100,144 +100,117 @@ fn build_result(finding: &Finding<'_>) -> SarifResult {
 
     // Build code flows for better visualization of location chains.
     // GitHub renders these as step-by-step traces in security alerts.
-    let code_flows = {
-        let thread_flow_locations: Vec<ThreadFlowLocation> = finding
-            .visible_locations()
-            .map(|loc| {
-                let importance = if loc.symbolic.is_primary() {
-                    "essential"
-                } else {
-                    "important"
-                };
-                ThreadFlowLocation::builder()
-                    .location(build_location(loc, None))
-                    // See: <https://github.com/psastras/sarif-rs/pull/972>
-                    .importance(serde_json::Value::String(importance.into()))
-                    .build()
-            })
-            .collect();
-        vec![
-            CodeFlow::builder()
-                .thread_flows(vec![
-                    ThreadFlow::builder()
-                        .locations(thread_flow_locations)
-                        .build(),
-                ])
-                .build(),
-        ]
-    };
+    let thread_flow_locations: Vec<ThreadFlowLocation> = finding
+        .visible_locations()
+        .map(|loc| {
+            let importance = if loc.symbolic.is_primary() {
+                ThreadFlowLocationImportance::Essential
+            } else {
+                ThreadFlowLocationImportance::Important
+            };
+            ThreadFlowLocation {
+                importance: Some(importance),
+                location: build_location(loc, None),
+            }
+        })
+        .collect();
+    let code_flows = vec![CodeFlow {
+        thread_flows: vec![ThreadFlow {
+            locations: thread_flow_locations,
+        }],
+    }];
 
-    SarifResult::builder()
-        .rule_id(format!("zizmor/{id}", id = finding.ident))
+    let mut additional_properties = BTreeMap::new();
+    additional_properties.insert(
+        "zizmor/confidence".into(),
+        serde_json::value::to_value(finding.determinations.confidence)
+            .expect("failed to serialize confidence"),
+    );
+    additional_properties.insert(
+        "zizmor/severity".into(),
+        serde_json::value::to_value(finding.determinations.severity)
+            .expect("failed to serialize severity"),
+    );
+    additional_properties.insert(
+        "zizmor/persona".into(),
+        serde_json::value::to_value(finding.determinations.persona)
+            .expect("failed to serialize persona"),
+    );
+
+    SarifResult {
+        code_flows,
+        kind: Some(ResultKind::from(finding.determinations.severity)),
+        level: Some(ResultLevel::from(finding.determinations.severity)),
+        locations: vec![build_location(primary, None)],
         // NOTE: Between 1.4.0 and 1.9.0 we used the primary location's
         // annotation for the message here. This produced a _slightly_
         // nicer message in some cases, but also produced meaningless
         // code security alert titles when the primary annotation was
         // terse. So now we use the finding's description again, like
         // we did before 1.4.0.
-        .message(
-            Message::builder()
-                .text(format!(
-                    "{desc}: {annotation}",
-                    desc = finding.desc,
-                    annotation = primary.symbolic.annotation
-                ))
-                .build(),
-        )
-        .locations(vec![build_location(primary, None)])
-        .code_flows(code_flows)
-        .level(ResultLevel::from(finding.determinations.severity))
-        .kind(ResultKind::from(finding.determinations.severity))
-        .properties(
-            PropertyBag::builder()
-                .additional_properties([
-                    (
-                        "zizmor/confidence".into(),
-                        serde_json::value::to_value(finding.determinations.confidence)
-                            .expect("failed to serialize confidence"),
-                    ),
-                    (
-                        "zizmor/severity".into(),
-                        serde_json::value::to_value(finding.determinations.severity)
-                            .expect("failed to serialize severity"),
-                    ),
-                    (
-                        "zizmor/persona".into(),
-                        serde_json::value::to_value(finding.determinations.persona)
-                            .expect("failed to serialize persona"),
-                    ),
-                ])
-                .build(),
-        )
-        .build()
+        message: Message {
+            text: format!(
+                "{desc}: {annotation}",
+                desc = finding.desc,
+                annotation = primary.symbolic.annotation
+            ),
+        },
+        properties: Some(PropertyBag {
+            tags: vec![],
+            additional_properties,
+        }),
+        rule_id: Some(format!("zizmor/{id}", id = finding.ident)),
+    }
 }
 
 fn build_physical_location(location: &Location<'_>) -> PhysicalLocation {
-    PhysicalLocation::builder()
-        .artifact_location(
-            ArtifactLocation::builder()
-                .uri(location.symbolic.key.sarif_path())
-                .build(),
-        )
-        .region(
-            Region::builder()
-                // NOTE: SARIF lines/columns are 1-based.
-                .start_line((location.concrete.location.start_point.row as i64) + 1)
-                .end_line((location.concrete.location.end_point.row as i64) + 1)
-                .start_column((location.concrete.location.start_point.column as i64) + 1)
-                .end_column((location.concrete.location.end_point.column as i64) + 1)
-                .source_language("yaml")
-                .snippet(
-                    ArtifactContent::builder()
-                        .text(location.concrete.feature)
-                        .build(),
-                )
-                .build(),
-        )
-        .build()
+    PhysicalLocation {
+        artifact_location: ArtifactLocation {
+            uri: location.symbolic.key.sarif_path().into(),
+        },
+        region: Region {
+            // NOTE: SARIF lines/columns are 1-based.
+            end_column: (location.concrete.location.end_point.column as i64) + 1,
+            end_line: (location.concrete.location.end_point.row as i64) + 1,
+            snippet: ArtifactContent {
+                text: location.concrete.feature.into(),
+            },
+            source_language: "yaml".into(),
+            start_column: (location.concrete.location.start_point.column as i64) + 1,
+            start_line: (location.concrete.location.start_point.row as i64) + 1,
+        },
+    }
 }
 
 fn build_logical_locations(location: &Location<'_>) -> Vec<LogicalLocation> {
-    vec![
-        LogicalLocation::builder()
-            .properties(
-                PropertyBag::builder()
-                    .additional_properties([(
-                        "symbolic".into(),
-                        serde_json::value::to_value(location.symbolic.clone())
-                            .expect("failed to serialize symbolic location"),
-                    )])
-                    .build(),
-            )
-            .build(),
-    ]
+    let mut additional_properties = BTreeMap::new();
+    additional_properties.insert(
+        "symbolic".into(),
+        serde_json::value::to_value(location.symbolic.clone())
+            .expect("failed to serialize symbolic location"),
+    );
+    vec![LogicalLocation {
+        properties: Some(PropertyBag {
+            tags: vec![],
+            additional_properties,
+        }),
+    }]
 }
 
 fn build_location(location: &Location<'_>, id: Option<i64>) -> SarifLocation {
-    let message = Message::builder()
-        .text(location.symbolic.annotation.as_ref())
-        .build();
-    let physical = build_physical_location(location);
-    let logical = build_logical_locations(location);
-
-    match id {
-        Some(id) => SarifLocation::builder()
-            .id(id)
-            .logical_locations(logical)
-            .physical_location(physical)
-            .message(message)
-            .build(),
-        None => SarifLocation::builder()
-            .logical_locations(logical)
-            .physical_location(physical)
-            .message(message)
-            .build(),
+    SarifLocation {
+        id,
+        logical_locations: build_logical_locations(location),
+        message: Some(Message {
+            text: location.symbolic.annotation.as_ref().into(),
+        }),
+        physical_location: Some(build_physical_location(location)),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_sarif::sarif::ResultKind;
+    use zizmor_sarif::ResultKind;
 
     use crate::finding::Severity;
 


### PR DESCRIPTION
The goal here is to preserve our existing SARIF serialization precisely, while removing our dependency on serde-sarif (which has been slow to uptake patches, unfortunately, plus comes with a large dependency stack).

The main cost to doing this is a new workspace member (`zizmor-sarif`), which only implements the exact subset of SARIF we need (without a builder API, since we can just omit the fields that don't concern us).

