### PR TITLE
dependabot-cooldown: honor config when fixing

### DIFF
--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -34,9 +34,10 @@ impl DependabotCooldown {
     /// Creates a fix that increases an insufficient default-days value
     fn create_increase_default_days_fix<'doc>(
         update: crate::models::dependabot::Update<'doc>,
+        minimum_days: u64,
     ) -> Fix<'doc> {
         Fix {
-            title: "increase default-days to 7".to_string(),
+            title: format!("increase default-days to {minimum_days}"),
             key: update.location().key,
             disposition: FixDisposition::Safe,
             patches: vec![Patch {
@@ -44,7 +45,7 @@ impl DependabotCooldown {
                     .location()
                     .route
                     .with_keys(["cooldown".into(), "default-days".into()]),
-                operation: Op::Replace(yaml_serde::Value::Number(7.into())),
+                operation: Op::Replace(yaml_serde::Value::Number(minimum_days.into())),
             }],
         }
     }
@@ -88,6 +89,8 @@ impl Audit for DependabotCooldown {
         config: &crate::config::Config,
     ) -> Result<Vec<crate::finding::Finding<'doc>>, AuditError> {
         let mut findings = vec![];
+
+        let minimum_days = config.dependabot_cooldown_config.days.get() as u64;
 
         for update in dependabot.updates() {
             // Check for cooldown + multi-ecosystem-group interaction.
@@ -152,24 +155,22 @@ impl Audit for DependabotCooldown {
                             .fix(Self::create_add_default_days_fix(update))
                             .build(dependabot)?,
                     ),
-                    Some(default_days)
-                        if default_days < config.dependabot_cooldown_config.days.get() as u64 =>
-                    {
-                        findings.push(
-                            Self::finding()
-                                .add_location(
-                                    update
-                                        .location()
-                                        .with_keys(["cooldown".into(), "default-days".into()])
-                                        .primary()
-                                        .annotated(format!("insufficient default-days configured (less than {days})", days = config.dependabot_cooldown_config.days)),
-                                )
-                                .confidence(Confidence::Medium)
-                                .severity(Severity::Low)
-                                .fix(Self::create_increase_default_days_fix(update))
-                                .build(dependabot)?,
-                        )
-                    }
+                    Some(default_days) if default_days < minimum_days => findings.push(
+                        Self::finding()
+                            .add_location(
+                                update
+                                    .location()
+                                    .with_keys(["cooldown".into(), "default-days".into()])
+                                    .primary()
+                                    .annotated(format!(
+                                        "insufficient default-days configured (less than {minimum_days})",
+                                    )),
+                            )
+                            .confidence(Confidence::Medium)
+                            .severity(Severity::Low)
+                            .fix(Self::create_increase_default_days_fix(update, minimum_days))
+                            .build(dependabot)?,
+                    ),
                     Some(_) => {}
                 },
                 None => findings.push(

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,12 +27,16 @@ of `zizmor`.
 
 ### Bug Fixes 🐛
 
-* Fixed a bug where zizmor's LSP would not recognize `dependabot.yaml` files in its
-  default configuration (#2026)
+* Fixed a bug where zizmor's LSP would not recognize `dependabot.yaml`
+  files in its default configuration (#2026)
 
     Many thanks to @fionn for implementing this fix!
 
-* Fixed a bug where [ref-version-mismatch] would fail to fully match some version comments (#2040)
+* Fixed a bug where [ref-version-mismatch] would fail to fully match some
+  version comments (#2040)
+
+* Fixed a bug where [dependabot-cooldown] would fail to honor the user's
+  configured days when performing autofixes (#2055)
 
 ### Changes ⚠️
 


### PR DESCRIPTION
Previously we only honored the config when auditing, not auto-fixing.

Fixes #2047. Closes #2048.