### PR TITLE
impostor-commit: remove autofix

### DIFF
--- a/crates/zizmor/src/audit/impostor_commit.rs
+++ b/crates/zizmor/src/audit/impostor_commit.rs
@@ -16,7 +16,7 @@ use crate::{
     audit::AuditError,
     config::Config,
     finding::{
-        Confidence, Finding, Fix, FixDisposition, Severity,
+        Confidence, Finding, Severity,
         location::{Locatable as _, Routable},
     },
     github::{self, ComparisonStatus},
@@ -297,80 +297,6 @@ impl ImpostorCommit {
 
         Ok(highest_tag)
     }
-
-    /// Create a fix for an impostor commit by replacing it with the latest tag
-    async fn create_impostor_fix<'doc, T>(
-        &self,
-        uses: &RepositoryUses,
-        step: &T,
-    ) -> Option<Fix<'doc>>
-    where
-        T: StepCommon<'doc> + for<'a> Routable<'a, 'doc>,
-    {
-        self.create_fix_for_location(uses, step.location().key, step.route().with_key("uses"))
-            .await
-    }
-
-    /// Create a fix for a reusable workflow job
-    async fn create_reusable_fix<'doc>(
-        &self,
-        uses: &RepositoryUses,
-        job: &ReusableWorkflowCallJob<'doc>,
-    ) -> Option<Fix<'doc>> {
-        self.create_fix_for_location(
-            uses,
-            job.location().key,
-            job.location().route.with_key("uses"),
-        )
-        .await
-    }
-
-    /// Create a fix for the given location parameters
-    async fn create_fix_for_location<'doc>(
-        &self,
-        uses: &RepositoryUses,
-        key: &'doc InputKey,
-        route: yamlpath::Route<'doc>,
-    ) -> Option<Fix<'doc>> {
-        // Get the latest tag for this repository
-        let latest_tag = match self.get_highest_tag(uses).await {
-            Ok(Some(tag)) => tag,
-            Ok(None) => {
-                tracing::warn!(
-                    "No tags found for {}/{}, cannot create fix",
-                    uses.owner(),
-                    uses.repo()
-                );
-                return None;
-            }
-            Err(e) => {
-                tracing::error!(
-                    "Failed to get latest tag for {}/{}: {}",
-                    uses.owner(),
-                    uses.repo(),
-                    e
-                );
-                return None;
-            }
-        };
-
-        // Build the new uses string with the latest tag
-        let mut uses_slug = format!("{}/{}", uses.owner(), uses.repo());
-        if let Some(subpath) = &uses.subpath() {
-            uses_slug.push_str(&format!("/{subpath}"));
-        }
-        let fixed_uses = format!("{uses_slug}@{latest_tag}");
-
-        Some(Fix {
-            title: format!("pin to latest tag {latest_tag}"),
-            key,
-            disposition: FixDisposition::Unsafe,
-            patches: vec![Patch {
-                route,
-                operation: Op::Replace(fixed_uses.into()),
-            }],
-        })
-    }
 }
 
 #[async_trait::async_trait]
@@ -417,10 +343,6 @@ impl Audit for ImpostorCommit {
                                         .annotated(IMPOSTOR_ANNOTATION),
                                 );
 
-                            if let Some(fix) = self.create_impostor_fix(uses, &step).await {
-                                finding_builder = finding_builder.fix(fix);
-                            }
-
                             findings.push(finding_builder.build(workflow).map_err(Self::err)?);
                         }
                     }
@@ -445,10 +367,6 @@ impl Audit for ImpostorCommit {
                                     .primary()
                                     .annotated(IMPOSTOR_ANNOTATION),
                             );
-
-                        if let Some(fix) = self.create_reusable_fix(uses, &reusable).await {
-                            finding_builder = finding_builder.fix(fix);
-                        }
 
                         findings.push(finding_builder.build(workflow).map_err(Self::err)?);
                     }
@@ -490,122 +408,5 @@ impl Audit for ImpostorCommit {
         }
 
         Ok(findings)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    #[cfg(feature = "gh-token-tests")]
