### PR TITLE
Skip statically-false `if:` steps in audits (#2059)

### DIFF
--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -1,7 +1,7 @@
 //! Enriching/context-bearing wrappers over GitHub Actions models
 //! from [`github_actions_models`].
 
-use github_actions_expressions::context;
+use github_actions_expressions::{Evaluation, Expr, context};
 use github_actions_models::common;
 use github_actions_models::common::Env;
 use github_actions_models::common::expr::LoE;
@@ -9,6 +9,32 @@ use github_actions_models::common::expr::LoE;
 use crate::finding::location::{Locatable, SymbolicLocation};
 use crate::models::inputs::HasInputs;
 use crate::models::workflow::matrix::Matrix;
+use crate::utils::ExtractedExpr;
+
+/// Returns whether the given `if:` condition is statically known to be false,
+/// meaning the step (or job) it guards cannot execute.
+///
+/// This recognizes:
+///
+/// 1. The literal `if: false` (which deserializes as [`common::If::Bool(false)`]).
+/// 2. Bare or fenced expressions that const-evaluate to a falsy boolean,
+///    e.g. `if: ${{ false }}`, `if: false && something`.
+///
+/// More elaborate "never runs" conditions (e.g. `if: github.actor == 'no-one'`)
+/// are intentionally out of scope; only conditions that we can prove falsy
+/// without any runtime context are recognized.
+pub(crate) fn if_is_statically_false(cond: &common::If) -> bool {
+    match cond {
+        common::If::Bool(b) => !*b,
+        common::If::Expr(raw) => {
+            let bare = ExtractedExpr::new(raw).as_bare();
+            let Ok(expr) = Expr::parse(bare) else {
+                return false;
+            };
+            matches!(expr.consteval(), Some(Evaluation::Boolean(false)))
+        }
+    }
+}
 
 pub(crate) mod action;
 pub(crate) mod coordinate;
@@ -70,5 +96,51 @@ pub(crate) trait StepCommon<'doc>: Locatable<'doc> + HasInputs {
 impl<'a, 'doc, T: StepCommon<'doc>> AsDocument<'a, 'doc> for T {
     fn as_document(&'a self) -> &'doc yamlpath::Document {
         self.document()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::if_is_statically_false;
+    use github_actions_models::common;
+
+    #[test]
+    fn test_if_is_statically_false() {
+        // Literal false / true.
+        assert!(if_is_statically_false(&common::If::Bool(false)));
+        assert!(!if_is_statically_false(&common::If::Bool(true)));
+
+        // Fenced and bare false expressions.
+        for raw in &[
+            "${{ false }}",
+            "${{false}}",
+            "false",
+            "${{ true && false }}",
+            "${{ !true }}",
+            "${{ false || false }}",
+        ] {
+            assert!(
+                if_is_statically_false(&common::If::Expr((*raw).into())),
+                "expected statically false: {raw}"
+            );
+        }
+
+        // Expressions that aren't statically false.
+        for raw in &[
+            "${{ true }}",
+            "true",
+            "${{ github.actor == 'foo' }}",
+            "${{ inputs.something }}",
+            // Non-Boolean falsy values are intentionally not matched.
+            "${{ '' }}",
+            "${{ null }}",
+            // Unparseable expressions should not be treated as false.
+            "${{ this is not valid",
+        ] {
+            assert!(
+                !if_is_statically_false(&common::If::Expr((*raw).into())),
+                "expected not statically false: {raw}"
+            );
+        }
     }
 }

--- a/crates/zizmor/src/models/action.rs
+++ b/crates/zizmor/src/models/action.rs
@@ -160,6 +160,10 @@ impl<'a, 'doc> AsDocument<'a, 'doc> for DockerAction<'doc> {
 }
 
 /// An iterable container for steps within a [`Job`].
+///
+/// Composite steps whose `if:` condition is statically known to be false
+/// (e.g. `if: false` or `if: ${{ false }}`) are skipped, since such steps
+/// cannot execute and therefore can't violate any runtime-behavior audit.
 pub(crate) struct CompositeSteps<'a> {
     inner: std::iter::Enumerate<std::slice::Iter<'a, github_actions_models::action::Step>>,
     parent: &'a Action,
@@ -182,12 +186,15 @@ impl<'a> Iterator for CompositeSteps<'a> {
     type Item = CompositeStep<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let item = self.inner.next();
-
-        match item {
-            Some((idx, step)) => Some(CompositeStep::new(idx, step, self.parent)),
-            None => None,
+        for (idx, step) in self.inner.by_ref() {
+            if let Some(cond) = step.r#if.as_ref()
+                && crate::models::if_is_statically_false(cond)
+            {
+                continue;
+            }
+            return Some(CompositeStep::new(idx, step, self.parent));
         }
+        None
     }
 }
 

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -642,6 +642,10 @@ impl<'doc> Step<'doc> {
 }
 
 /// An iterable container for steps within a [`Job`].
+///
+/// Steps whose `if:` condition is statically known to be false
+/// (e.g. `if: false` or `if: ${{ false }}`) are skipped, since such steps
+/// cannot execute and therefore can't violate any runtime-behavior audit.
 pub(crate) struct Steps<'doc> {
     inner: std::iter::Enumerate<std::slice::Iter<'doc, github_actions_models::workflow::job::Step>>,
     parent: NormalJob<'doc>,
@@ -661,12 +665,15 @@ impl<'doc> Iterator for Steps<'doc> {
     type Item = Step<'doc>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let item = self.inner.next();
-
-        match item {
-            Some((idx, step)) => Some(Step::new(idx, step, self.parent.clone())),
-            None => None,
+        for (idx, step) in self.inner.by_ref() {
+            if let Some(cond) = step.r#if.as_ref()
+                && crate::models::if_is_statically_false(cond)
+            {
+                continue;
+            }
+            return Some(Step::new(idx, step, self.parent.clone()));
         }
+        None
     }
 }
 

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -35,7 +35,7 @@ fn test_caching_enabled_by_default() -> anyhow::Result<()> {
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
-    4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
+    2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     ",
     );
 
@@ -144,7 +144,7 @@ fn test_caching_opt_out() -> anyhow::Result<()> {
         zizmor()
             .input(input_under_test("cache-poisoning/caching-opt-out.yml"))
             .run()?,
-        @"No findings to report. Good job! (1 ignored, 2 suppressed)"
+        @"No findings to report. Good job! (1 suppressed)"
     );
 
     Ok(())

--- a/crates/zizmor/tests/integration/audit/unpinned_tools.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_tools.rs
@@ -57,3 +57,27 @@ fn test_regular_persona() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Regression test for #2059: steps gated with a statically-false `if:`
+/// condition should not be audited, since they cannot execute.
+#[test]
+fn test_if_false_skipped() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("unpinned-tools-if-false.yml"))
+            .run()?,
+        @r"
+    warning[unpinned-tools]: action installs an unpinned external tool
+      --> @@INPUT@@:26:15
+       |
+    26 |       - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action implicitly uses an unpinned latest version
+       |
+       = note: audit confidence → High
+
+    3 findings (1 ignored, 1 suppressed): 0 informational, 0 low, 1 medium, 0 high
+    "
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/audit/unpinned_tools.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_tools.rs
@@ -64,19 +64,9 @@ fn test_regular_persona() -> anyhow::Result<()> {
 fn test_if_false_skipped() -> anyhow::Result<()> {
     insta::assert_snapshot!(
         zizmor()
-            .input(input_under_test("unpinned-tools-if-false.yml"))
+            .input(input_under_test("unpinned-tools/if-false.yml"))
             .run()?,
-        @r"
-    warning[unpinned-tools]: action installs an unpinned external tool
-      --> @@INPUT@@:26:15
-       |
-    26 |       - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action implicitly uses an unpinned latest version
-       |
-       = note: audit confidence → High
-
-    3 findings (1 ignored, 1 suppressed): 0 informational, 0 low, 1 medium, 0 high
-    "
+        @"No findings to report. Good job! (1 ignored, 1 suppressed)"
     );
 
     Ok(())

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/caching-enabled-by-default.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/caching-enabled-by-default.yml
@@ -19,7 +19,3 @@ jobs:
 
       - name: Setup CI caching
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-
-      - name: Publish on crates.io # zizmor: ignore[use-trusted-publishing]
-        if: false
-        run: cargo publish --token ${{ secrets.CRATESIO_PUBLISH_TOKEN }}

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/caching-opt-out.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/caching-opt-out.yml
@@ -20,7 +20,3 @@ jobs:
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           lookup-only: true
-
-      - name: Publish on crates.io # zizmor: ignore[use-trusted-publishing]
-        if: false
-        run: cargo publish --token ${{ secrets.CRATESIO_PUBLISH_TOKEN }}

--- a/crates/zizmor/tests/integration/test-data/unpinned-tools-if-false.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-tools-if-false.yml
@@ -1,0 +1,26 @@
+name: unpinned-tools-if-false
+
+on: push
+
+permissions: {}
+
+# Repro for #2059: steps with statically-false `if:` conditions should not be
+# audited, since they cannot execute. This pattern is used by composite-action
+# "allowlist" workflows where every `- uses:` entry is gated with `if: false`
+# purely so dependabot can track the SHA.
+jobs:
+  allowlist:
+    name: allowlist
+    runs-on: ubuntu-latest
+    steps:
+      # Would normally trip unpinned-tools, but `if: false` makes it a no-op.
+      - uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        if: false
+
+      - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+        if: ${{ false }} # zizmor: ignore[obfuscation]
+        with:
+          version: latest
+
+      # This one is *not* gated; it should still trigger.
+      - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6

--- a/crates/zizmor/tests/integration/test-data/unpinned-tools/if-false.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-tools/if-false.yml
@@ -21,6 +21,3 @@ jobs:
         if: ${{ false }} # zizmor: ignore[obfuscation]
         with:
           version: latest
-
-      # This one is *not* gated; it should still trigger.
-      - uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -38,6 +38,12 @@ of `zizmor`.
 * Fixed a bug where [dependabot-cooldown] would fail to honor the user's
   configured days when performing autofixes (#2055)
 
+* Steps gated by a statically-false `if:` condition (e.g. `if: false`,
+  `if: ${{ false }}`) are now skipped during auditing, since they cannot
+  execute. This eliminates a class of false positives in audits like
+  [unpinned-tools] when composite actions use the `if: false` pattern
+  as an allowlist registry (#2059)
+
 ### Changes ⚠️
 
 * The [impostor-commit] audit no longer suggests auto-fixes,


### PR DESCRIPTION
Steps whose `if:` condition is provably false at static-analysis time (e.g. `if: false`, `if: ${{ false }}`, `if: ${{ true && false }}`) cannot execute, so any "what happens when this step runs" audit (unpinned-tools, bot-conditions, cache-poisoning, etc.) would always be a false positive on them.

This is filtered at the iterator layer (`Steps`, `CompositeSteps`), so all step-level audits — and `conditions()`-based audits — inherit the behavior. Non-Boolean falsy values (`${{ '' }}`, `${{ 0 }}`) are kept out of scope; only conditions that const-evaluate to `Boolean(false)` are skipped.

Fixes #2059.

<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Removes the "static-analysis-time" `if: false` conditioned actions from auditing.

## Test Plan

Unit tests were updated as part of the change.
