### PR TITLE
fix(dependabot-cooldown): honor configured minimum days

### DIFF
--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -16,6 +16,7 @@ impl DependabotCooldown {
     /// Creates a fix that adds default-days to an existing cooldown block
     fn create_add_default_days_fix<'doc>(
         update: crate::models::dependabot::Update<'doc>,
+        days: u64,
     ) -> Fix<'doc> {
         Fix {
             title: "add default-days to cooldown".to_string(),
@@ -25,7 +26,7 @@ impl DependabotCooldown {
                 route: update.location().route.with_keys(["cooldown".into()]),
                 operation: Op::Add {
                     key: "default-days".to_string(),
-                    value: yaml_serde::Value::Number(7.into()),
+                    value: yaml_serde::Value::Number(days.into()),
                 },
             }],
         }
@@ -34,9 +35,10 @@ impl DependabotCooldown {
     /// Creates a fix that increases an insufficient default-days value
     fn create_increase_default_days_fix<'doc>(
         update: crate::models::dependabot::Update<'doc>,
+        days: u64,
     ) -> Fix<'doc> {
         Fix {
-            title: "increase default-days to 7".to_string(),
+            title: format!("increase default-days to {days}"),
             key: update.location().key,
             disposition: FixDisposition::Safe,
             patches: vec![Patch {
@@ -44,13 +46,16 @@ impl DependabotCooldown {
                     .location()
                     .route
                     .with_keys(["cooldown".into(), "default-days".into()]),
-                operation: Op::Replace(yaml_serde::Value::Number(7.into())),
+                operation: Op::Replace(yaml_serde::Value::Number(days.into())),
             }],
         }
     }
 
     /// Creates a fix that adds a cooldown block with default-days
-    fn create_add_cooldown_fix<'doc>(update: crate::models::dependabot::Update<'doc>) -> Fix<'doc> {
+    fn create_add_cooldown_fix<'doc>(
+        update: crate::models::dependabot::Update<'doc>,
+        days: u64,
+    ) -> Fix<'doc> {
         Fix {
             title: "add cooldown configuration".to_string(),
             key: update.location().key,
@@ -63,7 +68,7 @@ impl DependabotCooldown {
                         let mut map = yaml_serde::Mapping::new();
                         map.insert(
                             yaml_serde::Value::String("default-days".to_string()),
-                            yaml_serde::Value::Number(7.into()),
+                            yaml_serde::Value::Number(days.into()),
                         );
                         map
                     }),
@@ -88,6 +93,7 @@ impl Audit for DependabotCooldown {
         config: &crate::config::Config,
     ) -> Result<Vec<crate::finding::Finding<'doc>>, AuditError> {
         let mut findings = vec![];
+        let minimum_days = config.dependabot_cooldown_config.days.get() as u64;
 
         for update in dependabot.updates() {
             // Check for cooldown + multi-ecosystem-group interaction.
@@ -149,12 +155,10 @@ impl Audit for DependabotCooldown {
                             )
                             .confidence(Confidence::High)
                             .severity(Severity::Medium)
-                            .fix(Self::create_add_default_days_fix(update))
+                            .fix(Self::create_add_default_days_fix(update, minimum_days))
                             .build(dependabot)?,
                     ),
-                    Some(default_days)
-                        if default_days < config.dependabot_cooldown_config.days.get() as u64 =>
-                    {
+                    Some(default_days) if default_days < minimum_days => {
                         findings.push(
                             Self::finding()
                                 .add_location(
@@ -162,11 +166,15 @@ impl Audit for DependabotCooldown {
                                         .location()
                                         .with_keys(["cooldown".into(), "default-days".into()])
                                         .primary()
-                                        .annotated(format!("insufficient default-days configured (less than {days})", days = config.dependabot_cooldown_config.days)),
+                                        .annotated(format!(
+                                            "insufficient default-days configured (less than {minimum_days})"
+                                        )),
                                 )
                                 .confidence(Confidence::Medium)
                                 .severity(Severity::Low)
-                                .fix(Self::create_increase_default_days_fix(update))
+                                .fix(Self::create_increase_default_days_fix(
+                                    update, minimum_days,
+                                ))
                                 .build(dependabot)?,
                         )
                     }
@@ -182,7 +190,7 @@ impl Audit for DependabotCooldown {
                         )
                         .confidence(Confidence::High)
                         .severity(Severity::Medium)
-                        .fix(Self::create_add_cooldown_fix(update))
+                        .fix(Self::create_add_cooldown_fix(update, minimum_days))
                         .build(dependabot)?,
                 ),
             }

--- a/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
@@ -172,6 +172,33 @@ fn test_config_short_cooldown_permitted() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_configured_minimum_days_insufficient() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dependabot-cooldown/default-days-seven/dependabot.yml"
+            ))
+            .config(input_under_test(
+                "dependabot-cooldown/configs/cooldown-fourteen-days.yml"
+            ))
+            .run()?,
+        @"
+    help[dependabot-cooldown]: insufficient cooldown in Dependabot updates
+     --> @@INPUT@@:7:7
+      |
+    7 |       default-days: 7
+      |       ^^^^^^^^^^^^^^^ insufficient default-days configured (less than 14)
+      |
+      = note: audit confidence → Medium
+      = note: this finding has an auto-fix
+
+    1 findings (1 safe fixes): 0 informational, 1 low, 0 medium, 0 high
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn test_multi_ecosystem_group_with_cooldown() -> anyhow::Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/test-data/dependabot-cooldown/configs/cooldown-fourteen-days.yml
+++ b/crates/zizmor/tests/integration/test-data/dependabot-cooldown/configs/cooldown-fourteen-days.yml
@@ -1,0 +1,4 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 14

--- a/crates/zizmor/tests/integration/test-data/dependabot-cooldown/default-days-seven/dependabot.yml
+++ b/crates/zizmor/tests/integration/test-data/dependabot-cooldown/default-days-seven/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily
+    insecure-external-code-execution: deny


### PR DESCRIPTION
Use `rules.dependabot-cooldown.config.days` for audit checks and autofixes instead of hardcoding 7.  Add integration test for custom minimum.

<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Relates to issue https://github.com/zizmorcore/zizmor/issues/2047

AI: I'm not a Rust developer, so made use of Cursor to create this fix.  Only raising as a draft as I think someone with more Rust knowledge should take a deeper look! :) 

## Test Plan

Integration tests added.  

Also built and tested locally (MacOS) against Dependabot configuration files with and without cooldown config included, or cooldown values.   Example config tests included in raised issue: https://github.com/zizmorcore/zizmor/issues/2047