### PR TITLE
docs: set enable-cache to false for uv

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -100,6 +100,8 @@ GitHub Actions setup:
 
           - name: Install the latest version of uv
             uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+            with:
+              enable-cache: false
 
           - name: Run zizmor 🌈
             run: uvx zizmor --format=sarif . > results.sarif # (2)!
@@ -170,6 +172,8 @@ GitHub Actions setup:
 
           - name: Install the latest version of uv
             uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+            with:
+              enable-cache: false
 
           - name: Run zizmor 🌈
             run: uvx zizmor --format=github . # (2)!


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

fix #2079 


This PR adds `enable-cache: false` to `astral-sh/uv` in the docuemntation yml snippets. As enabled by default, zizmor's own provided snippets are getting flagged by zizmor.
<!-- Provide a summary of what your change does. -->

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->