-    #[tokio::test]
-    async fn test_impostor_commit_fix_snapshot() {
-        use insta::assert_snapshot;
-
-        use crate::models::AsDocument as _;
-
-        use super::*;
-        use crate::{models::workflow::Workflow, registry::input::InputKey};
-
-        // Test with a workflow that uses a commit hash that doesn't exist in the target repository
-        // We'll use actions/hello-world-javascript-action with a commit from actions/checkout
-        // This creates an impostor scenario: valid commit, wrong repository
-        let workflow_content = r#"
-name: Test Impostor Commit Fix
-on: push
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/hello-world-javascript-action@692973e3d937129bcbf40652eb9f2f61becf3332  # This is a commit from actions/checkout, not hello-world
-"#;
-
-        let key = InputKey::local("dummy".into(), "test.yml", None::<&str>);
-        let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
-
-        let state = crate::state::AuditState {
-            no_online_audits: false,
-            gh_client: Some(
-                crate::github::Client::new(
-                    &crate::github::GitHubHost::Standard("github.com".to_string()),
-                    &crate::github::GitHubToken::new(&std::env::var("GH_TOKEN").unwrap()).unwrap(),
-                    "/tmp".into(),
-                )
-                .unwrap(),
-            ),
-        };
-
-        let audit = ImpostorCommit::new(&state).unwrap();
-        let input = workflow.into();
-        let findings = audit
-            .audit("impostor-commit", &input, &Config::default())
-            .await
-            .unwrap();
-
-        // If we detect an impostor commit, there should be a fix available
-        if !findings.is_empty() {
-            assert!(
-                !findings[0].fixes.is_empty(),
-                "Expected fix for impostor commit"
-            );
-
-            // Apply the fix and snapshot test the result
-            let new_doc = findings[0].fixes[0].apply(input.as_document()).unwrap();
-            assert_snapshot!(new_doc.source(), @"
-
-            name: Test Impostor Commit Fix
-            on: push
-            jobs:
-              test:
-                runs-on: ubuntu-latest
-                steps:
-                  - uses: actions/hello-world-javascript-action@v1.1  # This is a commit from actions/checkout, not hello-world
-            ");
-        }
-    }
-
-    #[cfg(feature = "gh-token-tests")]
-    #[tokio::test]
-    async fn test_no_impostor_with_valid_tag() {
-        use super::*;
-        use crate::{models::workflow::Workflow, registry::input::InputKey};
-
-        // Test with a valid tag to ensure we don't get false positives
-        let workflow_content = r#"
-name: Test Valid Tag
-on: push
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-"#;
-
-        let key = InputKey::local("dummy".into(), "test.yml", None::<&str>);
-        let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
-
-        let state = crate::state::AuditState {
-            no_online_audits: false,
-            gh_client: Some(
-                crate::github::Client::new(
-                    &crate::github::GitHubHost::Standard("github.com".to_string()),
-                    &crate::github::GitHubToken::new(&std::env::var("GH_TOKEN").unwrap()).unwrap(),
-                    "/tmp".into(),
-                )
-                .unwrap(),
-            ),
-        };
-
-        let audit = ImpostorCommit::new(&state).unwrap();
-        let input = workflow.into();
-        let findings = audit
-            .audit("impostor-commit", &input, &Config::default())
-            .await
-            .unwrap();
-
-        // With a valid tag, we should not find any impostor commits
-        assert!(
-            findings.is_empty(),
-            "Valid tags should not be flagged as impostor commits"
-        );
     }
 }

--- a/crates/zizmor/src/audit/impostor_commit.rs
+++ b/crates/zizmor/src/audit/impostor_commit.rs
@@ -15,22 +15,11 @@ use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::{
     audit::AuditError,
     config::Config,
-    finding::{
-        Confidence, Finding, Severity,
-        location::{Locatable as _, Routable},
-    },
+    finding::{Confidence, Finding, Severity, location::Locatable as _},
     github::{self, ComparisonStatus},
-    models::{
-        StepCommon,
-        uses::RepositoryUsesExt as _,
-        version::Version,
-        workflow::{ReusableWorkflowCallJob, Workflow},
-    },
-    registry::input::InputKey,
+    models::{StepCommon, uses::RepositoryUsesExt as _, workflow::Workflow},
     state::AuditState,
 };
-
-use yamlpatch::{Op, Patch};
 
 pub const IMPOSTOR_ANNOTATION: &str = "uses a commit that doesn't belong to the specified org/repo";
 
