### PR TITLE
audit: add `unpinned-packages` rule

### DIFF
--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -51,6 +51,7 @@ pub(crate) mod template_injection;
 pub(crate) mod typosquat_uses;
 pub(crate) mod undocumented_permissions;
 pub(crate) mod unpinned_images;
+pub(crate) mod unpinned_packages;
 pub(crate) mod unpinned_tools;
 pub(crate) mod unpinned_uses;
 pub(crate) mod unredacted_secrets;

--- a/crates/zizmor/src/audit/unpinned_packages.rs
+++ b/crates/zizmor/src/audit/unpinned_packages.rs
@@ -1,0 +1,324 @@
+use crate::{
+    audit::{Audit, AuditError, AuditLoadError, audit_meta},
+    config::Config,
+    finding::{Confidence, Finding, Severity},
+    models::{StepBodyCommon, StepCommon, action::CompositeStep, workflow::Step},
+    state::AuditState,
+    utils::once::static_regex,
+};
+
+audit_meta!(
+    UnpinnedPackages,
+    "unpinned-packages",
+    "package installation outside the context of a lockfile"
+);
+
+static_regex!(NPM_INSTALL_PKG, r"(?mi)\bnpm\s+install\s+\S");
+static_regex!(PIP_INSTALL_PKG, r"(?mi)\bpip(?:\d+(?:\.\d+)?)?\s+install\s+\S");
+static_regex!(GEM_INSTALL_PKG, r"(?mi)\bgem\s+install\s+\S");
+static_regex!(NPX_EXEC, r"(?mi)\bnpx\s+(?:-y|--yes)\b");
+static_regex!(COMPOSER_REQUIRE, r"(?mi)\bcomposer\s+require\s+\S");
+
+pub(crate) struct UnpinnedPackages;
+
+impl UnpinnedPackages {
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let mut findings = vec![];
+
+        let StepBodyCommon::Run { run, .. } = step.body() else {
+            return Ok(findings);
+        };
+
+        if NPM_INSTALL_PKG.is_match(run) {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Medium)
+                    .confidence(Confidence::Medium)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(["run".into()])
+                            .annotated("npm install with package argument outside lockfile context"),
+                    )
+                    .tip("add the package to your package.json and use `npm ci` or `npm install` without arguments instead")
+                    .build(step)?,
+            );
+        }
+
+        if NPX_EXEC.is_match(run) {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Medium)
+                    .confidence(Confidence::Medium)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(["run".into()])
+                            .annotated("npx executed with --yes/-y flag, skipping install prompt"),
+                    )
+                    .tip("add the package to your package.json and use `npx` without `-y` or via a script instead")
+                    .build(step)?,
+            );
+        }
+
+        if PIP_INSTALL_PKG.is_match(run) {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Medium)
+                    .confidence(Confidence::Medium)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(["run".into()])
+                            .annotated("pip install outside the context of a lockfile or requirements file"),
+                    )
+                    .tip("pin dependencies in a requirements.txt or pyproject.toml and use `pip install -r requirements.txt` instead")
+                    .build(step)?,
+            );
+        }
+
+        if GEM_INSTALL_PKG.is_match(run) {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Medium)
+                    .confidence(Confidence::Medium)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(["run".into()])
+                            .annotated("gem install outside the context of a Gemfile"),
+                    )
+                    .tip("add the gem to your Gemfile and use `bundle exec` or `bundle install` instead")
+                    .build(step)?,
+            );
+        }
+
+        if COMPOSER_REQUIRE.is_match(run) {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Medium)
+                    .confidence(Confidence::Medium)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(["run".into()])
+                            .annotated("composer require outside the context of a lockfile"),
+                    )
+                    .tip("add the package to your composer.json and use `composer install` instead")
+                    .build(step)?,
+            );
+        }
+
+        Ok(findings)
+    }
+}
+
+#[async_trait::async_trait]
+impl Audit for UnpinnedPackages {
+    fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    async fn audit_step<'doc>(
+        &self,
+        step: &Step<'doc>,
+        _config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        self.process_step(step)
+    }
+
+    async fn audit_composite_step<'a>(
+        &self,
+        step: &CompositeStep<'a>,
+        _config: &Config,
+    ) -> Result<Vec<Finding<'a>>, AuditError> {
+        self.process_step(step)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::Config,
+        models::{workflow::Workflow},
+        registry::input::InputKey,
+        state::AuditState,
+    };
+
+    /// Macro for testing workflow audits with common boilerplate
+    macro_rules! test_workflow_audit {
+        ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
+            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
+            let audit_state = AuditState::default();
+            let audit = <$audit_type>::new(&audit_state).unwrap();
+            let findings = audit
+                .audit_workflow(&workflow, &Config::default())
+                .await
+                .unwrap();
+
+            $test_fn(&workflow, findings)
+        }};
+    }
+
+    #[tokio::test]
+    async fn test_npm_install_package() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm install some-package
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_npm_install.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(!findings.is_empty(), "Expected findings but got none");
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_npm_install_no_args_no_finding() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm install
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_npm_install_no_args.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(findings.is_empty());
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_npm_ci_no_finding() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm ci
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_npm_ci.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(findings.is_empty());
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gem_install() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gem install gem-release
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_gem_install.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(!findings.is_empty(), "Expected findings but got none");
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_npx_yes() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npx -y some-tool
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_npx_yes.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(!findings.is_empty(), "Expected findings but got none");
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pip_install() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pip install requests
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_pip_install.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(!findings.is_empty(), "Expected findings but got none");
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_composer_require() {
+        let workflow_content = r#"
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: composer require vendor/package
+"#;
+
+        test_workflow_audit!(
+            UnpinnedPackages,
+            "test_composer_require.yml",
+            workflow_content,
+            |_workflow: &Workflow, findings: Vec<Finding>| {
+                assert!(!findings.is_empty(), "Expected findings but got none");
+            }
+        );
+    }
+}

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -81,6 +81,7 @@ impl AuditRegistry {
         register_audit!(audit::superfluous_actions::SuperfluousActions);
         register_audit!(audit::github_app::GitHubApp);
         register_audit!(audit::unpinned_tools::UnpinnedTools);
+        register_audit!(audit::unpinned_packages::UnpinnedPackages);
 
         Ok(registry)
     }

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1910,6 +1910,75 @@ by running `#!bash docker inspect redis:7.4.3 --format='{{.RepoDigests}}'`.
               - run: "echo pinned container!"
         ```
 
+## `unpinned-packages`
+
+| Type     | Examples                | Introduced in | Works offline  | Auto-fixes available | Configurable |
+|----------|-------------------------|---------------|----------------|--------------------|--------------|
+| Workflow, Action  | N/A            | v1.26.0        | ✅            | ❌                | ❌          |
+
+
+
+Detects package installations performed outside the context of a lockfile,
+e.g. `#!bash npm install <pkg>`, `#!bash gem install <pkg>`, or
+`#!bash pip install <pkg>`.
+
+Installing packages directly through a package manager without going through
+a lockfile (like `package-lock.json`, `Gemfile.lock`, or `requirements.txt`)
+poses several supply chain security risks:
+
+* **No version pinning**: the latest version of the package and all of its
+  dependencies are installed automatically, increasing the likelihood of
+  pulling in a compromised release.
+* **No hash verification**: package managers that support content hashing
+  (like `npm` and `pip`) cannot enforce hash checks without a lockfile.
+* **Difficult post-incident analysis**: without a lockfile, determining
+  which exact versions were installed at a given point in time requires
+  sifting through job logs, which may not include specific version information.
+
+This audit detects the following patterns in `#!yaml run:` steps:
+
+* `npm install <pkg>` (installing individual packages without a lockfile)
+* `npx -y <pkg>` or `npx --yes <pkg>` (executing packages with automatic install)
+* `pip install <pkg>` (installing packages outside of a requirements file)
+* `gem install <pkg>` (installing gems outside of a Gemfile)
+* `composer require <pkg>` (requiring packages without a lockfile)
+
+!!! note
+
+    `#!bash npm install` (without arguments) and `#!bash npm ci` are not
+    flagged, as they install from the project's `package-lock.json`.
+
+### Remediation
+
+Add the package to your project's dependency manifest (`package.json`,
+`Gemfile`, `requirements.txt`, `composer.json`, etc.) and install from
+the lockfile instead.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="unpinned-packages.yml" hl_lines="5"
+        jobs:
+          release:
+            runs-on: ubuntu-latest
+            steps:
+              - run: gem install gem-release
+              - run: gem-release
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="unpinned-packages.yml" hl_lines="4-6"
+        jobs:
+          release:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Install dependencies
+                run: bundle install
+              - run: bundle exec gem-release
+        ```
+
 ## `unpinned-tools`
 
 | Type     | Examples                | Introduced in | Works offline  | Auto-fixes available | Configurable |


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->
Detects direct package installs outside lockfile context (`npm install <pkg>`, `gem install <pkg>`, `pip install <pkg>`, `npx -y`, `composer require <pkg>`) in workflow `run:` steps.

closes #2057 