### PR TITLE
docs: fix incorrect action name in unpinned-tools rule

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1943,7 +1943,7 @@ Even though the referenced action may itself by pinned, the action's configurati
 cause it to fetch the "latest" version of the tools used by it. At the moment, this audit only applies
 to a set of known actions with such behavior:
 
-- @aquasecurity/trivy-action
+- @aquasecurity/setup-trivy
 - @1password/load-secrets-action
 
 For these actions, zizmor reports a finding when:


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

Closes https://github.com/zizmorcore/zizmor/issues/2077

## Summary

The unpinned-tools rule documentation incorrectly referenced `aquasecurity/trivy-action` instead of `aquasecurity/setup-trivy`, which is the actual action listed in `KNOWN_UNPINNED_TOOLS_ACTIONS`.

## Test Plan

Ran `make site-live` and verified the corrected action name appears on the unpinned-tools page.

<img width="355" height="90" alt="image" src="https://github.com/user-attachments/assets/7f367354-186e-4698-88a4-4b8402cbde27" />

