### PR TITLE
ref-version-mismatch: generalize version comment pattern

### DIFF
--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -1,8 +1,5 @@
-use std::sync::LazyLock;
-
 use anyhow::anyhow;
 use github_actions_models::common::Uses;
-use regex::Regex;
 use subfeature::Subfeature;
 use yamlpatch::{Op, Patch};
 
@@ -15,6 +12,7 @@ use crate::{
     },
     github,
     models::{StepCommon, action::CompositeStep, uses::RepositoryUsesExt, workflow::Step},
+    utils::once::static_regex,
 };
 
 pub(crate) struct RefVersionMismatch {
@@ -27,17 +25,21 @@ audit_meta!(
     "action's hash pin has mismatched or missing version comment"
 );
 
-#[allow(clippy::unwrap_used)]
-static VERSION_COMMENT_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
-    vec![
-        // Matches "# tag=v2.8.0", "# tag=v6-beta", or any non-whitespace tag token.
-        Regex::new(r"#\s*tag\s*=\s*(\S+)").unwrap(),
-        // Matches "# v2.8.0" and prerelease forms like "# v1.2.3-rc.1", with or without the `v` suffix.
-        Regex::new(r"#\s*(v?\d+(?:\.\d+)*(?:-?[\w.-]+)?)").unwrap(),
-        // More flexible: "# version: 2.8.0"
-        Regex::new(r"#\s*(?:version|ver)\s*[:=]\s*(v?\d+(?:\.\d+)*(?:-?[\w.-]+)?)").unwrap(),
-    ]
-});
+static_regex!(
+    VERSION_COMMENT_PATTERN,
+    r#"(?x)                             # verbose mode
+    ^                                   # start of string
+    \#                                  # start of comment
+    \s*                                 # optional whitespace
+    (?:                                 # start non-capturing group for version prefix
+      (?:tag|version|ver)\s*[:=]\s*     # version prefix + `:` or `=`
+    )?                                  # end optional non-capturing group
+    (                                   # start capturing group for version
+      \S+                               # one or more non-whitespace characters
+    )                                   # end capturing group for version
+    $                                   # end of string
+    "#
+);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CommentVersionState<'doc> {
@@ -49,12 +51,10 @@ enum CommentVersionState<'doc> {
 impl RefVersionMismatch {
     fn extract_version_from_comments<'doc>(comments: &'doc [Comment<'doc>]) -> Option<&'doc str> {
         for comment in comments {
-            for pattern in VERSION_COMMENT_PATTERNS.iter() {
-                if let Some(captures) = pattern.captures(comment.as_ref())
-                    && let Some(version_match) = captures.get(1)
-                {
-                    return Some(version_match.as_str());
-                }
+            if let Some(captures) = VERSION_COMMENT_PATTERN.captures(comment.as_ref())
+                && let Some(version_match) = captures.get(1)
+            {
+                return Some(version_match.as_str());
             }
         }
         None
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_version_comment_patterns() {
+    fn test_version_comment_pattern() {
         let test_cases = vec![
             ("# tag=v2.8.0", Some("v2.8.0")),
             ("# tag=v6-beta", Some("v6-beta")),
@@ -316,21 +316,24 @@ mod tests {
             ("# ver=1.0.0", Some("1.0.0")),
             ("# visit the docs", None),
             ("# some other comment", None),
+            ("# zizmor: ignore[ref-version-mismatch]", None),
         ];
 
         for (comment, expected) in test_cases {
             // Test the pattern matching directly
-            let comment_text = comment;
-            let mut found_version = None;
-            for pattern in VERSION_COMMENT_PATTERNS.iter() {
-                if let Some(captures) = pattern.captures(comment_text) {
-                    if let Some(version_match) = captures.get(1) {
-                        found_version = Some(version_match.as_str());
-                        break;
-                    }
+            match (VERSION_COMMENT_PATTERN.captures(comment), expected) {
+                (None, None) => (),
+                (None, Some(expected)) => {
+                    assert!(
+                        false,
+                        "Got no match in '{comment}', but expected {expected}"
+                    )
                 }
+                (Some(caps), None) => {
+                    assert!(false, "Got unexpected match: {caps:?}")
+                }
+                (Some(_), Some(_)) => (),
             }
-            assert_eq!(found_version, expected, "Failed for comment: {}", comment);
         }
     }
 

--- a/crates/zizmor/tests/integration/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/tests/integration/audit/ref_version_mismatch.rs
@@ -203,6 +203,20 @@ fn test_issue_1899() -> Result<()> {
     Ok(())
 }
 
+/// Bug #1938: version comments like `# create-github-app-token/v0.2.2` should be detected correctly.
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
+fn test_issue_1938() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(false)
+            .args(["--persona=pedantic"])
+            .input(input_under_test("ref-version-mismatch/issue-1938-repro.yml"))
+            .run()?, @"No findings to report. Good job!");
+
+    Ok(())
+}
+
 /// Bug #2039: version comments like `# 1.2.3rc1` should be detected correctly.
 #[cfg_attr(not(feature = "gh-token-tests"), ignore)]
 #[test]

--- a/crates/zizmor/tests/integration/test-data/ref-version-mismatch/issue-1938-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/ref-version-mismatch/issue-1938-repro.yml
@@ -1,0 +1,18 @@
+name: ISSUE-1938-REPRO
+
+on:
+  push:
+
+permissions: {}
+
+concurrency:
+  group: ISSUE-1938-REPRO
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Namespaced tag comment should match pinned SHA
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2


### PR DESCRIPTION
This is similar to #1977, but with just a single change (flattening our extraction down to one, slightly more complicated pattern).

Closes #1938. Closes #1977.