@@ -278,25 +267,6 @@ impl ImpostorCommit {
             _ => Ok(true),
         }
     }
-
-    /// Return the highest semantically versioned tag in the repository.
-    async fn get_highest_tag(&self, uses: &RepositoryUses) -> Result<Option<String>, AuditError> {
-        let tags = self
-            .client
-            .list_tags(uses.owner(), uses.repo())
-            .await
-            .map_err(Self::err)?;
-
-        // Filter tags down to those that can be parsed as semantic versions,
-        // get the highest one, and return its original string representation.
-        let highest_tag = tags
-            .iter()
-            .filter_map(|tag| Version::parse(&tag.name).ok())
-            .max()
-            .map(|vers| vers.raw().to_string());
-
-        Ok(highest_tag)
-    }
 }
 
 #[async_trait::async_trait]
@@ -331,7 +301,7 @@ impl Audit for ImpostorCommit {
                         };
 
                         if self.impostor(uses).await? {
-                            let mut finding_builder = Self::finding()
+                            let finding_builder = Self::finding()
                                 .severity(Severity::High)
                                 .confidence(Confidence::High)
                                 .add_location(step.location_with_grip())
@@ -355,7 +325,7 @@ impl Audit for ImpostorCommit {
                     };
 
                     if self.impostor(uses).await? {
-                        let mut finding_builder = Self::finding()
+                        let finding_builder = Self::finding()
                             .severity(Severity::High)
                             .confidence(Confidence::High)
                             .add_location(reusable.location_with_grip())
@@ -388,7 +358,7 @@ impl Audit for ImpostorCommit {
         };
 
         if self.impostor(uses).await? {
-            let mut finding_builder = Self::finding()
+            let finding_builder = Self::finding()
                 .severity(Severity::High)
                 .confidence(Confidence::High)
                 .add_location(step.location_with_grip())
@@ -399,10 +369,6 @@ impl Audit for ImpostorCommit {
                         .primary()
                         .annotated(IMPOSTOR_ANNOTATION),
                 );
-
-            if let Some(fix) = self.create_impostor_fix(uses, step).await {
-                finding_builder = finding_builder.fix(fix);
-            }
 
             findings.push(finding_builder.build(step).map_err(Self::err)?);
         }

--- a/crates/zizmor/src/models/version.rs
+++ b/crates/zizmor/src/models/version.rs
@@ -28,6 +28,7 @@ static_regex!(
 #[derive(Eq)]
 pub(crate) struct Version<'a> {
     /// The raw version, exactly as it appears in its source.
+    #[allow(dead_code)]
     raw: &'a str,
     major: u64,
     minor: u64,
@@ -78,11 +79,6 @@ impl<'a> Version<'a> {
             minor,
             patch,
         })
-    }
-
-    /// Return the raw version string, exactly as it was parsed.
-    pub(crate) fn raw(&self) -> &'a str {
-        self.raw
     }
 }
 
@@ -136,7 +132,7 @@ mod tests {
             assert_eq!(version.major, exp_major);
             assert_eq!(version.minor, exp_minor);
             assert_eq!(version.patch, exp_patch);
-            assert_eq!(version.raw(), input);
+            assert_eq!(version.raw, input);
         }
     }
 

--- a/crates/zizmor/tests/integration/audit/impostor_commit.rs
+++ b/crates/zizmor/tests/integration/audit/impostor_commit.rs
@@ -21,9 +21,8 @@ fn test_regular_persona() -> anyhow::Result<()> {
        | |____________________________________- this step
        |
        = note: audit confidence → High
-       = note: this finding has an auto-fix
 
-    4 findings (3 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
+    4 findings (3 suppressed): 0 informational, 0 low, 0 medium, 1 high
     "
     );
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,12 @@ of `zizmor`.
 
 * Fixed a bug where [ref-version-mismatch] would fail to fully match some version comments (#2040)
 
+### Changes ⚠️
+
+* The [impostor-commit] audit no longer suggests auto-fixes,
+  to avoid incorrectly minimizing the amount of manual remediation
+  work needed (#2054)
+
 ## 1.25.2
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
The more I think about this, the more I'm convinced it doesn't make sense to have an autofix here: a true-positive impostor commit is a very strong signal of total compromise, and silently moving the user to a real ref might give them the false impression that everything is fixed when really they need to perform manual, in-depth triage.

