### PR TITLE
Add another cache control heuristic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,12 +618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +1008,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 name = "github-actions-expressions"
 version = "1.25.2"
 dependencies = [
- "pretty_assertions",
+ "insta",
  "serde",
  "serde_json",
  "subfeature",
@@ -2078,16 +2072,6 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
 ]
 
 [[package]]
@@ -4260,12 +4244,6 @@ dependencies = [
  "tree-sitter-yaml",
  "yaml_serde",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.25.2" }
 
 anyhow = "1.0.102"
 itertools = "0.14.0"
-pretty_assertions = "1.4.1"
 annotate-snippets = "0.12.16"
 anstream = "1.0.0"
 assert_cmd = "2.2.2"

--- a/crates/github-actions-expressions/Cargo.toml
+++ b/crates/github-actions-expressions/Cargo.toml
@@ -19,5 +19,5 @@ serde_json.workspace = true
 subfeature.workspace = true
 
 [dev-dependencies]
-pretty_assertions.workspace = true
+insta.workspace = true
 serde.workspace = true

--- a/crates/github-actions-expressions/src/lib.rs
+++ b/crates/github-actions-expressions/src/lib.rs
@@ -10,7 +10,7 @@ use crate::{
     context::Context,
     identifier::Identifier,
     literal::Literal,
-    op::{BinOp, UnOp},
+    op::{BinExpr, BinOp, UnOp},
 };
 
 pub mod call;
@@ -73,7 +73,11 @@ impl<'a> Origin<'a> {
 /// was parsed from, with no surrounding whitespace. A parenthesized expression
 /// includes its parentheses, so every span is a balanced, self-contained slice
 /// of the source.
-#[derive(Debug, PartialEq)]
+///
+/// NOTE: `SpannedExpr` has a manual [`PartialEq`] implementation that only considers
+/// the underlying expression, not the span. In opther words, two `SpannedExpr` instances
+/// are equal if their ASTs are equal, even if their source spans are not.
+#[derive(Debug)]
 pub struct SpannedExpr<'src> {
     /// The expression's source origin.
     pub origin: Origin<'src>,
@@ -115,11 +119,11 @@ impl<'a> SpannedExpr<'a> {
                     .iter()
                     .for_each(|part| contexts.extend(part.contexts()));
             }
-            Expr::BinOp { lhs, op: _, rhs } => {
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
                 contexts.extend(lhs.contexts());
                 contexts.extend(rhs.contexts());
             }
-            Expr::UnOp { op: _, expr } => contexts.extend(expr.contexts()),
+            Expr::UnExpr { op: _, expr } => contexts.extend(expr.contexts()),
             _ => (),
         }
 
@@ -155,7 +159,7 @@ impl<'a> SpannedExpr<'a> {
             // `Object` but `${{ fromJSON(something).foo }}` evaluates
             // to the contents of `something.foo`.
             Expr::Context(ctx) => contexts.push((ctx, &self.origin)),
-            Expr::BinOp { lhs, op, rhs } => match op {
+            Expr::BinExpr(BinExpr { lhs, op, rhs }) => match op {
                 // With && only the RHS can flow into the evaluation as a context
                 // (rather than a boolean).
                 BinOp::And => {
@@ -191,7 +195,7 @@ impl<'a> SpannedExpr<'a> {
         let mut leaves = vec![];
 
         match self.deref() {
-            Expr::BinOp { lhs, op, rhs } => match op {
+            Expr::BinExpr(BinExpr { lhs, op, rhs }) => match op {
                 BinOp::And => {
                     leaves.extend(rhs.leaf_expressions());
                 }
@@ -231,11 +235,11 @@ impl<'a> SpannedExpr<'a> {
                     index_exprs.extend(part.computed_indices());
                 }
             }
-            Expr::BinOp { lhs, op: _, rhs } => {
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
                 index_exprs.extend(lhs.computed_indices());
                 index_exprs.extend(rhs.computed_indices());
             }
-            Expr::UnOp { op: _, expr } => {
+            Expr::UnExpr { op: _, expr } => {
                 index_exprs.extend(expr.computed_indices());
             }
             _ => {}
@@ -271,11 +275,11 @@ impl<'a> SpannedExpr<'a> {
                     subexprs.extend(part.constant_reducible_subexprs());
                 }
             }
-            Expr::BinOp { lhs, op: _, rhs } => {
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
                 subexprs.extend(lhs.constant_reducible_subexprs());
                 subexprs.extend(rhs.constant_reducible_subexprs());
             }
-            Expr::UnOp { op: _, expr } => subexprs.extend(expr.constant_reducible_subexprs()),
+            Expr::UnExpr { op: _, expr } => subexprs.extend(expr.constant_reducible_subexprs()),
 
             Expr::Index(expr) => subexprs.extend(expr.constant_reducible_subexprs()),
             _ => {}
@@ -299,6 +303,12 @@ impl<'doc> From<&SpannedExpr<'doc>> for subfeature::Fragment<'doc> {
     }
 }
 
+impl PartialEq for SpannedExpr<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
 /// Represents a GitHub Actions expression.
 #[derive(Debug, PartialEq)]
 pub enum Expr<'src> {
@@ -314,17 +324,10 @@ pub enum Expr<'src> {
     Index(Box<SpannedExpr<'src>>),
     /// A full context reference.
     Context(Context<'src>),
-    /// A binary operation, either logical or arithmetic.
-    BinOp {
-        /// The LHS of the binop.
-        lhs: Box<SpannedExpr<'src>>,
-        /// The binary operator.
-        op: BinOp,
-        /// The RHS of the binop.
-        rhs: Box<SpannedExpr<'src>>,
-    },
-    /// A unary operation. Negation (`!`) is currently the only `UnOp`.
-    UnOp {
+    /// A binary expression, either logical or arithmetic.
+    BinExpr(BinExpr<'src>),
+    /// A unary expression. Negation (`!`) is currently the only `UnOp`.
+    UnExpr {
         /// The unary operator.
         op: UnOp,
         /// The expression to apply the operator to.
@@ -371,9 +374,11 @@ impl<'src> Expr<'src> {
             // Literals are always reducible.
             Expr::Literal(_) => true,
             // Binops are reducible if their LHS and RHS are reducible.
-            Expr::BinOp { lhs, op: _, rhs } => lhs.constant_reducible() && rhs.constant_reducible(),
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
+                lhs.constant_reducible() && rhs.constant_reducible()
+            }
             // Unops are reducible if their interior expression is reducible.
-            Expr::UnOp { op: _, expr } => expr.constant_reducible(),
+            Expr::UnExpr { op: _, expr } => expr.constant_reducible(),
             Expr::Call(Call { func, args }) => {
                 // These functions are reducible if their arguments are reducible.
                 // TODO(ww): `fromJSON` *is* frequently reducible, but
@@ -401,6 +406,38 @@ impl<'src> Expr<'src> {
     /// Parses the given string into an expression.
     pub fn parse(expr: &'src str) -> Result<SpannedExpr<'src>, Error> {
         parser::parse(expr)
+    }
+
+    /// Returns whether this expression 'commutatively matches' the given expression.
+    ///
+    /// For most expressions, this is the same as equivalence (i.e. `==`).
+    /// For binary expressions that are also commutative, this takes commutivity into account.
+    /// For example, `a == b` is considered to match `b == a`, but `a > b` is not
+    /// considered to match `b > a`. This check is recusive, i.e. two nested binary expressions
+    /// will be fully checked for commutative equivalence.
+    pub fn commutative_matches(&self, other: &Expr<'src>) -> bool {
+        match (self, other) {
+            (Self::BinExpr(sb), Self::BinExpr(ob)) => {
+                if sb.op != ob.op {
+                    return false;
+                }
+
+                // Same-position match (lhs/lhs, rhs/rhs); commutative ops
+                // additionally accept the swapped pairing below.
+                let positional = sb.lhs.inner.commutative_matches(&ob.lhs.inner)
+                    && sb.rhs.inner.commutative_matches(&ob.rhs.inner);
+
+                match sb.op {
+                    BinOp::And | BinOp::Or | BinOp::Eq | BinOp::Neq => {
+                        positional
+                            || (sb.lhs.inner.commutative_matches(&ob.rhs.inner)
+                                && sb.rhs.inner.commutative_matches(&ob.lhs.inner))
+                    }
+                    _ => positional,
+                }
+            }
+            _ => self == other,
+        }
     }
 }
 
@@ -732,7 +769,7 @@ impl<'src> Expr<'src> {
         match self {
             Expr::Literal(literal) => Some(literal.consteval()),
 
-            Expr::BinOp { lhs, op, rhs } => {
+            Expr::BinExpr(BinExpr { lhs, op, rhs }) => {
                 let lhs_val = lhs.consteval()?;
                 let rhs_val = rhs.consteval()?;
 
@@ -762,7 +799,7 @@ impl<'src> Expr<'src> {
                 }
             }
 
-            Expr::UnOp { op, expr } => {
+            Expr::UnExpr { op, expr } => {
                 let val = expr.consteval()?;
                 match op {
                     UnOp::Not => Some(Evaluation::Boolean(!val.as_boolean())),
@@ -781,11 +818,9 @@ impl<'src> Expr<'src> {
 mod tests {
     use std::borrow::Cow;
 
-    use pretty_assertions::assert_eq;
+    use crate::{Error, Literal, context::Context};
 
-    use crate::{Call, Error, Literal, Origin, SpannedExpr, context::Context};
-
-    use super::{BinOp, Expr, Function, UnOp};
+    use super::Expr;
 
     #[test]
     fn test_literal_string_borrows() {
@@ -999,355 +1034,1038 @@ mod tests {
     }
 
     #[test]
-    fn test_parse() {
+    fn test_parse_snapshot() -> Result<(), Error> {
         // These cases pin the parser's exact AST shape and byte-range origins.
-        let cases = &[
-            (
-                "!true || false || true",
-                SpannedExpr::new(
-                    Origin::new(0..22, "!true || false || true"),
-                    Expr::BinOp {
-                        lhs: Box::new(SpannedExpr::new(
-                            Origin::new(0..14, "!true || false"),
-                            Expr::BinOp {
-                                lhs: Box::new(SpannedExpr::new(
-                                    Origin::new(0..5, "!true"),
-                                    Expr::UnOp {
-                                        op: UnOp::Not,
-                                        expr: Box::new(SpannedExpr::new(
-                                            Origin::new(1..5, "true"),
-                                            Expr::Literal(Literal::Boolean(true)),
-                                        )),
-                                    },
-                                )),
-                                op: BinOp::Or,
-                                rhs: Box::new(SpannedExpr::new(
-                                    Origin::new(9..14, "false"),
-                                    Expr::Literal(Literal::Boolean(false)),
-                                )),
-                            },
-                        )),
-                        op: BinOp::Or,
-                        rhs: Box::new(SpannedExpr::new(
-                            Origin::new(18..22, "true"),
-                            Expr::Literal(Literal::Boolean(true)),
-                        )),
-                    },
-                ),
-            ),
-            (
-                "'foo '' bar'",
-                SpannedExpr::new(
-                    Origin::new(0..12, "'foo '' bar'"),
-                    Expr::Literal(Literal::String(Cow::Borrowed("foo ' bar"))),
-                ),
-            ),
-            (
-                "('foo '' bar')",
-                SpannedExpr::new(
-                    Origin::new(0..14, "('foo '' bar')"),
-                    Expr::Literal(Literal::String(Cow::Borrowed("foo ' bar"))),
-                ),
-            ),
-            (
-                "((('foo '' bar')))",
-                SpannedExpr::new(
-                    Origin::new(0..18, "((('foo '' bar')))"),
-                    Expr::Literal(Literal::String(Cow::Borrowed("foo ' bar"))),
-                ),
-            ),
-            (
-                "format('{0} {1}', 2, 3)",
-                SpannedExpr::new(
-                    Origin::new(0..23, "format('{0} {1}', 2, 3)"),
-                    Expr::Call(Call {
-                        func: Function::Format,
-                        args: vec![
-                            SpannedExpr::new(
-                                Origin::new(7..16, "'{0} {1}'"),
-                                Expr::Literal(Literal::String(Cow::Borrowed("{0} {1}"))),
-                            ),
-                            SpannedExpr::new(
-                                Origin::new(18..19, "2"),
-                                Expr::Literal(Literal::Number(2.0)),
-                            ),
-                            SpannedExpr::new(
-                                Origin::new(21..22, "3"),
-                                Expr::Literal(Literal::Number(3.0)),
-                            ),
-                        ],
-                    }),
-                ),
-            ),
-            (
-                "foo.bar.baz",
-                SpannedExpr::new(
-                    Origin::new(0..11, "foo.bar.baz"),
-                    Expr::context(vec![
-                        SpannedExpr::new(Origin::new(0..3, "foo"), Expr::ident("foo")),
-                        SpannedExpr::new(Origin::new(4..7, "bar"), Expr::ident("bar")),
-                        SpannedExpr::new(Origin::new(8..11, "baz"), Expr::ident("baz")),
-                    ]),
-                ),
-            ),
-            (
-                "foo.bar.baz[1][2]",
-                SpannedExpr::new(
-                    Origin::new(0..17, "foo.bar.baz[1][2]"),
-                    Expr::context(vec![
-                        SpannedExpr::new(Origin::new(0..3, "foo"), Expr::ident("foo")),
-                        SpannedExpr::new(Origin::new(4..7, "bar"), Expr::ident("bar")),
-                        SpannedExpr::new(Origin::new(8..11, "baz"), Expr::ident("baz")),
-                        SpannedExpr::new(
-                            Origin::new(11..14, "[1]"),
-                            Expr::Index(Box::new(SpannedExpr::new(
-                                Origin::new(12..13, "1"),
-                                Expr::Literal(Literal::Number(1.0)),
-                            ))),
-                        ),
-                        SpannedExpr::new(
-                            Origin::new(14..17, "[2]"),
-                            Expr::Index(Box::new(SpannedExpr::new(
-                                Origin::new(15..16, "2"),
-                                Expr::Literal(Literal::Number(2.0)),
-                            ))),
-                        ),
-                    ]),
-                ),
-            ),
-            (
-                "foo.bar.baz[*]",
-                SpannedExpr::new(
-                    Origin::new(0..14, "foo.bar.baz[*]"),
-                    Expr::context(vec![
-                        SpannedExpr::new(Origin::new(0..3, "foo"), Expr::ident("foo")),
-                        SpannedExpr::new(Origin::new(4..7, "bar"), Expr::ident("bar")),
-                        SpannedExpr::new(Origin::new(8..11, "baz"), Expr::ident("baz")),
-                        SpannedExpr::new(
-                            Origin::new(11..14, "[*]"),
-                            Expr::Index(Box::new(SpannedExpr::new(
-                                Origin::new(12..13, "*"),
-                                Expr::Star,
-                            ))),
-                        ),
-                    ]),
-                ),
-            ),
-            (
-                "vegetables.*.ediblePortions",
-                SpannedExpr::new(
-                    Origin::new(0..27, "vegetables.*.ediblePortions"),
-                    Expr::context(vec![
-                        SpannedExpr::new(
-                            Origin::new(0..10, "vegetables"),
-                            Expr::ident("vegetables"),
-                        ),
-                        SpannedExpr::new(Origin::new(11..12, "*"), Expr::Star),
-                        SpannedExpr::new(
-                            Origin::new(13..27, "ediblePortions"),
-                            Expr::ident("ediblePortions"),
-                        ),
-                    ]),
-                ),
-            ),
-            (
-                "github.ref == 'refs/heads/main' && 'value_for_main_branch' || 'value_for_other_branches'",
-                SpannedExpr::new(
-                    Origin::new(
-                        0..88,
-                        "github.ref == 'refs/heads/main' && 'value_for_main_branch' || 'value_for_other_branches'",
-                    ),
-                    Expr::BinOp {
-                        lhs: Box::new(SpannedExpr::new(
-                            Origin::new(
-                                0..58,
-                                "github.ref == 'refs/heads/main' && 'value_for_main_branch'",
-                            ),
-                            Expr::BinOp {
-                                lhs: Box::new(SpannedExpr::new(
-                                    Origin::new(0..31, "github.ref == 'refs/heads/main'"),
-                                    Expr::BinOp {
-                                        lhs: Box::new(SpannedExpr::new(
-                                            Origin::new(0..10, "github.ref"),
-                                            Expr::context(vec![
-                                                SpannedExpr::new(
-                                                    Origin::new(0..6, "github"),
-                                                    Expr::ident("github"),
-                                                ),
-                                                SpannedExpr::new(
-                                                    Origin::new(7..10, "ref"),
-                                                    Expr::ident("ref"),
-                                                ),
-                                            ]),
-                                        )),
-                                        op: BinOp::Eq,
-                                        rhs: Box::new(SpannedExpr::new(
-                                            Origin::new(14..31, "'refs/heads/main'"),
-                                            Expr::Literal(Literal::String(Cow::Borrowed(
-                                                "refs/heads/main",
-                                            ))),
-                                        )),
-                                    },
-                                )),
-                                op: BinOp::And,
-                                rhs: Box::new(SpannedExpr::new(
-                                    Origin::new(35..58, "'value_for_main_branch'"),
-                                    Expr::Literal(Literal::String(Cow::Borrowed(
-                                        "value_for_main_branch",
-                                    ))),
-                                )),
-                            },
-                        )),
-                        op: BinOp::Or,
-                        rhs: Box::new(SpannedExpr::new(
-                            Origin::new(62..88, "'value_for_other_branches'"),
-                            Expr::Literal(Literal::String(Cow::Borrowed(
-                                "value_for_other_branches",
-                            ))),
-                        )),
-                    },
-                ),
-            ),
-            (
-                "(true || false) == true",
-                SpannedExpr::new(
-                    Origin::new(0..23, "(true || false) == true"),
-                    Expr::BinOp {
-                        lhs: Box::new(SpannedExpr::new(
-                            Origin::new(0..15, "(true || false)"),
-                            Expr::BinOp {
-                                lhs: Box::new(SpannedExpr::new(
-                                    Origin::new(1..5, "true"),
-                                    Expr::Literal(Literal::Boolean(true)),
-                                )),
-                                op: BinOp::Or,
-                                rhs: Box::new(SpannedExpr::new(
-                                    Origin::new(9..14, "false"),
-                                    Expr::Literal(Literal::Boolean(false)),
-                                )),
-                            },
-                        )),
-                        op: BinOp::Eq,
-                        rhs: Box::new(SpannedExpr::new(
-                            Origin::new(19..23, "true"),
-                            Expr::Literal(Literal::Boolean(true)),
-                        )),
-                    },
-                ),
-            ),
-            (
-                "!(!true || false)",
-                SpannedExpr::new(
-                    Origin::new(0..17, "!(!true || false)"),
-                    Expr::UnOp {
-                        op: UnOp::Not,
-                        expr: Box::new(SpannedExpr::new(
-                            Origin::new(1..17, "(!true || false)"),
-                            Expr::BinOp {
-                                lhs: Box::new(SpannedExpr::new(
-                                    Origin::new(2..7, "!true"),
-                                    Expr::UnOp {
-                                        op: UnOp::Not,
-                                        expr: Box::new(SpannedExpr::new(
-                                            Origin::new(3..7, "true"),
-                                            Expr::Literal(Literal::Boolean(true)),
-                                        )),
-                                    },
-                                )),
-                                op: BinOp::Or,
-                                rhs: Box::new(SpannedExpr::new(
-                                    Origin::new(11..16, "false"),
-                                    Expr::Literal(Literal::Boolean(false)),
-                                )),
-                            },
-                        )),
-                    },
-                ),
-            ),
-            (
-                "foobar[format('{0}', 'event')]",
-                SpannedExpr::new(
-                    Origin::new(0..30, "foobar[format('{0}', 'event')]"),
-                    Expr::context(vec![
-                        SpannedExpr::new(Origin::new(0..6, "foobar"), Expr::ident("foobar")),
-                        SpannedExpr::new(
-                            Origin::new(6..30, "[format('{0}', 'event')]"),
-                            Expr::Index(Box::new(SpannedExpr::new(
-                                Origin::new(7..29, "format('{0}', 'event')"),
-                                Expr::Call(Call {
-                                    func: Function::Format,
-                                    args: vec![
-                                        SpannedExpr::new(
-                                            Origin::new(14..19, "'{0}'"),
-                                            Expr::Literal(Literal::String(Cow::Borrowed("{0}"))),
-                                        ),
-                                        SpannedExpr::new(
-                                            Origin::new(21..28, "'event'"),
-                                            Expr::Literal(Literal::String(Cow::Borrowed("event"))),
-                                        ),
-                                    ],
-                                }),
-                            ))),
-                        ),
-                    ]),
-                ),
-            ),
-            (
-                "github.actor_id == '49699333'",
-                SpannedExpr::new(
-                    Origin::new(0..29, "github.actor_id == '49699333'"),
-                    Expr::BinOp {
-                        lhs: Box::new(SpannedExpr::new(
-                            Origin::new(0..15, "github.actor_id"),
-                            Expr::context(vec![
-                                SpannedExpr::new(
-                                    Origin::new(0..6, "github"),
-                                    Expr::ident("github"),
-                                ),
-                                SpannedExpr::new(
-                                    Origin::new(7..15, "actor_id"),
-                                    Expr::ident("actor_id"),
-                                ),
-                            ]),
-                        )),
-                        op: BinOp::Eq,
-                        rhs: Box::new(SpannedExpr::new(
-                            Origin::new(19..29, "'49699333'"),
-                            Expr::Literal(Literal::String(Cow::Borrowed("49699333"))),
-                        )),
-                    },
-                ),
-            ),
-            (
-                "(fromJSON('[]'))[1]",
-                SpannedExpr::new(
-                    Origin::new(0..19, "(fromJSON('[]'))[1]"),
-                    Expr::context(vec![
-                        SpannedExpr::new(
-                            Origin::new(0..16, "(fromJSON('[]'))"),
-                            Expr::Call(Call {
-                                func: Function::FromJSON,
-                                args: vec![SpannedExpr::new(
-                                    Origin::new(10..14, "'[]'"),
-                                    Expr::Literal(Literal::String(Cow::Borrowed("[]"))),
-                                )],
-                            }),
-                        ),
-                        SpannedExpr::new(
-                            Origin::new(16..19, "[1]"),
-                            Expr::Index(Box::new(SpannedExpr::new(
-                                Origin::new(17..18, "1"),
-                                Expr::Literal(Literal::Number(1.0)),
-                            ))),
-                        ),
-                    ]),
-                ),
-            ),
-        ];
 
-        for (case, expr) in cases {
-            assert_eq!(*expr, Expr::parse(case).unwrap());
+        insta::assert_debug_snapshot!(Expr::parse("!true || false || true")?, @r#"
+        SpannedExpr {
+            origin: Origin {
+                span: Span {
+                    start: 0,
+                    end: 22,
+                },
+                raw: "!true || false || true",
+            },
+            inner: BinExpr(
+                BinExpr {
+                    lhs: SpannedExpr {
+                        origin: Origin {
+                            span: Span {
+                                start: 0,
+                                end: 14,
+                            },
+                            raw: "!true || false",
+                        },
+                        inner: BinExpr(
+                            BinExpr {
+                                lhs: SpannedExpr {
+                                    origin: Origin {
+                                        span: Span {
+                                            start: 0,
+                                            end: 5,
+                                        },
+                                        raw: "!true",
+                                    },
+                                    inner: UnExpr {
+                                        op: Not,
+                                        expr: SpannedExpr {
+                                            origin: Origin {
+                                                span: Span {
+                                                    start: 1,
+                                                    end: 5,
+                                                },
+                                                raw: "true",
+                                            },
+                                            inner: Literal(
+                                                Boolean(
+                                                    true,
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                },
+                                op: Or,
+                                rhs: SpannedExpr {
+                                    origin: Origin {
+                                        span: Span {
+                                            start: 9,
+                                            end: 14,
+                                        },
+                                        raw: "false",
+                                    },
+                                    inner: Literal(
+                                        Boolean(
+                                            false,
+                                        ),
+                                    ),
+                                },
+                            },
+                        ),
+                    },
+                    op: Or,
+                    rhs: SpannedExpr {
+                        origin: Origin {
+                            span: Span {
+                                start: 18,
+                                end: 22,
+                            },
+                            raw: "true",
+                        },
+                        inner: Literal(
+                            Boolean(
+                                true,
+                            ),
+                        ),
+                    },
+                },
+            ),
         }
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("'foo '' bar'")?, @r#"
+        SpannedExpr {
+            origin: Origin {
+                span: Span {
+                    start: 0,
+                    end: 12,
+                },
+                raw: "'foo '' bar'",
+            },
+            inner: Literal(
+                String(
+                    "foo ' bar",
+                ),
+            ),
+        }
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("('foo '' bar')")?, @r#"
+        SpannedExpr {
+            origin: Origin {
+                span: Span {
+                    start: 0,
+                    end: 14,
+                },
+                raw: "('foo '' bar')",
+            },
+            inner: Literal(
+                String(
+                    "foo ' bar",
+                ),
+            ),
+        }
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("((('foo '' bar')))")?, @r#"
+        SpannedExpr {
+            origin: Origin {
+                span: Span {
+                    start: 0,
+                    end: 18,
+                },
+                raw: "((('foo '' bar')))",
+            },
+            inner: Literal(
+                String(
+                    "foo ' bar",
+                ),
+            ),
+        }
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("format('{0} {1}', 2, 3)")?, @r#"
+        SpannedExpr {
+            origin: Origin {
+                span: Span {
+                    start: 0,
+                    end: 23,
+                },
+                raw: "format('{0} {1}', 2, 3)",
+            },
+            inner: Call(
+                Call {
+                    func: Format,
+                    args: [
+                        SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 7,
+                                    end: 16,
+                                },
+                                raw: "'{0} {1}'",
+                            },
+                            inner: Literal(
+                                String(
+                                    "{0} {1}",
+                                ),
+                            ),
+                        },
+                        SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 18,
+                                    end: 19,
+                                },
+                                raw: "2",
+                            },
+                            inner: Literal(
+                                Number(
+                                    2.0,
+                                ),
+                            ),
+                        },
+                        SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 21,
+                                    end: 22,
+                                },
+                                raw: "3",
+                            },
+                            inner: Literal(
+                                Number(
+                                    3.0,
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+        }
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("foo.bar.baz")?, @r#"
+        SpannedExpr {
+            origin: Origin {
+                span: Span {
+                    start: 0,
+                    end: 11,
+                },
+                raw: "foo.bar.baz",
+            },
+            inner: Context(
+                Context {
+                    parts: [
+                        SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 0,
+                                    end: 3,
+                                },
+                                raw: "foo",
+                            },
+                            inner: Identifier(
+                                Identifier(
+                                    "foo",
+                                ),
+                            ),
+                        },
+                        SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 4,
+                                    end: 7,
+                                },
+                                raw: "bar",
+                            },
+                            inner: Identifier(
+                                Identifier(
+                                    "bar",
+                                ),
+                            ),
+                        },
+                        SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 8,
+                                    end: 11,
+                                },
+                                raw: "baz",
+                            },
+                            inner: Identifier(
+                                Identifier(
+                                    "baz",
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+        }
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("foo.bar.baz[1][2]"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 17,
+                    },
+                    raw: "foo.bar.baz[1][2]",
+                },
+                inner: Context(
+                    Context {
+                        parts: [
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 0,
+                                        end: 3,
+                                    },
+                                    raw: "foo",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "foo",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 4,
+                                        end: 7,
+                                    },
+                                    raw: "bar",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "bar",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 8,
+                                        end: 11,
+                                    },
+                                    raw: "baz",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "baz",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 11,
+                                        end: 14,
+                                    },
+                                    raw: "[1]",
+                                },
+                                inner: Index(
+                                    SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 12,
+                                                end: 13,
+                                            },
+                                            raw: "1",
+                                        },
+                                        inner: Literal(
+                                            Number(
+                                                1.0,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 14,
+                                        end: 17,
+                                    },
+                                    raw: "[2]",
+                                },
+                                inner: Index(
+                                    SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 15,
+                                                end: 16,
+                                            },
+                                            raw: "2",
+                                        },
+                                        inner: Literal(
+                                            Number(
+                                                2.0,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("foo.bar.baz[*]"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 14,
+                    },
+                    raw: "foo.bar.baz[*]",
+                },
+                inner: Context(
+                    Context {
+                        parts: [
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 0,
+                                        end: 3,
+                                    },
+                                    raw: "foo",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "foo",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 4,
+                                        end: 7,
+                                    },
+                                    raw: "bar",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "bar",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 8,
+                                        end: 11,
+                                    },
+                                    raw: "baz",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "baz",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 11,
+                                        end: 14,
+                                    },
+                                    raw: "[*]",
+                                },
+                                inner: Index(
+                                    SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 12,
+                                                end: 13,
+                                            },
+                                            raw: "*",
+                                        },
+                                        inner: Star,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("vegetables.*.ediblePortions"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 27,
+                    },
+                    raw: "vegetables.*.ediblePortions",
+                },
+                inner: Context(
+                    Context {
+                        parts: [
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 0,
+                                        end: 10,
+                                    },
+                                    raw: "vegetables",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "vegetables",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 11,
+                                        end: 12,
+                                    },
+                                    raw: "*",
+                                },
+                                inner: Star,
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 13,
+                                        end: 27,
+                                    },
+                                    raw: "ediblePortions",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "ediblePortions",
+                                    ),
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("github.ref == 'refs/heads/main' && 'value_for_main_branch' || 'value_for_other_branches'"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 88,
+                    },
+                    raw: "github.ref == 'refs/heads/main' && 'value_for_main_branch' || 'value_for_other_branches'",
+                },
+                inner: BinExpr(
+                    BinExpr {
+                        lhs: SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 0,
+                                    end: 58,
+                                },
+                                raw: "github.ref == 'refs/heads/main' && 'value_for_main_branch'",
+                            },
+                            inner: BinExpr(
+                                BinExpr {
+                                    lhs: SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 0,
+                                                end: 31,
+                                            },
+                                            raw: "github.ref == 'refs/heads/main'",
+                                        },
+                                        inner: BinExpr(
+                                            BinExpr {
+                                                lhs: SpannedExpr {
+                                                    origin: Origin {
+                                                        span: Span {
+                                                            start: 0,
+                                                            end: 10,
+                                                        },
+                                                        raw: "github.ref",
+                                                    },
+                                                    inner: Context(
+                                                        Context {
+                                                            parts: [
+                                                                SpannedExpr {
+                                                                    origin: Origin {
+                                                                        span: Span {
+                                                                            start: 0,
+                                                                            end: 6,
+                                                                        },
+                                                                        raw: "github",
+                                                                    },
+                                                                    inner: Identifier(
+                                                                        Identifier(
+                                                                            "github",
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                SpannedExpr {
+                                                                    origin: Origin {
+                                                                        span: Span {
+                                                                            start: 7,
+                                                                            end: 10,
+                                                                        },
+                                                                        raw: "ref",
+                                                                    },
+                                                                    inner: Identifier(
+                                                                        Identifier(
+                                                                            "ref",
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                                op: Eq,
+                                                rhs: SpannedExpr {
+                                                    origin: Origin {
+                                                        span: Span {
+                                                            start: 14,
+                                                            end: 31,
+                                                        },
+                                                        raw: "'refs/heads/main'",
+                                                    },
+                                                    inner: Literal(
+                                                        String(
+                                                            "refs/heads/main",
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    op: And,
+                                    rhs: SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 35,
+                                                end: 58,
+                                            },
+                                            raw: "'value_for_main_branch'",
+                                        },
+                                        inner: Literal(
+                                            String(
+                                                "value_for_main_branch",
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ),
+                        },
+                        op: Or,
+                        rhs: SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 62,
+                                    end: 88,
+                                },
+                                raw: "'value_for_other_branches'",
+                            },
+                            inner: Literal(
+                                String(
+                                    "value_for_other_branches",
+                                ),
+                            ),
+                        },
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("(true || false) == true"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 23,
+                    },
+                    raw: "(true || false) == true",
+                },
+                inner: BinExpr(
+                    BinExpr {
+                        lhs: SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 0,
+                                    end: 15,
+                                },
+                                raw: "(true || false)",
+                            },
+                            inner: BinExpr(
+                                BinExpr {
+                                    lhs: SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 1,
+                                                end: 5,
+                                            },
+                                            raw: "true",
+                                        },
+                                        inner: Literal(
+                                            Boolean(
+                                                true,
+                                            ),
+                                        ),
+                                    },
+                                    op: Or,
+                                    rhs: SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 9,
+                                                end: 14,
+                                            },
+                                            raw: "false",
+                                        },
+                                        inner: Literal(
+                                            Boolean(
+                                                false,
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ),
+                        },
+                        op: Eq,
+                        rhs: SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 19,
+                                    end: 23,
+                                },
+                                raw: "true",
+                            },
+                            inner: Literal(
+                                Boolean(
+                                    true,
+                                ),
+                            ),
+                        },
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("!(!true || false)"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 17,
+                    },
+                    raw: "!(!true || false)",
+                },
+                inner: UnExpr {
+                    op: Not,
+                    expr: SpannedExpr {
+                        origin: Origin {
+                            span: Span {
+                                start: 1,
+                                end: 17,
+                            },
+                            raw: "(!true || false)",
+                        },
+                        inner: BinExpr(
+                            BinExpr {
+                                lhs: SpannedExpr {
+                                    origin: Origin {
+                                        span: Span {
+                                            start: 2,
+                                            end: 7,
+                                        },
+                                        raw: "!true",
+                                    },
+                                    inner: UnExpr {
+                                        op: Not,
+                                        expr: SpannedExpr {
+                                            origin: Origin {
+                                                span: Span {
+                                                    start: 3,
+                                                    end: 7,
+                                                },
+                                                raw: "true",
+                                            },
+                                            inner: Literal(
+                                                Boolean(
+                                                    true,
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                },
+                                op: Or,
+                                rhs: SpannedExpr {
+                                    origin: Origin {
+                                        span: Span {
+                                            start: 11,
+                                            end: 16,
+                                        },
+                                        raw: "false",
+                                    },
+                                    inner: Literal(
+                                        Boolean(
+                                            false,
+                                        ),
+                                    ),
+                                },
+                            },
+                        ),
+                    },
+                },
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("foobar[format('{0}', 'event')]"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 30,
+                    },
+                    raw: "foobar[format('{0}', 'event')]",
+                },
+                inner: Context(
+                    Context {
+                        parts: [
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 0,
+                                        end: 6,
+                                    },
+                                    raw: "foobar",
+                                },
+                                inner: Identifier(
+                                    Identifier(
+                                        "foobar",
+                                    ),
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 6,
+                                        end: 30,
+                                    },
+                                    raw: "[format('{0}', 'event')]",
+                                },
+                                inner: Index(
+                                    SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 7,
+                                                end: 29,
+                                            },
+                                            raw: "format('{0}', 'event')",
+                                        },
+                                        inner: Call(
+                                            Call {
+                                                func: Format,
+                                                args: [
+                                                    SpannedExpr {
+                                                        origin: Origin {
+                                                            span: Span {
+                                                                start: 14,
+                                                                end: 19,
+                                                            },
+                                                            raw: "'{0}'",
+                                                        },
+                                                        inner: Literal(
+                                                            String(
+                                                                "{0}",
+                                                            ),
+                                                        ),
+                                                    },
+                                                    SpannedExpr {
+                                                        origin: Origin {
+                                                            span: Span {
+                                                                start: 21,
+                                                                end: 28,
+                                                            },
+                                                            raw: "'event'",
+                                                        },
+                                                        inner: Literal(
+                                                            String(
+                                                                "event",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("github.actor_id == '49699333'"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 29,
+                    },
+                    raw: "github.actor_id == '49699333'",
+                },
+                inner: BinExpr(
+                    BinExpr {
+                        lhs: SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 0,
+                                    end: 15,
+                                },
+                                raw: "github.actor_id",
+                            },
+                            inner: Context(
+                                Context {
+                                    parts: [
+                                        SpannedExpr {
+                                            origin: Origin {
+                                                span: Span {
+                                                    start: 0,
+                                                    end: 6,
+                                                },
+                                                raw: "github",
+                                            },
+                                            inner: Identifier(
+                                                Identifier(
+                                                    "github",
+                                                ),
+                                            ),
+                                        },
+                                        SpannedExpr {
+                                            origin: Origin {
+                                                span: Span {
+                                                    start: 7,
+                                                    end: 15,
+                                                },
+                                                raw: "actor_id",
+                                            },
+                                            inner: Identifier(
+                                                Identifier(
+                                                    "actor_id",
+                                                ),
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                        op: Eq,
+                        rhs: SpannedExpr {
+                            origin: Origin {
+                                span: Span {
+                                    start: 19,
+                                    end: 29,
+                                },
+                                raw: "'49699333'",
+                            },
+                            inner: Literal(
+                                String(
+                                    "49699333",
+                                ),
+                            ),
+                        },
+                    },
+                ),
+            },
+        )
+        "#);
+
+        insta::assert_debug_snapshot!(Expr::parse("(fromJSON('[]'))[1]"), @r#"
+        Ok(
+            SpannedExpr {
+                origin: Origin {
+                    span: Span {
+                        start: 0,
+                        end: 19,
+                    },
+                    raw: "(fromJSON('[]'))[1]",
+                },
+                inner: Context(
+                    Context {
+                        parts: [
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 0,
+                                        end: 16,
+                                    },
+                                    raw: "(fromJSON('[]'))",
+                                },
+                                inner: Call(
+                                    Call {
+                                        func: FromJSON,
+                                        args: [
+                                            SpannedExpr {
+                                                origin: Origin {
+                                                    span: Span {
+                                                        start: 10,
+                                                        end: 14,
+                                                    },
+                                                    raw: "'[]'",
+                                                },
+                                                inner: Literal(
+                                                    String(
+                                                        "[]",
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                            SpannedExpr {
+                                origin: Origin {
+                                    span: Span {
+                                        start: 16,
+                                        end: 19,
+                                    },
+                                    raw: "[1]",
+                                },
+                                inner: Index(
+                                    SpannedExpr {
+                                        origin: Origin {
+                                            span: Span {
+                                                start: 17,
+                                                end: 18,
+                                            },
+                                            raw: "1",
+                                        },
+                                        inner: Literal(
+                                            Number(
+                                                1.0,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        )
+        "#);
+
+        Ok(())
     }
 
     #[test]
@@ -1931,7 +2649,7 @@ mod tests {
         let expr = Expr::parse("foo.bar == 'abc'")?;
         let leaves = expr.leaf_expressions();
         assert_eq!(leaves.len(), 1);
-        assert!(matches!(&leaves[0].inner, Expr::BinOp { .. }));
+        assert!(matches!(&leaves[0].inner, Expr::BinExpr { .. }));
 
         Ok(())
     }
@@ -1959,5 +2677,51 @@ mod tests {
                 "input: {input}"
             );
         }
+    }
+
+    #[test]
+    fn test_expr_commutative_matches() -> Result<(), Error> {
+        let cases = &[
+            // Identical expressions always match.
+            ("a == b", "a == b", true),
+            // Commutative operators match when swapped.
+            ("a == b", "b == a", true),
+            ("a != b", "b != a", true),
+            ("a && b", "b && a", true),
+            ("a || b", "b || a", true),
+            // Non-commutative operators don't match when swapped.
+            ("a > b", "b > a", false),
+            ("a >= b", "b >= a", false),
+            ("a < b", "b < a", false),
+            ("a <= b", "b <= a", false),
+            // Non-commutative operators still match positionally.
+            ("a > b", "a > b", true),
+            // Different operators never match.
+            ("a == b", "a != b", false),
+            ("a > b", "a < b", false),
+            // Recursive commutative matching through nested commutative ops.
+            ("(a == b) && (c == d)", "(d == c) && (b == a)", true),
+            ("(a == b) && (c == d)", "(c == d) && (a == b)", true),
+            // Recursion descends into non-commutative ops positionally.
+            ("(a == b) > (c == d)", "(b == a) > (d == c)", true),
+            ("(a == b) > (c == d)", "(c == d) > (a == b)", false),
+            // Non-binexpr fall-through uses equality.
+            ("'foo'", "'foo'", true),
+            ("'foo'", "'bar'", false),
+            // Mixed binexpr vs non-binexpr never matches.
+            ("a == b", "'foo'", false),
+        ];
+
+        for (lhs, rhs, expected) in cases {
+            let lhs_expr = Expr::parse(lhs)?;
+            let rhs_expr = Expr::parse(rhs)?;
+            assert_eq!(
+                lhs_expr.inner.commutative_matches(&rhs_expr.inner),
+                *expected,
+                "{lhs} <=> {rhs}",
+            );
+        }
+
+        Ok(())
     }
 }

--- a/crates/github-actions-expressions/src/op.rs
+++ b/crates/github-actions-expressions/src/op.rs
@@ -1,4 +1,6 @@
-//! Unary and binary operators.
+//! Unary and binary expressions and operators.
+
+use crate::SpannedExpr;
 
 /// Binary operations allowed in an expression.
 #[derive(Debug, PartialEq)]
@@ -19,6 +21,19 @@ pub enum BinOp {
     Lt,
     /// `expr <= expr`
     Le,
+}
+
+/// Represents a binary expression.
+///
+/// Binary expressions can be either logical or arithmetic.
+#[derive(Debug, PartialEq)]
+pub struct BinExpr<'src> {
+    /// The LHS of the expr.
+    pub lhs: Box<SpannedExpr<'src>>,
+    /// The binary operator.
+    pub op: BinOp,
+    /// The RHS of the expr.
+    pub rhs: Box<SpannedExpr<'src>>,
 }
 
 /// Unary operations allowed in an expression.

--- a/crates/github-actions-expressions/src/parser.rs
+++ b/crates/github-actions-expressions/src/parser.rs
@@ -10,7 +10,7 @@ use crate::{
     call::Call,
     lexer::{self, Tok, Token, syntax_error},
     literal::Literal,
-    op::{BinOp, UnOp},
+    op::{BinExpr, BinOp, UnOp},
 };
 
 /// The result of parsing a single grammar production.
@@ -125,11 +125,11 @@ impl<'src> Parser<'src> {
             lhs = self.spanned(
                 lhs.origin.span.start,
                 rhs.origin.span.end,
-                Expr::BinOp {
+                Expr::BinExpr(BinExpr {
                     lhs: Box::new(lhs),
                     op,
                     rhs: Box::new(rhs),
-                },
+                }),
             );
         }
 
@@ -147,7 +147,7 @@ impl<'src> Parser<'src> {
         Ok(self.spanned(
             bang.start,
             inner.origin.span.end,
-            Expr::UnOp {
+            Expr::UnExpr {
                 op: UnOp::Not,
                 expr: Box::new(inner),
             },

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -4,7 +4,7 @@ use github_actions_expressions::{
     Expr, SpannedExpr,
     call::Call,
     context::{Context, ContextPattern},
-    op::{BinOp, UnOp},
+    op::{BinExpr, BinOp, UnOp},
 };
 use github_actions_models::{
     common::If,
@@ -278,7 +278,7 @@ impl BotConditions {
                 .reduce(|(bc, _), (bc_next, _)| (bc.or(bc_next), false))
                 .unwrap_or((None, dominating)),
             Expr::Index(expr) => Self::walk_tree_for_bot_condition(expr, dominating),
-            Expr::BinOp { lhs, op, rhs } => match op {
+            Expr::BinExpr(BinExpr { lhs, op, rhs }) => match op {
                 // || is dominating.
                 BinOp::Or => {
                     let (bc_lhs, _) = Self::walk_tree_for_bot_condition(lhs, true);
@@ -323,7 +323,7 @@ impl BotConditions {
                     (bc_lhs.or(bc_rhs), false)
                 }
             },
-            Expr::UnOp { op, expr } => match op {
+            Expr::UnExpr { op, expr } => match op {
                 // We don't really know what we're negating, so naively
                 // assume we're non-dominating.
                 //

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use github_actions_expressions::call::{Call, Function};
 use github_actions_expressions::literal::Literal;
-use github_actions_expressions::op::UnOp;
+use github_actions_expressions::op::{BinExpr, BinOp, UnOp};
 use github_actions_expressions::{Expr, SpannedExpr};
 use github_actions_models::common::EnvValue;
 use github_actions_models::common::expr::LoE;
@@ -25,6 +25,13 @@ use yamlpatch::{Op, Patch};
 use super::AuditLoadError;
 
 const TAG_REF_PREFIX: &str = "refs/tags/";
+/// A canonical parse for our [`CacheControlExpr::RefTypeTagPush`] heuristic below.
+/// We don't match this verbatim; instead we decompose it for commutative comparisons.
+static REF_TYPE_TAG_PUSH_GUARD: LazyLock<Expr> = LazyLock::new(|| {
+    Expr::parse("github.event_name == 'push' && github.ref_type == 'tag'")
+        .expect("impossible")
+        .inner
+});
 
 /// The list of known cache-aware actions
 /// In the future we can easily retrieve this list from the static API,
@@ -303,9 +310,10 @@ enum PublishingScenario<'doc> {
 enum CacheControlExpr {
     /// A literal `${{ true }}` or `${{ false }}`.
     Bool(bool),
-    // At the moment, this is the only combination of cache control expression and workflow trigger
-    // that we recognize.
+    // An expression like `startsWith(github.ref, 'refs/tags/')`.
     StartsWithGithubRefTagPrefix,
+    // An expression like `github.event_name == 'push' && github.ref_type == 'tag'`
+    RefTypeTagPush,
     /// A negation of another cache control expression.
     Not(Box<CacheControlExpr>),
 }
@@ -320,7 +328,7 @@ impl CacheControlExpr {
     fn from_spanned(expr: &SpannedExpr) -> Option<Self> {
         match &expr.inner {
             Expr::Literal(Literal::Boolean(value)) => Some(Self::Bool(*value)),
-            Expr::UnOp {
+            Expr::UnExpr {
                 op: UnOp::Not,
                 expr,
             } => Some(Self::Not(Box::new(Self::from_spanned(expr)?))),
@@ -339,6 +347,13 @@ impl CacheControlExpr {
                     None
                 }
             }
+            expr @ Expr::BinExpr(BinExpr { op: BinOp::And, .. }) => {
+                if expr.commutative_matches(&REF_TYPE_TAG_PUSH_GUARD) {
+                    Some(Self::RefTypeTagPush)
+                } else {
+                    None
+                }
+            }
             // TODO: At some point we might want to add heuristics for `case(...)` here as well.
             _ => None,
         }
@@ -349,6 +364,7 @@ impl CacheControlExpr {
             Self::Bool(value) => *value,
             Self::Not(expr) => !expr.eval_for_tag_push(),
             Self::StartsWithGithubRefTagPrefix => true,
+            Self::RefTypeTagPush => true,
         }
     }
 }

--- a/crates/zizmor/src/audit/overprovisioned_secrets.rs
+++ b/crates/zizmor/src/audit/overprovisioned_secrets.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use github_actions_expressions::{
     Expr, SpannedExpr,
     call::{Call, Function},
+    op::BinExpr,
 };
 
 use crate::{
@@ -107,11 +108,11 @@ impl OverprovisionedSecrets {
                     _ => results.extend(ctx.parts.iter().flat_map(Self::secrets_expansions)),
                 }
             }
-            Expr::BinOp { lhs, op: _, rhs } => {
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
                 results.extend(Self::secrets_expansions(lhs));
                 results.extend(Self::secrets_expansions(rhs));
             }
-            Expr::UnOp { op: _, expr } => results.extend(Self::secrets_expansions(expr)),
+            Expr::UnExpr { op: _, expr } => results.extend(Self::secrets_expansions(expr)),
             _ => (),
         }
 

--- a/crates/zizmor/src/audit/unredacted_secrets.rs
+++ b/crates/zizmor/src/audit/unredacted_secrets.rs
@@ -4,6 +4,7 @@ use github_actions_expressions::{
     Expr, SpannedExpr,
     call::{Call, Function},
     context::Context,
+    op::BinExpr,
 };
 
 use crate::{
@@ -92,11 +93,11 @@ impl UnredactedSecrets {
             Expr::Context(Context { parts, .. }) => {
                 results.extend(parts.iter().flat_map(Self::secret_leakages))
             }
-            Expr::BinOp { lhs, op: _, rhs } => {
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
                 results.extend(Self::secret_leakages(lhs));
                 results.extend(Self::secret_leakages(rhs));
             }
-            Expr::UnOp { op: _, expr } => results.extend(Self::secret_leakages(expr)),
+            Expr::UnExpr { op: _, expr } => results.extend(Self::secret_leakages(expr)),
             _ => (),
         }
 

--- a/crates/zizmor/src/audit/unsound_contains.rs
+++ b/crates/zizmor/src/audit/unsound_contains.rs
@@ -5,6 +5,7 @@ use github_actions_expressions::{
     call::{Call, Function},
     context::Context,
     literal::Literal,
+    op::BinExpr,
 };
 use github_actions_models::common::If;
 
@@ -106,13 +107,13 @@ impl UnsoundContains {
                 Box::new(exprs.iter().flat_map(Self::walk_tree_for_unsound_contains))
             }
             Expr::Index(expr) => Self::walk_tree_for_unsound_contains(expr),
-            Expr::BinOp { lhs, rhs, .. } => {
+            Expr::BinExpr(BinExpr { lhs, rhs, .. }) => {
                 let bc_lhs = Self::walk_tree_for_unsound_contains(lhs);
                 let bc_rhs = Self::walk_tree_for_unsound_contains(rhs);
 
                 Box::new(bc_lhs.chain(bc_rhs))
             }
-            Expr::UnOp { expr, .. } => Self::walk_tree_for_unsound_contains(expr),
+            Expr::UnExpr { expr, .. } => Self::walk_tree_for_unsound_contains(expr),
             _ => Box::new(std::iter::empty()),
         }
     }

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -654,12 +654,35 @@ fn test_trigger_heuristics_tag_only() -> anyhow::Result<()> {
     19 | |           # but *only* for tag events, which we consider unsafe becaue we assume that
     20 | |           # tag events correspond to releases.
     21 | |           sccache: ${{ startsWith(github.ref, 'refs/tags/') }}
-       | |_______________________________________________________________- enables caching explicitly here
+       | |______________________________________________________________- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    3 findings (2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:22:9
+       |
+     3 | / on:
+     4 | |   push:
+     5 | |     branches:
+     6 | |       - master
+     7 | |     tags:
+     8 | |       - "*"
+       | |___________- generally used when publishing artifacts generated at runtime
+    ...
+    22 |         - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    23 | /         with:
+    24 | |           # this is the opposite of #2050: caching is explicitly enabled here for
+    25 | |           # pushes to tag refs, which we consider unsafe because we assume that tag
+    26 | |           # pushes correspond to releases.
+    27 | |           sccache: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+       | |__________________________________________________________________________________- enables caching explicitly here
+       |
+       = note: audit confidence → Low
+       = note: this finding has an auto-fix
+
+    4 findings (2 suppressed, 2 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
     "#
     );
 
@@ -674,7 +697,7 @@ fn test_trigger_heuristics_tag_and_release() -> anyhow::Result<()> {
                 "cache-poisoning/trigger-heuristics/tag-and-release.yml"
             ))
             .run()?,
-        @"No findings to report. Good job! (2 suppressed)"
+        @"No findings to report. Good job!"
     );
 
     Ok(())
@@ -708,12 +731,35 @@ fn test_trigger_heuristics_tag_and_branch() -> anyhow::Result<()> {
     20 | |           # for this workflow, but since there's also a branch trigger that looks like
     21 | |           # a release we can't assert that all release events will also be tag events.
     22 | |           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-       | |________________________________________________________________- may enable caching here
+       | |_______________________________________________________________- may enable caching here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    3 findings (2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:23:9
+       |
+     3 | / on:
+     4 | |   push:
+     5 | |     branches:
+     6 | |       - release
+     7 | |     tags:
+     8 | |       - "*"
+     9 | |   release:
+       | |__________- generally used when publishing artifacts generated at runtime
+    ...
+    23 |         - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    24 | /         with:
+    25 | |           # same as above: we would consider this safe if there wasn't also a branch
+    26 | |           # trigger that looks like a release.
+    27 | |           sccache: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
+       | |_____________________________________________________________________________________- may enable caching here
+       |
+       = note: audit confidence → Low
+       = note: this finding has an auto-fix
+
+    4 findings (2 suppressed, 2 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/trigger-heuristics/tag-and-branch.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/trigger-heuristics/tag-and-branch.yml
@@ -20,3 +20,8 @@ jobs:
           # for this workflow, but since there's also a branch trigger that looks like
           # a release we can't assert that all release events will also be tag events.
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          # same as above: we would consider this safe if there wasn't also a branch
+          # trigger that looks like a release.
+          sccache: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/trigger-heuristics/tag-and-release.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/trigger-heuristics/tag-and-release.yml
@@ -10,11 +10,20 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.base_ref == main }}
+
 jobs:
   publish:
+    name: publish
     runs-on: ubuntu-latest
     steps:
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           # this is safe since both `push: tags` and `release` are tied to a tag.
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          # this is safe since both `push: tags` and `release` are tied to a tag.
+          sccache: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/trigger-heuristics/tag-only.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/trigger-heuristics/tag-only.yml
@@ -19,3 +19,9 @@ jobs:
           # but *only* for tag events, which we consider unsafe becaue we assume that
           # tag events correspond to releases.
           sccache: ${{ startsWith(github.ref, 'refs/tags/') }}
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          # this is the opposite of #2050: caching is explicitly enabled here for
+          # pushes to tag refs, which we consider unsafe because we assume that tag
+          # pushes correspond to releases.
+          sccache: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,11 @@ of `zizmor`.
 
     Many thanks to @andrew for proposing and implementing this improvement!
 
+### Enhancements 🌱
+
+* The [cache-poisoning] audit now detects additional cache disablement
+  heuristics (#2053)
+
 ### Performance Improvements 🚄
 
 * Most online audits are significantly faster, thanks to more precise retry handling (#2036)


### PR DESCRIPTION
This ended up being very large due to refactoring (mostly moving `BinExpr` into its own proper type and changing how origin tests are represented), but the core change is only a hundred lines or so.

TL;DR: we can now detect (with acceptable generality) patterns like `github.event_name == 'push' && github.ref_type == 'tag'` (and their negation). Needs more tests still.

Fixes #2050.
