### PR TITLE
feat(adhoc-packages): Implement an adhoc-packages rule for banning `gem install pkg` and `npm install pkg` commands.

### DIFF
--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -12,12 +12,9 @@ use crate::{
 };
 
 const BASH_COMMAND_QUERY: &str = "(command name: (_) @cmd argument: (_)+ @args) @span";
-const PWSH_COMMAND_QUERY: &str =
-    "(command command_name: (_) @cmd command_elements: (_ (generic_token) @args)+) @span";
 
 pub(crate) struct AdhocPackages {
     bash_command_query: utils::SpannedQuery,
-    pwsh_command_query: utils::SpannedQuery,
 }
 
 audit_meta!(
@@ -41,6 +38,7 @@ impl AdhocPackages {
     /// ad-hoc package installation, e.g. `gem install <package>`.
     fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
         match cmd {
+            // TODO: Add support for `npm install pkg` and `pip install pkg`, etc later.
             "gem" => {
                 // Looking for `gem install <pkg> ...`, where `install` is the
                 // first non-flag argument and at least one package name follows.
@@ -75,15 +73,10 @@ impl AdhocPackages {
 
                 (&self.bash_command_query, tree)
             }
-            "pwsh" | "powershell" => {
-                let mut parser = utils::pwsh_parser();
-                let tree = parser
-                    .parse(run, None)
-                    .context("failed to parse `run:` body as pwsh")
-                    .map_err(Self::err)?;
-
-                (&self.pwsh_command_query, tree)
-            }
+            // TODO: support pwsh. The tree-sitter-powershell grammar emits
+            // each `command_elements` child as its own query match, which
+            // breaks the multi-arg `gem install <pkg>` pattern we need to
+            // detect here.
             _ => {
                 tracing::debug!("unable to analyze 'run:' block: unknown shell '{normalized}'");
                 return Ok(vec![]);
@@ -150,7 +143,13 @@ impl AdhocPackages {
             return Ok(findings);
         };
 
-        let shell = step.shell().map(|s| s.0).unwrap_or("bash");
+        let shell = step.shell().map(|s| s.0).unwrap_or_else(|| {
+            tracing::debug!(
+                "adhoc-packages: couldn't determine shell for step {idx}; assuming bash",
+                idx = step.index()
+            );
+            "bash"
+        });
 
         for subfeature in self.adhoc_install_candidates(run, shell)? {
             findings.push(
@@ -184,7 +183,6 @@ impl Audit for AdhocPackages {
     fn new(_state: &AuditState) -> Result<Self, AuditLoadError> {
         Ok(Self {
             bash_command_query: utils::SpannedQuery::new(BASH_COMMAND_QUERY, &utils::BASH),
-            pwsh_command_query: utils::SpannedQuery::new(PWSH_COMMAND_QUERY, &utils::PWSH),
         })
     }
 
@@ -211,8 +209,10 @@ mod tests {
     fn test_is_adhoc_install_command() {
         for (args, expected) in &[
             (&["gem", "install", "rake"][..], true),
+            (&["gem", "install", "rails:7.0.0"][..], true),
             (&["gem", "install", "rake", "rspec"][..], true),
             (&["gem", "install", "--no-document", "rake"][..], true),
+            (&["gem", "install", "rails", "--no-document"][..], true),
             (&["gem", "install", "rake", "-v", "13.0.6"][..], true),
             (&["gem", "--silent", "install", "rake"][..], true),
             // No package, just flags

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -45,7 +45,9 @@ impl AdhocPackages {
                 // don't flag malformed invocations like `gem install`.
                 // Looking for `gem install <pkg> ...`, where `install` is the
                 // first non-flag argument and at least one package name follows.
-                args.any(|arg| arg == "install") && args.any(|arg| !arg.starts_with('-'))
+                // `gem i` is a documented alias for `gem install`.
+                args.any(|arg| arg == "install" || arg == "i")
+                    && args.any(|arg| !arg.starts_with('-'))
             }
             "npm" => {
                 // Looking for `npm install <pkg>` or `npm exec <pkg>`, where
@@ -241,9 +243,14 @@ mod tests {
             (&["gem", "install", "rails", "--no-document"][..], true),
             (&["gem", "install", "rake", "-v", "13.0.6"][..], true),
             (&["gem", "--silent", "install", "rake"][..], true),
+            // `gem i` is an alias for `gem install`.
+            (&["gem", "i", "rake"][..], true),
+            (&["gem", "i", "--no-document", "rake"][..], true),
             // No package, just flags
             (&["gem", "install"][..], false),
             (&["gem", "install", "--help"][..], false),
+            (&["gem", "i"][..], false),
+            (&["gem", "i", "--help"][..], false),
             // Other gem subcommands
             (&["gem", "build", "foo.gemspec"][..], false),
             (&["gem", "push", "foo-0.1.0.gem"][..], false),

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -286,7 +286,6 @@ mod tests {
             // In the future we should consider catching wrapped commands, those using `sudo` and so on.
             // (&["sudo", "gem", "install", "rails"][..], true),
             // (&["bundle", "exec", "gem", "install", "rails"][..], true),
-
         ] {
             let cmd = args[0];
             let args_iter = args[1..].iter().copied();

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -37,6 +37,8 @@ impl AdhocPackages {
     /// Determine whether the given command and arguments correspond to an
     /// ad-hoc package installation, e.g. `gem install <package>`.
     fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
+    
+    let mut args = args;
         match cmd {
             // TODO: Add support for `npm install pkg` and `pip install pkg`, etc later.
             "gem" => {

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -283,6 +283,10 @@ mod tests {
             (&["npx", "foobar@1.2.3"][..], false),
             // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),
+            // In the future we should consider catching wrapped commands, those using `sudo` and so on.
+            // (&["sudo", "gem", "install", "rails"][..], true),
+            // (&["bundle", "exec", "gem", "install", "rails"][..], true),
+
         ] {
             let cmd = args[0];
             let args_iter = args[1..].iter().copied();

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -25,7 +25,7 @@ pub(crate) struct AdhocPackages {
 audit_meta!(
     AdhocPackages,
     "adhoc-packages",
-    "ad-hoc package installation outside of a lockfile"
+    "ad-hoc installation of packages"
 );
 
 impl AdhocPackages {

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -37,18 +37,10 @@ impl AdhocPackages {
     /// Determine whether the given command and arguments correspond to an
     /// ad-hoc package installation, e.g. `gem install <package>`.
     fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
-    
-    let mut args = args;
+        let mut args = args;
         match cmd {
             // TODO: Add support for `npm install pkg` and `pip install pkg`, etc later.
             "gem" => {
-                // Looking for `gem install <pkg> ...`, where `install` is the
-                // first non-flag argument and at least one package name follows.
-                let mut args = args.skip_while(|arg| arg.starts_with('-'));
-                if args.next() != Some("install") {
-                    return false;
-                }
-
                 // Require at least one non-flag argument after `install` so we
                 // don't flag malformed invocations like `gem install`.
                 // Looking for `gem install <pkg> ...`, where `install` is the

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -1,0 +1,239 @@
+use anyhow::Context as _;
+use subfeature::Subfeature;
+use tree_sitter::StreamingIterator as _;
+
+use super::{Audit, AuditLoadError, audit_meta};
+use crate::audit::AuditError;
+use crate::{
+    finding::{Confidence, Finding, Severity},
+    models::{StepBodyCommon, StepCommon},
+    state::AuditState,
+    utils,
+};
+
+const BASH_COMMAND_QUERY: &str = "(command name: (_) @cmd argument: (_)+ @args) @span";
+const PWSH_COMMAND_QUERY: &str =
+    "(command command_name: (_) @cmd command_elements: (_ (generic_token) @args)+) @span";
+
+pub(crate) struct AdhocPackages {
+    bash_command_query: utils::SpannedQuery,
+    pwsh_command_query: utils::SpannedQuery,
+}
+
+audit_meta!(
+    AdhocPackages,
+    "adhoc-packages",
+    "ad-hoc package installation outside of a lockfile"
+);
+
+impl AdhocPackages {
+    fn query<'a>(
+        &self,
+        query: &'a utils::SpannedQuery,
+        cursor: &'a mut tree_sitter::QueryCursor,
+        tree: &'a tree_sitter::Tree,
+        source: &'a str,
+    ) -> tree_sitter::QueryMatches<'a, 'a, &'a [u8], &'a [u8]> {
+        cursor.matches(query, tree.root_node(), source.as_bytes())
+    }
+
+    /// Determine whether the given command and arguments correspond to an
+    /// ad-hoc package installation, e.g. `gem install <package>`.
+    fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
+        match cmd {
+            "gem" => {
+                // Looking for `gem install <pkg> ...`, where `install` is the
+                // first non-flag argument and at least one package name follows.
+                let mut args = args.skip_while(|arg| arg.starts_with('-'));
+                if args.next() != Some("install") {
+                    return false;
+                }
+
+                // Require at least one non-flag argument after `install` so we
+                // don't flag malformed invocations like `gem install`.
+                args.any(|arg| !arg.starts_with('-'))
+            }
+            _ => false,
+        }
+    }
+
+    fn adhoc_install_candidates<'doc>(
+        &self,
+        run: &'doc str,
+        shell: &str,
+    ) -> Result<Vec<Subfeature<'doc>>, AuditError> {
+        let normalized = utils::normalize_shell(shell);
+
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let (query, tree) = match normalized {
+            "bash" | "sh" | "zsh" => {
+                let mut parser = utils::bash_parser();
+                let tree = parser
+                    .parse(run, None)
+                    .context("failed to parse `run:` body as bash")
+                    .map_err(Self::err)?;
+
+                (&self.bash_command_query, tree)
+            }
+            "pwsh" | "powershell" => {
+                let mut parser = utils::pwsh_parser();
+                let tree = parser
+                    .parse(run, None)
+                    .context("failed to parse `run:` body as pwsh")
+                    .map_err(Self::err)?;
+
+                (&self.pwsh_command_query, tree)
+            }
+            _ => {
+                tracing::debug!("unable to analyze 'run:' block: unknown shell '{normalized}'");
+                return Ok(vec![]);
+            }
+        };
+
+        let matches = self.query(query, &mut cursor, &tree, run);
+        let cmd = query
+            .capture_index_for_name("cmd")
+            .expect("internal error: missing capture index for 'cmd'");
+        let args = query
+            .capture_index_for_name("args")
+            .expect("internal error: missing capture index for 'args'");
+
+        let mut subfeatures = vec![];
+        matches.for_each(|mat| {
+            let cmd = {
+                let cap = mat
+                    .captures
+                    .iter()
+                    .find(|cap| cap.index == cmd)
+                    .expect("internal error: expected capture for cmd");
+                cap.node
+                    .utf8_text(run.as_bytes())
+                    .expect("impossible: capture should be UTF-8 by construction")
+            };
+
+            let args = mat
+                .captures
+                .iter()
+                .filter(|cap| cap.index == args)
+                .map(|cap| {
+                    cap.node
+                        .utf8_text(run.as_bytes())
+                        .expect("impossible: capture should be UTF-8 by construction")
+                });
+
+            if Self::is_adhoc_install_command(cmd, args) {
+                let span = mat
+                    .captures
+                    .iter()
+                    .find(|cap| cap.index == query.span_idx)
+                    .expect("internal error: expected capture for span");
+
+                let span_contents = span
+                    .node
+                    .utf8_text(run.as_bytes())
+                    .expect("impossible: capture should be UTF-8 by construction");
+
+                subfeatures.push(Subfeature::new(span.node.start_byte(), span_contents));
+            }
+        });
+
+        Ok(subfeatures)
+    }
+
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let mut findings = vec![];
+
+        let StepBodyCommon::Run { run, .. } = step.body() else {
+            return Ok(findings);
+        };
+
+        let shell = step.shell().map(|s| s.0).unwrap_or("bash");
+
+        for subfeature in self.adhoc_install_candidates(run, shell)? {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Low)
+                    .confidence(Confidence::High)
+                    .add_location(step.location().hidden())
+                    .add_location(
+                        step.location()
+                            .with_keys(["run".into()])
+                            .key_only()
+                            .annotated("this step"),
+                    )
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(["run".into()])
+                            .subfeature(subfeature)
+                            .annotated("installs a package outside of a lockfile"),
+                    )
+                    .build(step)?,
+            );
+        }
+
+        Ok(findings)
+    }
+}
+
+#[async_trait::async_trait]
+impl Audit for AdhocPackages {
+    fn new(_state: &AuditState) -> Result<Self, AuditLoadError> {
+        Ok(Self {
+            bash_command_query: utils::SpannedQuery::new(BASH_COMMAND_QUERY, &utils::BASH),
+            pwsh_command_query: utils::SpannedQuery::new(PWSH_COMMAND_QUERY, &utils::PWSH),
+        })
+    }
+
+    async fn audit_step<'doc>(
+        &self,
+        step: &crate::models::workflow::Step<'doc>,
+        _config: &crate::config::Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        self.process_step(step)
+    }
+
+    async fn audit_composite_step<'doc>(
+        &self,
+        step: &crate::models::action::CompositeStep<'doc>,
+        _config: &crate::config::Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        self.process_step(step)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_is_adhoc_install_command() {
+        for (args, expected) in &[
+            (&["gem", "install", "rake"][..], true),
+            (&["gem", "install", "rake", "rspec"][..], true),
+            (&["gem", "install", "--no-document", "rake"][..], true),
+            (&["gem", "install", "rake", "-v", "13.0.6"][..], true),
+            (&["gem", "--silent", "install", "rake"][..], true),
+            // No package, just flags
+            (&["gem", "install"][..], false),
+            (&["gem", "install", "--help"][..], false),
+            // Other gem subcommands
+            (&["gem", "build", "foo.gemspec"][..], false),
+            (&["gem", "push", "foo-0.1.0.gem"][..], false),
+            (&["gem", "env"][..], false),
+            // Unrelated commands
+            (&["bundle", "install"][..], false),
+            (&["npm", "install", "lodash"][..], false),
+            (&["pip", "install", "requests"][..], false),
+        ] {
+            let cmd = args[0];
+            let args_iter = args[1..].iter().copied();
+            assert_eq!(
+                super::AdhocPackages::is_adhoc_install_command(cmd, args_iter),
+                *expected,
+                "cmd: {cmd:?}, args: {args:?}"
+            );
+        }
+    }
+}

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -224,8 +224,15 @@ mod tests {
             (&["gem", "env"][..], false),
             // `bundle install` is lockfile-aware, so it should stay false.
             (&["bundle", "install"][..], false),
-            // TODO: flip to `true` once `npm install` is covered.
+            // TODO: flip to `true` once `npm install`/`npx` is covered.
             (&["npm", "install", "lodash"][..], false),
+            (&["npm", "install", "oxlint@1.55.0"][..], false),
+            (&["npm", "install", "--no-fund", "oxlint@1.55.0"][..], false),
+            (&["npx", "-y", "lodash"][..], false),
+            (&["npx", "--yes", "lodash"][..], false),
+            (&["npx", "--yes", "lodash@1.2.3"][..], false),
+            (&["npm", "exec", "lodash"][..], false),
+            (&["npm", "exec", "lodash@1.2.3"][..], false),
             // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),
         ] {

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -44,7 +44,7 @@ impl AdhocPackages {
     fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
         let mut args = args;
         match cmd {
-            // TODO: Add support for `pip install pkg`, etc later.
+            // TODO: Add support for `pip install pkg`, `yarn install pkg`, etc. later.
             "gem" => {
                 // Require at least one non-flag argument after `install` so we
                 // don't flag malformed invocations like `gem install`.
@@ -258,10 +258,11 @@ mod tests {
             (&["gem", "env"][..], false),
             // `bundle install` is lockfile-aware, so it should stay false.
             (&["bundle", "install"][..], false),
-            // `npm install`/`npx` is also disallowed.
+            // `npm install pkg` is also disallowed.
             (&["npm", "install", "lodash"][..], true),
             (&["npm", "install", "oxlint@1.55.0"][..], true),
             (&["npm", "install", "--no-fund", "oxlint@1.55.0"][..], true),
+            (&["npm", "install", "oxlint@^1.55.0"][..], true),
             // `npm install` aliases — `i`/`add` are common; `isnt` etc. are
             // documented typo-tolerant aliases.
             (&["npm", "i", "lodash"][..], true),
@@ -275,7 +276,7 @@ mod tests {
             (&["npm", "install", "--help"][..], false),
             (&["npm", "install", "--no-fund"][..], false),
             (&["npm", "ci"][..], false),
-            // `npx` is not flagged for now.
+            // `npx` is not flagged for now, should be considered in the future.
             (&["npx", "foobar"][..], false),
             (&["npx", "-y", "foobar"][..], false),
             (&["npx", "--yes", "foobar"][..], false),

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -235,16 +235,21 @@ mod tests {
             (&["npm", "install", "lodash"][..], true),
             (&["npm", "install", "oxlint@1.55.0"][..], true),
             (&["npm", "install", "--no-fund", "oxlint@1.55.0"][..], true),
+            (&["npm", "install", "package-with-dashes"][..], true),
             (&["npx", "-y", "lodash"][..], true),
             (&["npx", "--yes", "lodash"][..], true),
             (&["npx", "--yes", "lodash@1.2.3"][..], true),
             (&["npm", "exec", "lodash"][..], true),
             (&["npm", "exec", "lodash@1.2.3"][..], true),
+            (&["npm", "exec", "--package=lodash@1.2.3"][..], true),
+            (&["npm", "exec", "-p=lodash@1.2.3"][..], true),
+            (&["npm", "exec", "--ws", "--", "eslint", "./*.js"][..], true),
             // npm flags without a package shouldn't be flagged.
             (&["npm", "install", "--help"][..], false),
             (&["npm", "install", "--no-fund"][..], false),
             (&["npm", "ci"][..], false),
             (&["npx", "foobar"][..], false),
+            (&["npx", "foobar@1.2.3"][..], false),
             // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),
         ] {

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -222,9 +222,11 @@ mod tests {
             (&["gem", "build", "foo.gemspec"][..], false),
             (&["gem", "push", "foo-0.1.0.gem"][..], false),
             (&["gem", "env"][..], false),
-            // Unrelated commands
+            // `bundle install` is lockfile-aware, so it should stay false.
             (&["bundle", "install"][..], false),
+            // TODO: flip to `true` once `npm install` is covered.
             (&["npm", "install", "lodash"][..], false),
+            // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),
         ] {
             let cmd = args[0];

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -12,9 +12,14 @@ use crate::{
 };
 
 const BASH_COMMAND_QUERY: &str = "(command name: (_) @cmd argument: (_)+ @args) @span";
+const PWSH_COMMAND_QUERY: &str = "(command \
+    command_name: (_) @cmd \
+    command_elements: (command_elements (_)+ @args) \
+) @span";
 
 pub(crate) struct AdhocPackages {
     bash_command_query: utils::SpannedQuery,
+    pwsh_command_query: utils::SpannedQuery,
 }
 
 audit_meta!(
@@ -97,13 +102,16 @@ impl AdhocPackages {
                     .parse(run, None)
                     .context("failed to parse `run:` body as bash")
                     .map_err(Self::err)?;
-
                 (&self.bash_command_query, tree)
             }
-            // TODO: support pwsh. The tree-sitter-powershell grammar emits
-            // each `command_elements` child as its own query match, which
-            // breaks the multi-arg `gem install <pkg>` pattern we need to
-            // detect here.
+            "pwsh" | "powershell" => {
+                let mut parser = utils::pwsh_parser();
+                let tree = parser
+                    .parse(run, None)
+                    .context("failed to parse `run:` body as pwsh")
+                    .map_err(Self::err)?;
+                (&self.pwsh_command_query, tree)
+            }
             _ => {
                 tracing::debug!("unable to analyze 'run:' block: unknown shell '{normalized}'");
                 return Ok(vec![]);
@@ -111,10 +119,10 @@ impl AdhocPackages {
         };
 
         let matches = self.query(query, &mut cursor, &tree, run);
-        let cmd = query
+        let cmd_idx = query
             .capture_index_for_name("cmd")
             .expect("internal error: missing capture index for 'cmd'");
-        let args = query
+        let args_idx = query
             .capture_index_for_name("args")
             .expect("internal error: missing capture index for 'args'");
 
@@ -124,7 +132,7 @@ impl AdhocPackages {
                 let cap = mat
                     .captures
                     .iter()
-                    .find(|cap| cap.index == cmd)
+                    .find(|cap| cap.index == cmd_idx)
                     .expect("internal error: expected capture for cmd");
                 cap.node
                     .utf8_text(run.as_bytes())
@@ -134,7 +142,13 @@ impl AdhocPackages {
             let args = mat
                 .captures
                 .iter()
-                .filter(|cap| cap.index == args)
+                .filter(|cap| cap.index == args_idx)
+                // The powershell grammar interleaves `command_argument_sep`
+                // whitespace nodes between real arguments inside
+                // `command_elements`. They have no analogue in bash, so
+                // filtering here is a no-op for bash but lets the single
+                // query work for pwsh too.
+                .filter(|cap| cap.node.kind() != "command_argument_sep")
                 .map(|cap| {
                     cap.node
                         .utf8_text(run.as_bytes())
@@ -210,6 +224,7 @@ impl Audit for AdhocPackages {
     fn new(_state: &AuditState) -> Result<Self, AuditLoadError> {
         Ok(Self {
             bash_command_query: utils::SpannedQuery::new(BASH_COMMAND_QUERY, &utils::BASH),
+            pwsh_command_query: utils::SpannedQuery::new(PWSH_COMMAND_QUERY, &utils::PWSH),
         })
     }
 

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -48,8 +48,27 @@ impl AdhocPackages {
                 args.any(|arg| arg == "install") && args.any(|arg| !arg.starts_with('-'))
             }
             "npm" => {
-                args.any(|arg| arg == "install" || arg == "exec")
-                    && args.any(|arg| !arg.starts_with('-'))
+                // Looking for `npm install <pkg>` or `npm exec <pkg>`, where
+                // the subcommand is the first non-flag argument.
+                let mut args = args.skip_while(|arg| arg.starts_with('-'));
+                match args.next() {
+                    // `npm install` and its many documented aliases. Without
+                    // a package name, the command installs from
+                    // package-lock.json, so it's lockfile-aware.
+                    Some(
+                        "install" | "i" | "in" | "ins" | "inst" | "insta" | "instal" | "isnt"
+                        | "isnta" | "isntal" | "isntall" | "add",
+                    ) => args.any(|arg| !arg.starts_with('-')),
+                    // `npm exec` triggers an install when either a package
+                    // name is given positionally or via `-p`/`--package`.
+                    Some("exec" | "x") => args.any(|arg| {
+                        !arg.starts_with('-')
+                            || matches!(arg, "-p" | "--package")
+                            || arg.starts_with("-p=")
+                            || arg.starts_with("--package=")
+                    }),
+                    _ => false,
+                }
             }
             // Only hit npx if it has -y or --yes, to avoid flagging npx
             // invocations that run a package installed via lockfile.
@@ -235,12 +254,30 @@ mod tests {
             (&["npm", "install", "lodash"][..], true),
             (&["npm", "install", "oxlint@1.55.0"][..], true),
             (&["npm", "install", "--no-fund", "oxlint@1.55.0"][..], true),
+            // `npm install` aliases — `i`/`add` are common; `isnt` etc. are
+            // documented typo-tolerant aliases.
+            (&["npm", "i", "lodash"][..], true),
+            (&["npm", "add", "lodash"][..], true),
+            (&["npm", "isnt", "lodash"][..], true),
+            (&["npm", "i", "--no-fund", "oxlint@1.55.0"][..], true),
+            (&["npm", "i", "--help"][..], false),
+            (&["npm", "i"][..], false),
             (&["npm", "install", "package-with-dashes"][..], true),
             (&["npx", "-y", "lodash"][..], true),
             (&["npx", "--yes", "lodash"][..], true),
             (&["npx", "--yes", "lodash@1.2.3"][..], true),
             (&["npm", "exec", "lodash"][..], true),
             (&["npm", "exec", "lodash@1.2.3"][..], true),
+            // `npm x` is an alias for `npm exec`.
+            (&["npm", "x", "lodash"][..], true),
+            (&["npm", "x", "--package=lodash"][..], true),
+            // `npm exec` with `-p`/`--package` installs the named package
+            // even when only flags are present (i.e. no positional pkg).
+            (&["npm", "exec", "-p", "lodash"][..], true),
+            (&["npm", "exec", "--package", "lodash"][..], true),
+            (&["npm", "exec", "-p=lodash"][..], true),
+            (&["npm", "exec", "--package=lodash"][..], true),
+            (&["npm", "exec", "--package=lodash", "--", "ls"][..], true),
             (&["npm", "exec", "--package=lodash@1.2.3"][..], true),
             (&["npm", "exec", "-p=lodash@1.2.3"][..], true),
             (&["npm", "exec", "--ws", "--", "eslint", "./*.js"][..], true),
@@ -248,6 +285,8 @@ mod tests {
             (&["npm", "install", "--help"][..], false),
             (&["npm", "install", "--no-fund"][..], false),
             (&["npm", "ci"][..], false),
+            // `npx` without `-y` or `--yes` shouldn't be flagged, as it means they are
+            // running a package that was installed already.
             (&["npx", "foobar"][..], false),
             (&["npx", "foobar@1.2.3"][..], false),
             // TODO: flip to `true` once `pip install` is covered.

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -51,7 +51,9 @@ impl AdhocPackages {
 
                 // Require at least one non-flag argument after `install` so we
                 // don't flag malformed invocations like `gem install`.
-                args.any(|arg| !arg.starts_with('-'))
+                // Looking for `gem install <pkg> ...`, where `install` is the
+                // first non-flag argument and at least one package name follows.
+                args.any(|arg| arg == "install") && args.any(|arg| !arg.starts_with('-'))
             }
             _ => false,
         }

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -66,22 +66,8 @@ impl AdhocPackages {
                         "install" | "i" | "in" | "ins" | "inst" | "insta" | "instal" | "isnt"
                         | "isnta" | "isntal" | "isntall" | "add",
                     ) => args.any(|arg| !arg.starts_with('-')),
-                    // `npm exec` triggers an install when either a package
-                    // name is given positionally or via `-p`/`--package`.
-                    Some("exec" | "x") => args.any(|arg| {
-                        !arg.starts_with('-')
-                            || matches!(arg, "-p" | "--package")
-                            || arg.starts_with("-p=")
-                            || arg.starts_with("--package=")
-                    }),
                     _ => false,
                 }
-            }
-            // Only hit npx if it has -y or --yes, to avoid flagging npx
-            // invocations that run a package installed via lockfile.
-            "npx" => {
-                args.any(|arg| arg == "-y" || arg == "--yes")
-                    && args.any(|arg| !arg.starts_with('-'))
             }
             _ => false,
         }
@@ -285,31 +271,14 @@ mod tests {
             (&["npm", "i", "--help"][..], false),
             (&["npm", "i"][..], false),
             (&["npm", "install", "package-with-dashes"][..], true),
-            (&["npx", "-y", "lodash"][..], true),
-            (&["npx", "--yes", "lodash"][..], true),
-            (&["npx", "--yes", "lodash@1.2.3"][..], true),
-            (&["npm", "exec", "lodash"][..], true),
-            (&["npm", "exec", "lodash@1.2.3"][..], true),
-            // `npm x` is an alias for `npm exec`.
-            (&["npm", "x", "lodash"][..], true),
-            (&["npm", "x", "--package=lodash"][..], true),
-            // `npm exec` with `-p`/`--package` installs the named package
-            // even when only flags are present (i.e. no positional pkg).
-            (&["npm", "exec", "-p", "lodash"][..], true),
-            (&["npm", "exec", "--package", "lodash"][..], true),
-            (&["npm", "exec", "-p=lodash"][..], true),
-            (&["npm", "exec", "--package=lodash"][..], true),
-            (&["npm", "exec", "--package=lodash", "--", "ls"][..], true),
-            (&["npm", "exec", "--package=lodash@1.2.3"][..], true),
-            (&["npm", "exec", "-p=lodash@1.2.3"][..], true),
-            (&["npm", "exec", "--ws", "--", "eslint", "./*.js"][..], true),
             // npm flags without a package shouldn't be flagged.
             (&["npm", "install", "--help"][..], false),
             (&["npm", "install", "--no-fund"][..], false),
             (&["npm", "ci"][..], false),
-            // `npx` without `-y` or `--yes` shouldn't be flagged, as it means they are
-            // running a package that was installed already.
+            // `npx` is not flagged for now.
             (&["npx", "foobar"][..], false),
+            (&["npx", "-y", "foobar"][..], false),
+            (&["npx", "--yes", "foobar"][..], false),
             (&["npx", "foobar@1.2.3"][..], false),
             // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -39,13 +39,23 @@ impl AdhocPackages {
     fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
         let mut args = args;
         match cmd {
-            // TODO: Add support for `npm install pkg` and `pip install pkg`, etc later.
+            // TODO: Add support for `pip install pkg`, etc later.
             "gem" => {
                 // Require at least one non-flag argument after `install` so we
                 // don't flag malformed invocations like `gem install`.
                 // Looking for `gem install <pkg> ...`, where `install` is the
                 // first non-flag argument and at least one package name follows.
                 args.any(|arg| arg == "install") && args.any(|arg| !arg.starts_with('-'))
+            }
+            "npm" => {
+                args.any(|arg| arg == "install" || arg == "exec")
+                    && args.any(|arg| !arg.starts_with('-'))
+            }
+            // Only hit npx if it has -y or --yes, to avoid flagging npx
+            // invocations that run a package installed via lockfile.
+            "npx" => {
+                args.any(|arg| arg == "-y" || arg == "--yes")
+                    && args.any(|arg| !arg.starts_with('-'))
             }
             _ => false,
         }
@@ -204,6 +214,7 @@ mod tests {
     #[test]
     fn test_is_adhoc_install_command() {
         for (args, expected) in &[
+            // `gem install` with various argument patterns that should be flagged as ad-hoc installs.
             (&["gem", "install", "rake"][..], true),
             (&["gem", "install", "rails:7.0.0"][..], true),
             (&["gem", "install", "rake", "rspec"][..], true),
@@ -220,15 +231,20 @@ mod tests {
             (&["gem", "env"][..], false),
             // `bundle install` is lockfile-aware, so it should stay false.
             (&["bundle", "install"][..], false),
-            // TODO: flip to `true` once `npm install`/`npx` is covered.
-            (&["npm", "install", "lodash"][..], false),
-            (&["npm", "install", "oxlint@1.55.0"][..], false),
-            (&["npm", "install", "--no-fund", "oxlint@1.55.0"][..], false),
-            (&["npx", "-y", "lodash"][..], false),
-            (&["npx", "--yes", "lodash"][..], false),
-            (&["npx", "--yes", "lodash@1.2.3"][..], false),
-            (&["npm", "exec", "lodash"][..], false),
-            (&["npm", "exec", "lodash@1.2.3"][..], false),
+            // `npm install`/`npx` is also disallowed.
+            (&["npm", "install", "lodash"][..], true),
+            (&["npm", "install", "oxlint@1.55.0"][..], true),
+            (&["npm", "install", "--no-fund", "oxlint@1.55.0"][..], true),
+            (&["npx", "-y", "lodash"][..], true),
+            (&["npx", "--yes", "lodash"][..], true),
+            (&["npx", "--yes", "lodash@1.2.3"][..], true),
+            (&["npm", "exec", "lodash"][..], true),
+            (&["npm", "exec", "lodash@1.2.3"][..], true),
+            // npm flags without a package shouldn't be flagged.
+            (&["npm", "install", "--help"][..], false),
+            (&["npm", "install", "--no-fund"][..], false),
+            (&["npm", "ci"][..], false),
+            (&["npx", "foobar"][..], false),
             // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),
         ] {

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -55,7 +55,7 @@ impl AdhocPackages {
                     && args.any(|arg| !arg.starts_with('-'))
             }
             "npm" => {
-                // Looking for `npm install <pkg>` or `npm exec <pkg>`, where
+                // Looking for `npm install <pkg>` where
                 // the subcommand is the first non-flag argument.
                 let mut args = args.skip_while(|arg| arg.starts_with('-'));
                 match args.next() {

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     state::AuditState,
 };
 
+pub(crate) mod adhoc_packages;
 pub(crate) mod anonymous_definition;
 pub(crate) mod archived_uses;
 pub(crate) mod artipacked;

--- a/crates/zizmor/src/config/schema.rs
+++ b/crates/zizmor/src/config/schema.rs
@@ -137,7 +137,8 @@ define_audit_rules! {
     misfeature,
     superfluous_actions,
     github_app,
-    unpinned_tools;
+    unpinned_tools,
+    adhoc_packages;
 
     [DependabotCooldownRuleConfig] dependabot_cooldown,
     [ForbiddenUsesRuleConfig] forbidden_uses,

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -82,6 +82,7 @@ impl AuditRegistry {
         register_audit!(audit::superfluous_actions::SuperfluousActions);
         register_audit!(audit::github_app::GitHubApp);
         register_audit!(audit::unpinned_tools::UnpinnedTools);
+        register_audit!(audit::adhoc_packages::AdhocPackages);
 
         Ok(registry)
     }

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -140,36 +140,6 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:70:14
-       |
-    70 |         run: npm exec lodash
-       |         ---  ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
-       |         |
-       |         this step
-       |
-       = note: audit confidence → High
-
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:75:14
-       |
-    75 |         run: npx -y lodash
-       |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
-       |         |
-       |         this step
-       |
-       = note: audit confidence → High
-
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:79:14
-       |
-    79 |         run: npx --yes lodash@1.2.3
-       |         ---  ^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
-       |         |
-       |         this step
-       |
-       = note: audit confidence → High
-
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
        --> @@INPUT@@:123:14
         |
     123 |         run: gem install rake
@@ -190,16 +160,6 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-       --> @@INPUT@@:131:14
-        |
-    131 |         run: npx -y lodash
-        |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
-        |         |
-        |         this step
-        |
-        = note: audit confidence → High
-
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
        --> @@INPUT@@:137:11
         |
     135 |         run: |
@@ -210,7 +170,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    20 findings: 0 informational, 20 low, 0 medium, 0 high
+    16 findings: 0 informational, 16 low, 0 medium, 0 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -6,7 +6,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         zizmor()
             .input(input_under_test("adhoc-packages.yml"))
             .run()?,
-        @r"
+        @r#"
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:18:14
        |
@@ -30,8 +30,8 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:26:14
        |
-    26 |         run: gem install rake -v 13.0.6
-       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+    26 |         run: gem install rake:13.0.6
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
@@ -40,15 +40,47 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:30:14
        |
-    30 |         run: gem install --no-document rake
+    30 |         run: gem install rake -v 13.0.6
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:34:14
+       |
+    34 |         run: gem install --no-document rake
        |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
        = note: audit confidence → High
 
-    4 findings: 0 informational, 4 low, 0 medium, 0 high
-    "
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:40:11
+       |
+    38 |         run: |
+       |         --- this step
+    39 |           echo "Hello"
+    40 |           gem install foo
+       |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:41:11
+       |
+    38 |         run: |
+       |         --- this step
+    ...
+    41 |           gem install bar
+       |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |
+       = note: audit confidence → High
+
+    7 findings: 0 informational, 7 low, 0 medium, 0 high
+    "#
     );
 
     Ok(())

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -1,0 +1,55 @@
+use crate::common::{input_under_test, zizmor};
+
+#[test]
+fn test_adhoc_packages() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("adhoc-packages.yml"))
+            .run()?,
+        @r"
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:18:14
+       |
+    18 |         run: gem install rake
+       |         ---  ^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:22:14
+       |
+    22 |         run: gem install rake rspec
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:26:14
+       |
+    26 |         run: gem install rake -v 13.0.6
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:30:14
+       |
+    30 |         run: gem install --no-document rake
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    4 findings: 0 informational, 4 low, 0 medium, 0 high
+    "
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -7,7 +7,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
             .input(input_under_test("adhoc-packages.yml"))
             .run()?,
         @r#"
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:18:14
        |
     18 |         run: gem install rake
@@ -17,7 +17,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:22:14
        |
     22 |         run: gem install rake rspec
@@ -27,7 +27,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:26:14
        |
     26 |         run: gem install rake:13.0.6
@@ -37,7 +37,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:30:14
        |
     30 |         run: gem install rake -v 13.0.6
@@ -47,7 +47,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:34:14
        |
     34 |         run: gem install --no-document rake
@@ -57,7 +57,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:38:14
        |
     38 |         run: gem i rake
@@ -67,7 +67,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:44:11
        |
     42 |         run: |
@@ -78,7 +78,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:45:11
        |
     42 |         run: |
@@ -89,7 +89,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:50:14
        |
     50 |         run: npm install lodash
@@ -99,7 +99,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:54:14
        |
     54 |         run: npm install oxlint@1.55.0
@@ -109,7 +109,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:56:14
        |
     56 |         run: npm install oxlint@^1.55.0
@@ -119,7 +119,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:60:14
        |
     60 |         run: npm install --no-fund oxlint@1.55.0
@@ -129,7 +129,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:64:14
        |
     64 |         run: npm i lodash
@@ -139,7 +139,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
       --> @@INPUT@@:68:14
        |
     68 |         run: npm add lodash
@@ -149,7 +149,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:110:14
         |
     110 |         run: gem install rake
@@ -159,7 +159,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:114:14
         |
     114 |         run: npm install lodash
@@ -169,7 +169,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:118:14
         |
     118 |         run: npm i lodash
@@ -179,7 +179,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:122:14
         |
     122 |         run: npm install lodash@1.2.3
@@ -189,7 +189,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:124:14
         |
     124 |         run: npm install lodash@^1.2.3
@@ -199,7 +199,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:130:11
         |
     128 |         run: |
@@ -210,7 +210,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:135:14
         |
     135 |         run: gem install foo bar baz
@@ -220,7 +220,7 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         |
         = note: audit confidence → High
 
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+    help[adhoc-packages]: ad-hoc installation of packages
        --> @@INPUT@@:139:14
         |
     139 |         run: gem install foo@1.2.3

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -169,7 +169,48 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    16 findings: 0 informational, 16 low, 0 medium, 0 high
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:123:14
+        |
+    123 |         run: gem install rake
+        |         ---  ^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:127:14
+        |
+    127 |         run: npm install lodash
+        |         ---  ^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:131:14
+        |
+    131 |         run: npx -y lodash
+        |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:137:11
+        |
+    135 |         run: |
+        |         --- this step
+    136 |           Write-Host "Hello"
+    137 |           gem install foo
+        |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |
+        = note: audit confidence → High
+
+    20 findings: 0 informational, 20 low, 0 medium, 0 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -58,42 +58,42 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:40:11
+      --> @@INPUT@@:38:14
        |
-    38 |         run: |
-       |         --- this step
-    39 |           echo "Hello"
-    40 |           gem install foo
-       |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
-       |
-       = note: audit confidence → High
-
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:41:11
-       |
-    38 |         run: |
-       |         --- this step
-    ...
-    41 |           gem install bar
-       |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
-       |
-       = note: audit confidence → High
-
-    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:46:14
-       |
-    46 |         run: npm install lodash
-       |         ---  ^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+    38 |         run: gem i rake
+       |         ---  ^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:44:11
+       |
+    42 |         run: |
+       |         --- this step
+    43 |           echo "Hello"
+    44 |           gem install foo
+       |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:45:11
+       |
+    42 |         run: |
+       |         --- this step
+    ...
+    45 |           gem install bar
+       |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:50:14
        |
-    50 |         run: npm install oxlint@1.55.0
-       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+    50 |         run: npm install lodash
+       |         ---  ^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
@@ -102,8 +102,8 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:54:14
        |
-    54 |         run: npm install --no-fund oxlint@1.55.0
-       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+    54 |         run: npm install oxlint@1.55.0
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
@@ -112,8 +112,8 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:58:14
        |
-    58 |         run: npm i lodash
-       |         ---  ^^^^^^^^^^^^ installs a package outside of a lockfile
+    58 |         run: npm install --no-fund oxlint@1.55.0
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
@@ -122,8 +122,8 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:62:14
        |
-    62 |         run: npm add lodash
-       |         ---  ^^^^^^^^^^^^^^ installs a package outside of a lockfile
+    62 |         run: npm i lodash
+       |         ---  ^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
@@ -132,18 +132,18 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:66:14
        |
-    66 |         run: npm exec lodash
-       |         ---  ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+    66 |         run: npm add lodash
+       |         ---  ^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:71:14
+      --> @@INPUT@@:70:14
        |
-    71 |         run: npx -y lodash
-       |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
+    70 |         run: npm exec lodash
+       |         ---  ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
@@ -152,14 +152,24 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:75:14
        |
-    75 |         run: npx --yes lodash@1.2.3
+    75 |         run: npx -y lodash
+       |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:79:14
+       |
+    79 |         run: npx --yes lodash@1.2.3
        |         ---  ^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
        = note: audit confidence → High
 
-    15 findings: 0 informational, 15 low, 0 medium, 0 high
+    16 findings: 0 informational, 16 low, 0 medium, 0 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -79,7 +79,67 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        |
        = note: audit confidence → High
 
-    7 findings: 0 informational, 7 low, 0 medium, 0 high
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:46:14
+       |
+    46 |         run: npm install lodash
+       |         ---  ^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:50:14
+       |
+    50 |         run: npm install oxlint@1.55.0
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:54:14
+       |
+    54 |         run: npm install --no-fund oxlint@1.55.0
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:58:14
+       |
+    58 |         run: npm exec lodash
+       |         ---  ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:63:14
+       |
+    63 |         run: npx -y lodash
+       |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:67:14
+       |
+    67 |         run: npx --yes lodash@1.2.3
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    13 findings: 0 informational, 13 low, 0 medium, 0 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -112,7 +112,27 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
       --> @@INPUT@@:58:14
        |
-    58 |         run: npm exec lodash
+    58 |         run: npm i lodash
+       |         ---  ^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:62:14
+       |
+    62 |         run: npm add lodash
+       |         ---  ^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:66:14
+       |
+    66 |         run: npm exec lodash
        |         ---  ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
@@ -120,9 +140,9 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:63:14
+      --> @@INPUT@@:71:14
        |
-    63 |         run: npx -y lodash
+    71 |         run: npx -y lodash
        |         ---  ^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
@@ -130,16 +150,16 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:67:14
+      --> @@INPUT@@:75:14
        |
-    67 |         run: npx --yes lodash@1.2.3
+    75 |         run: npx --yes lodash@1.2.3
        |         ---  ^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
        |
        = note: audit confidence → High
 
-    13 findings: 0 informational, 13 low, 0 medium, 0 high
+    15 findings: 0 informational, 15 low, 0 medium, 0 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/adhoc_packages.rs
+++ b/crates/zizmor/tests/integration/audit/adhoc_packages.rs
@@ -110,9 +110,19 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:58:14
+      --> @@INPUT@@:56:14
        |
-    58 |         run: npm install --no-fund oxlint@1.55.0
+    56 |         run: npm install oxlint@^1.55.0
+       |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+       |         |
+       |         this step
+       |
+       = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+      --> @@INPUT@@:60:14
+       |
+    60 |         run: npm install --no-fund oxlint@1.55.0
        |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
@@ -120,9 +130,9 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:62:14
+      --> @@INPUT@@:64:14
        |
-    62 |         run: npm i lodash
+    64 |         run: npm i lodash
        |         ---  ^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
@@ -130,9 +140,9 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-      --> @@INPUT@@:66:14
+      --> @@INPUT@@:68:14
        |
-    66 |         run: npm add lodash
+    68 |         run: npm add lodash
        |         ---  ^^^^^^^^^^^^^^ installs a package outside of a lockfile
        |         |
        |         this step
@@ -140,9 +150,9 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
        = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-       --> @@INPUT@@:123:14
+       --> @@INPUT@@:110:14
         |
-    123 |         run: gem install rake
+    110 |         run: gem install rake
         |         ---  ^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
         |         |
         |         this step
@@ -150,9 +160,9 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-       --> @@INPUT@@:127:14
+       --> @@INPUT@@:114:14
         |
-    127 |         run: npm install lodash
+    114 |         run: npm install lodash
         |         ---  ^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
         |         |
         |         this step
@@ -160,17 +170,67 @@ fn test_adhoc_packages() -> anyhow::Result<()> {
         = note: audit confidence → High
 
     help[adhoc-packages]: ad-hoc package installation outside of a lockfile
-       --> @@INPUT@@:137:11
+       --> @@INPUT@@:118:14
         |
-    135 |         run: |
+    118 |         run: npm i lodash
+        |         ---  ^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:122:14
+        |
+    122 |         run: npm install lodash@1.2.3
+        |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:124:14
+        |
+    124 |         run: npm install lodash@^1.2.3
+        |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:130:11
+        |
+    128 |         run: |
         |         --- this step
-    136 |           Write-Host "Hello"
-    137 |           gem install foo
+    129 |           Write-Host "Hello"
+    130 |           gem install foo
         |           ^^^^^^^^^^^^^^^ installs a package outside of a lockfile
         |
         = note: audit confidence → High
 
-    16 findings: 0 informational, 16 low, 0 medium, 0 high
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:135:14
+        |
+    135 |         run: gem install foo bar baz
+        |         ---  ^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    help[adhoc-packages]: ad-hoc package installation outside of a lockfile
+       --> @@INPUT@@:139:14
+        |
+    139 |         run: gem install foo@1.2.3
+        |         ---  ^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+        |         |
+        |         this step
+        |
+        = note: audit confidence → High
+
+    22 findings: 0 informational, 22 low, 0 medium, 0 high
     "#
     );
 

--- a/crates/zizmor/tests/integration/audit/mod.rs
+++ b/crates/zizmor/tests/integration/audit/mod.rs
@@ -1,5 +1,6 @@
 //! Per-audit integrationt tests, including snapshots.
 
+mod adhoc_packages;
 mod anonymous_definition;
 mod archived_uses;
 mod artipacked;

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_569.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__issue_569.snap
@@ -390,6 +390,16 @@ error[unpinned-uses]: unpinned action reference
    = note: audit confidence → High
    = note: this finding has an auto-fix
 
+help[adhoc-packages]: ad-hoc installation of packages
+  --> .github/workflows/new-bugs-announce-notifier.yml:19:14
+   |
+19 |       - run: npm install mailgun.js form-data
+   |         ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ installs a package outside of a lockfile
+   |         |
+   |         this step
+   |
+   = note: audit confidence → High
+
 error[unpinned-uses]: unpinned action reference
   --> .github/workflows/project-updater.yml:26:15
    |
@@ -705,4 +715,4 @@ error[unpinned-uses]: unpinned action reference
    = note: audit confidence → High
    = note: this finding has an auto-fix
 
-150 findings (1 ignored, 73 suppressed): 0 informational, 1 low, 0 medium, 75 high
+151 findings (1 ignored, 73 suppressed): 0 informational, 2 low, 0 medium, 75 high

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -113,3 +113,38 @@ jobs:
       # already installed via a lockfile.
       - name: not-vulnerable-6
         run: npx foobar
+
+  vulnerable-pwsh:
+    name: vulnerable-pwsh
+    runs-on: windows-latest
+    steps:
+      # NOT OK: ad-hoc `gem install` in pwsh.
+      - name: vulnerable-pwsh-1
+        run: gem install rake
+
+      # NOT OK: ad-hoc `npm install` in pwsh.
+      - name: vulnerable-pwsh-2
+        run: npm install lodash
+
+      # NOT OK: `npx -y` in pwsh.
+      - name: vulnerable-pwsh-3
+        run: npx -y lodash
+
+      # NOT OK: multiline pwsh `run:` with a `gem install`.
+      - name: vulnerable-pwsh-4
+        run: |
+          Write-Host "Hello"
+          gem install foo
+          Write-Host "Goodbye"
+
+  not-vulnerable-pwsh:
+    name: not-vulnerable-pwsh
+    runs-on: windows-latest
+    steps:
+      # OK: `npm ci` in pwsh.
+      - name: not-vulnerable-pwsh-1
+        run: npm ci
+
+      # OK: bare `npx foobar` in pwsh.
+      - name: not-vulnerable-pwsh-2
+        run: npx foobar

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -29,6 +29,16 @@ jobs:
       - name: vulnerable-4
         run: gem install --no-document rake
 
+      # TODO: enable once `npm install` is covered.
+      # # NOT OK: ad-hoc `npm install`.
+      # - name: vulnerable-5
+      #   run: npm install lodash
+
+      # TODO: enable once `pip install` is covered.
+      # # NOT OK: ad-hoc `pip install`.
+      # - name: vulnerable-6
+      #   run: pip install requests
+
   not-vulnerable:
     name: not-vulnerable
     runs-on: ubuntu-latest

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -33,6 +33,10 @@ jobs:
       - name: vulnerable-5
         run: gem install --no-document rake
 
+      # NOT OK: `gem i` is an alias for `gem install`.
+      - name: vulnerable-5a
+        run: gem i rake
+
       # NOT OK: multiple ad-hoc `gem install` invocations in a multi-line `run:`.
       - name: vulnerable-6
         run: |

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -52,6 +52,8 @@ jobs:
       # NOT OK: ad-hoc `npm install` with a version pin.
       - name: vulnerable-8
         run: npm install oxlint@1.55.0
+      - name: vulnerable-8a
+        run: npm install oxlint@^1.55.0
 
       # NOT OK: ad-hoc `npm install` with extra flags.
       - name: vulnerable-9
@@ -64,19 +66,6 @@ jobs:
       # NOT OK: `npm add` is also an alias for `npm install`.
       - name: vulnerable-9b
         run: npm add lodash
-
-      # NOT OK: ad-hoc `npm exec`.
-      - name: vulnerable-10
-        run: npm exec lodash
-
-      # NOT OK: `npx -y` skips the install prompt and pulls the package
-      # directly from the registry.
-      - name: vulnerable-11
-        run: npx -y lodash
-
-      # NOT OK: `npx --yes` is the long form of `npx -y`.
-      - name: vulnerable-12
-        run: npx --yes lodash@1.2.3
 
       # TODO: enable once `pip install` is covered.
       # # NOT OK: ad-hoc `pip install`.
@@ -104,15 +93,13 @@ jobs:
       - name: not-vulnerable-4
         run: npm ci
 
+      - name: not-vulnerable-5
+        run: npm install
+
       # OK: `npm install` without a package name uses the project's
       # package-lock.json.
-      - name: not-vulnerable-5
-        run: npm install --no-fund
-
-      # OK: `npx <pkg>` without `-y`/`--yes` runs a package that's
-      # already installed via a lockfile.
       - name: not-vulnerable-6
-        run: npx foobar
+        run: npm install --no-fund
 
   vulnerable-pwsh:
     name: vulnerable-pwsh
@@ -126,16 +113,30 @@ jobs:
       - name: vulnerable-pwsh-2
         run: npm install lodash
 
-      # NOT OK: `npx -y` in pwsh.
+      # NOT OK: ad-hoc `npm install` in pwsh.
       - name: vulnerable-pwsh-3
-        run: npx -y lodash
+        run: npm i lodash
+
+      # NOT OK: ad-hoc `npm install` with version pin in pwsh.
+      - name: vulnerable-pwsh-4
+        run: npm install lodash@1.2.3
+      - name: vulnerable-pwsh-4a
+        run: npm install lodash@^1.2.3
 
       # NOT OK: multiline pwsh `run:` with a `gem install`.
-      - name: vulnerable-pwsh-4
+      - name: vulnerable-pwsh-5
         run: |
           Write-Host "Hello"
           gem install foo
           Write-Host "Goodbye"
+
+      # NOT OK: installing multiple gems.
+      - name: vulnerable-pwsh-6
+        run: gem install foo bar baz
+
+      # NOT OK: installing a gem with a specific version.
+      - name: vulnerable-pwsh-7
+        run: gem install foo@1.2.3
 
   not-vulnerable-pwsh:
     name: not-vulnerable-pwsh
@@ -145,6 +146,6 @@ jobs:
       - name: not-vulnerable-pwsh-1
         run: npm ci
 
-      # OK: bare `npx foobar` in pwsh.
+      # OK: `bundle install` is fine and lockfile-respecting.
       - name: not-vulnerable-pwsh-2
-        run: npx foobar
+        run: bundle install

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -21,22 +21,34 @@ jobs:
       - name: vulnerable-2
         run: gem install rake rspec
 
-      # NOT OK: ad-hoc `gem install` with a version pin (still no lockfile).
+      # NOT OK: ad-hoc `gem install` with a version pin.
       - name: vulnerable-3
+        run: gem install rake:13.0.6
+
+      # NOT OK: ad-hoc `gem install` with a different kind of version pin.
+      - name: vulnerable-4
         run: gem install rake -v 13.0.6
 
       # NOT OK: ad-hoc `gem install` with extra flags.
-      - name: vulnerable-4
+      - name: vulnerable-5
         run: gem install --no-document rake
+
+      # NOT OK: multiple ad-hoc `gem install` invocations in a multi-line `run:`.
+      - name: vulnerable-6
+        run: |
+          echo "Hello"
+          gem install foo
+          gem install bar
+          echo "Goodbye"
 
       # TODO: enable once `npm install` is covered.
       # # NOT OK: ad-hoc `npm install`.
-      # - name: vulnerable-5
+      # - name: vulnerable-7
       #   run: npm install lodash
 
       # TODO: enable once `pip install` is covered.
       # # NOT OK: ad-hoc `pip install`.
-      # - name: vulnerable-6
+      # - name: vulnerable-8
       #   run: pip install requests
 
   not-vulnerable:

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -146,6 +146,12 @@ jobs:
       - name: not-vulnerable-pwsh-1
         run: npm ci
 
-      # OK: `bundle install` is fine and lockfile-respecting.
+      # OK: `npm install` in pwsh.
       - name: not-vulnerable-pwsh-2
+        run: npm install
+      - name: not-vulnerable-pwsh-2a
+        run: npm i
+
+      # OK: `bundle install` is fine and lockfile-respecting.
+      - name: not-vulnerable-pwsh-3
         run: bundle install

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -41,14 +41,34 @@ jobs:
           gem install bar
           echo "Goodbye"
 
-      # TODO: enable once `npm install` is covered.
-      # # NOT OK: ad-hoc `npm install`.
-      # - name: vulnerable-7
-      #   run: npm install lodash
+      # NOT OK: ad-hoc `npm install`.
+      - name: vulnerable-7
+        run: npm install lodash
+
+      # NOT OK: ad-hoc `npm install` with a version pin.
+      - name: vulnerable-8
+        run: npm install oxlint@1.55.0
+
+      # NOT OK: ad-hoc `npm install` with extra flags.
+      - name: vulnerable-9
+        run: npm install --no-fund oxlint@1.55.0
+
+      # NOT OK: ad-hoc `npm exec`.
+      - name: vulnerable-10
+        run: npm exec lodash
+
+      # NOT OK: `npx -y` skips the install prompt and pulls the package
+      # directly from the registry.
+      - name: vulnerable-11
+        run: npx -y lodash
+
+      # NOT OK: `npx --yes` is the long form of `npx -y`.
+      - name: vulnerable-12
+        run: npx --yes lodash@1.2.3
 
       # TODO: enable once `pip install` is covered.
       # # NOT OK: ad-hoc `pip install`.
-      # - name: vulnerable-8
+      # - name: vulnerable-13
       #   run: pip install requests
 
   not-vulnerable:
@@ -67,3 +87,17 @@ jobs:
       # but we don't flag it.
       - name: not-vulnerable-3
         run: gem install --help
+
+      # OK: `npm ci` is lockfile-aware.
+      - name: not-vulnerable-4
+        run: npm ci
+
+      # OK: `npm install` without a package name uses the project's
+      # package-lock.json.
+      - name: not-vulnerable-5
+        run: npm install --no-fund
+
+      # OK: `npx <pkg>` without `-y`/`--yes` runs a package that's
+      # already installed via a lockfile.
+      - name: not-vulnerable-6
+        run: npx foobar

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -1,0 +1,47 @@
+name: adhoc-packages
+
+on: push
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vulnerable:
+    name: vulnerable
+    runs-on: ubuntu-latest
+    steps:
+      # NOT OK: ad-hoc `gem install`.
+      - name: vulnerable-1
+        run: gem install rake
+
+      # NOT OK: ad-hoc `gem install` with multiple packages.
+      - name: vulnerable-2
+        run: gem install rake rspec
+
+      # NOT OK: ad-hoc `gem install` with a version pin (still no lockfile).
+      - name: vulnerable-3
+        run: gem install rake -v 13.0.6
+
+      # NOT OK: ad-hoc `gem install` with extra flags.
+      - name: vulnerable-4
+        run: gem install --no-document rake
+
+  not-vulnerable:
+    name: not-vulnerable
+    runs-on: ubuntu-latest
+    steps:
+      # OK: `bundle install` uses the project's Gemfile.lock.
+      - name: not-vulnerable-1
+        run: bundle install
+
+      # OK: other gem subcommands are not flagged.
+      - name: not-vulnerable-2
+        run: gem build foo.gemspec
+
+      # OK: `gem install` without a package name is malformed,
+      # but we don't flag it.
+      - name: not-vulnerable-3
+        run: gem install --help

--- a/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+++ b/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
@@ -53,6 +53,14 @@ jobs:
       - name: vulnerable-9
         run: npm install --no-fund oxlint@1.55.0
 
+      # NOT OK: `npm i` is an alias for `npm install`.
+      - name: vulnerable-9a
+        run: npm i lodash
+
+      # NOT OK: `npm add` is also an alias for `npm install`.
+      - name: vulnerable-9b
+        run: npm add lodash
+
       # NOT OK: ad-hoc `npm exec`.
       - name: vulnerable-10
         run: npm exec lodash

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -55,6 +55,9 @@ Currently this audit flags:
   `#!bash npx <pkg>` without `-y`/`--yes` is not flagged, since it typically
   runs a binary already installed via a lockfile.
 
+This audit analyzes `#!yaml run:` steps written in either bash (the default on
+Linux/macOS runners) or PowerShell (the default on Windows runners).
+
 ### Remediation
 
 Add the package to a manifest that produces a lockfile (e.g. a `Gemfile`),

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -44,8 +44,10 @@ Currently this audit flags:
 - `#!bash gem install <pkg>` invocations, including those with extra flags or
   version specifiers (e.g. `-v 13.0.6`). Other subcommands like
   `#!bash gem build` or `#!bash gem push` are not flagged.
-- `#!bash npm install <pkg>` and `#!bash npm exec <pkg>` invocations.
-  `#!bash npm install` with no package name (which installs from
+- `#!bash npm install <pkg>` and `#!bash npm exec <pkg>` invocations,
+  including their documented aliases (e.g. `#!bash npm i <pkg>`,
+  `#!bash npm add <pkg>`, `#!bash npm x <pkg>`). `#!bash npm install`/
+  `#!bash npm i` with no package name (which installs from
   `package-lock.json`) and `#!bash npm ci` are not flagged.
 - `#!bash npx -y <pkg>` / `#!bash npx --yes <pkg>` invocations, which skip
   the install prompt and pull the package straight from the registry.

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -25,9 +25,10 @@ Legend:
 Detects `#!yaml run:` steps that install packages ad hoc, outside of a
 lockfile-managed manifest.
 
-Installing packages directly with commands like `#!bash gem install <pkg>`
-sidesteps the project's lockfile (e.g. `Gemfile.lock`), which causes several
-supply-chain hazards:
+Installing packages directly with commands like `#!bash gem install <pkg>` or
+`#!bash npm install <pkg>` sidesteps the project's lockfile (e.g.
+`Gemfile.lock`, `package-lock.json`), which causes several supply-chain
+hazards:
 
 - Without a lockfile to pin against, the workflow always installs whichever
   version the registry currently advertises. A compromised release of an
@@ -38,9 +39,18 @@ supply-chain hazards:
 - Reproducibility is lost: re-running the same workflow can install different
   versions of the same package over time.
 
-Currently this audit only flags `#!bash gem install <pkg>` invocations,
-including those with extra flags or version specifiers (e.g. `-v 13.0.6`).
-Subcommands like `#!bash gem build` or `#!bash gem push` are not flagged.
+Currently this audit flags:
+
+- `#!bash gem install <pkg>` invocations, including those with extra flags or
+  version specifiers (e.g. `-v 13.0.6`). Other subcommands like
+  `#!bash gem build` or `#!bash gem push` are not flagged.
+- `#!bash npm install <pkg>` and `#!bash npm exec <pkg>` invocations.
+  `#!bash npm install` with no package name (which installs from
+  `package-lock.json`) and `#!bash npm ci` are not flagged.
+- `#!bash npx -y <pkg>` / `#!bash npx --yes <pkg>` invocations, which skip
+  the install prompt and pull the package straight from the registry.
+  `#!bash npx <pkg>` without `-y`/`--yes` is not flagged, since it typically
+  runs a binary already installed via a lockfile.
 
 ### Remediation
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -33,9 +33,13 @@ hazards:
 - Without a lockfile to pin against, the workflow always installs whichever
   version the registry currently advertises. A compromised release of an
   upstream dependency is therefore picked up automatically on the next run.
+- Without a lockfile, the sub-dependencies of the adhoc package are also
+  unpinned, and so packages you may not know about would also be installed
+  with their latest version, even if you have pinned to a specific version
+  in the install command (`#!bash npm install foo@1.2.3`).
 - Lockfiles record content hashes that can be cross-checked against the
-  registry. Ad-hoc installs perform no such verification, so a compromised
-  package is harder to detect after the fact.
+  registry. Ad-hoc installs perform no such verification, and so a registry
+  compromise would be able to send malicious packages to your CI runs.
 - Reproducibility is lost: re-running the same workflow can install different
   versions of the same package over time.
 
@@ -45,24 +49,20 @@ Currently this audit flags:
   including those with extra flags or version specifiers (e.g. `-v 13.0.6`).
   Other subcommands like `#!bash gem build` or `#!bash gem push` are not
   flagged.
-- `#!bash npm install <pkg>` and `#!bash npm exec <pkg>` invocations,
-  including their documented aliases (e.g. `#!bash npm i <pkg>`,
-  `#!bash npm add <pkg>`, `#!bash npm x <pkg>`). `#!bash npm install`/
-  `#!bash npm i` with no package name (which installs from
+- `#!bash npm install <pkg>` invocations, including its documented aliases
+  (e.g. `#!bash npm i <pkg>`, `#!bash npm add <pkg>`). `#!bash npm install`/
+  `#!bash npm i` with no package name (which installs from 
   `package-lock.json`) and `#!bash npm ci` are not flagged.
-- `#!bash npx -y <pkg>` / `#!bash npx --yes <pkg>` invocations, which skip
-  the install prompt and pull the package straight from the registry.
-  `#!bash npx <pkg>` without `-y`/`--yes` is not flagged, since it typically
-  runs a binary already installed via a lockfile.
 
 This audit analyzes `#!yaml run:` steps written in either bash (the default on
 Linux/macOS runners) or PowerShell (the default on Windows runners).
 
 ### Remediation
 
-Add the package to a manifest that produces a lockfile (e.g. a `Gemfile`),
-commit the resulting lockfile, and install via the corresponding lockfile-aware
-command (e.g. `#!bash bundle install`).
+Add the package to a manifest that produces a lockfile (e.g. a `Gemfile` or
+`package.json`), commit the resulting lockfile, and install via the
+corresponding lockfile-aware command (`#!bash bundle install`, `#!bash npm ci`,
+etc.).
 
 !!! example
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -22,40 +22,28 @@ Legend:
 
 [adhoc-packages.yml]: https://github.com/zizmorcore/zizmor/blob/main/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
 
-Detects `#!yaml run:` steps that install packages ad hoc, outside of a
-lockfile-managed manifest.
+Detects `#!yaml run:` steps that install packages in an ad-hoc manner, i.e. outside of a managed
+and locked manifest.
 
 Installing packages directly with commands like `#!bash gem install <pkg>` or
-`#!bash npm install <pkg>` sidesteps the project's lockfile (e.g.
-`Gemfile.lock`, `package-lock.json`), which causes several supply-chain
-hazards:
+`#!bash npm install <pkg>` represents a potential risk:
 
-- Without a lockfile to pin against, the workflow always installs whichever
-  version the registry currently advertises. A compromised release of an
-  upstream dependency is therefore picked up automatically on the next run.
-- Without a lockfile, the sub-dependencies of the adhoc package are also
-  unpinned, and so packages you may not know about would also be installed
-  with their latest version, even if you have pinned to a specific version
-  in the install command (`#!bash npm install foo@1.2.3`).
-- Lockfiles record content hashes that can be cross-checked against the
-  registry. Ad-hoc installs perform no such verification, and so a registry
-  compromise would be able to send malicious packages to your CI runs.
-- Reproducibility is lost: re-running the same workflow can install different
-  versions of the same package over time.
+- Packages that are installed in an ad-hoc manner are often not pinned to
+  a specific version, meaning that the installer will often use whatever latest
+  version is available. This makes it easier to accidentally pick up a compromised
+  version of a package in your workflows.
+- Even if a version is specified, the sub-dependencies of a package are
+  typically still unpinned. For example, `#!bash npm install foo@1.2.3`
+  will install a specific version of `foo`, but `foo`'s dependencies
+  will be newly resolved and may undermine the user's intent of a safe
+  cutoff.
 
-Currently this audit flags:
+This audit currently detects ad-hoc installation patterns for the following ecosystems and tools:
 
-- `#!bash gem install <pkg>` invocations (and the alias `#!bash gem i <pkg>`),
-  including those with extra flags or version specifiers (e.g. `-v 13.0.6`).
-  Other subcommands like `#!bash gem build` or `#!bash gem push` are not
-  flagged.
-- `#!bash npm install <pkg>` invocations, including its documented aliases
-  (e.g. `#!bash npm i <pkg>`, `#!bash npm add <pkg>`). `#!bash npm install`/
-  `#!bash npm i` with no package name (which installs from 
-  `package-lock.json`) and `#!bash npm ci` are not flagged.
-
-This audit analyzes `#!yaml run:` steps written in either bash (the default on
-Linux/macOS runners) or PowerShell (the default on Windows runners).
+| Ecosystem | Tools |
+|-----------|-------|
+| JavaScript | `npm` |
+| Ruby | `gem` |
 
 ### Remediation
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -41,9 +41,10 @@ hazards:
 
 Currently this audit flags:
 
-- `#!bash gem install <pkg>` invocations, including those with extra flags or
-  version specifiers (e.g. `-v 13.0.6`). Other subcommands like
-  `#!bash gem build` or `#!bash gem push` are not flagged.
+- `#!bash gem install <pkg>` invocations (and the alias `#!bash gem i <pkg>`),
+  including those with extra flags or version specifiers (e.g. `-v 13.0.6`).
+  Other subcommands like `#!bash gem build` or `#!bash gem push` are not
+  flagged.
 - `#!bash npm install <pkg>` and `#!bash npm exec <pkg>` invocations,
   including their documented aliases (e.g. `#!bash npm i <pkg>`,
   `#!bash npm add <pkg>`, `#!bash npm x <pkg>`). `#!bash npm install`/

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -14,6 +14,64 @@ Legend:
 |----------|------------------|---------------|----------------|--------------------|--------------|
 | Workflow, Action, Dependabot | Links to vulnerable examples | Added to `zizmor` in this version | The audit works with `--offline` | The audit supports auto-fixes when used in the `--fix` mode | The audit supports custom configuration |
 
+## `adhoc-packages`
+
+| Type             | Examples            | Introduced in | Works offline  | Auto-fixes available | Configurable |
+|------------------|---------------------|---------------|----------------|--------------------|--------------|
+| Workflow, Action | [adhoc-packages.yml] | v1.26.0       | ✅             | ❌                 | ❌           |
+
+[adhoc-packages.yml]: https://github.com/zizmorcore/zizmor/blob/main/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
+
+Detects `#!yaml run:` steps that install packages ad hoc, outside of a
+lockfile-managed manifest.
+
+Installing packages directly with commands like `#!bash gem install <pkg>`
+sidesteps the project's lockfile (e.g. `Gemfile.lock`), which causes several
+supply-chain hazards:
+
+- Without a lockfile to pin against, the workflow always installs whichever
+  version the registry currently advertises. A compromised release of an
+  upstream dependency is therefore picked up automatically on the next run.
+- Lockfiles record content hashes that can be cross-checked against the
+  registry. Ad-hoc installs perform no such verification, so a compromised
+  package is harder to detect after the fact.
+- Reproducibility is lost: re-running the same workflow can install different
+  versions of the same package over time.
+
+Currently this audit only flags `#!bash gem install <pkg>` invocations,
+including those with extra flags or version specifiers (e.g. `-v 13.0.6`).
+Subcommands like `#!bash gem build` or `#!bash gem push` are not flagged.
+
+### Remediation
+
+Add the package to a manifest that produces a lockfile (e.g. a `Gemfile`),
+commit the resulting lockfile, and install via the corresponding lockfile-aware
+command (e.g. `#!bash bundle install`).
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="adhoc-packages.yml" hl_lines="6"
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
+              - run: gem install rake
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="adhoc-packages.yml" hl_lines="6"
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
+              - run: bundle install
+        ```
+
 ## `anonymous-definition`
 
 | Type            | Examples         | Introduced in | Works offline | Auto-fixes available | Configurable |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,7 +11,7 @@ of `zizmor`.
 
 ### New Features 🌈
 
-* **New audit**: [typosquat-uses] detects `uses:` clauses that reference likely
+* **New audit**: [typosquat-uses] detects `#!yaml uses:` clauses that reference likely
   typoed actions (#1985)
 
     Many thanks to @andrew for proposing and implementing this improvement!
@@ -20,6 +20,11 @@ of `zizmor`.
   don't evaluate as expected (#2085)
 
     Many thanks to @terror for proposing and implementing this improvement!
+
+* **New audit**: [adhoc-packages] detects `#!yaml run:` steps that install packages
+  in an ad-hoc manner (#2061)
+
+    Many thanks to @connorshea for proposing and implementing this improvement!
 
 ### Enhancements 🌱
 
@@ -1887,5 +1892,7 @@ This is one of `zizmor`'s bigger recent releases! Key enhancements include:
 [github-app]: ./audits.md#github-app
 [unpinned-tools]: ./audits.md#unpinned-tools
 [typosquat-uses]: ./audits.md#typosquat-uses
+[unsound-ternary]: ./audits.md#unsound-ternary
+[adhoc-packages]: ./audits.md#adhoc-packages
 
 [exit code]: ./usage.md#exit-codes

--- a/support/zizmor.schema.json
+++ b/support/zizmor.schema.json
@@ -243,6 +243,9 @@
     "RulesConfig": {
       "type": "object",
       "properties": {
+        "adhoc-packages": {
+          "$ref": "#/definitions/BaseRuleConfig"
+        },
         "anonymous-definition": {
           "$ref": "#/definitions/BaseRuleConfig"
         },


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Resolves #2057.

AI Disclosure: Initial version generated using Claude Code (Opus 4.7), intentionally scoped minimally. This covers `gem install`/`gem i` commands because Ruby is the language/package manager I'm personally most familiar with and I wanted to make sure the change was as easy as possible to review and test.

This also covers `npm install pkg` and `npm i pkg`. In the future, it'd be good to add `pnpm`, `yarn`, `pip`, and other language tooling.

I'm able to explain the code changes involved here without using the AI tooling. This PR description was written by hand.

I reviewed and iterated on the code involved here from the initial version by Claude, though most of the code was written in that initial version. The rule is heavily based on the `use_trusted_publishing` rule, which also checks for specific commands in `run` blocks.

A few caveats to note: 

- To avoid the complexity of parsing "wrapped" commands, things like `bundle exec gem install rails` or `sudo gem install rails` are not caught by this as it's written right now. The `use_trusted_publishing` audit rule also does not handle `sudo` usage as far as I can tell.

## Test Plan

- Basic unit tests and snapshot tests of a few different shapes.