### PR TITLE
Add `--select` flag to run only selected audit rules

### DIFF
--- a/crates/zizmor/src/config/mod.rs
+++ b/crates/zizmor/src/config/mod.rs
@@ -537,19 +537,27 @@ impl Config {
     where
         F: AsyncFnOnce() -> Result<Option<Self>, ConfigError>,
     {
-        if options.no_config {
+        let mut config = if options.no_config {
             // User has explicitly disabled config loading.
             tracing::debug!("skipping config discovery: explicitly disabled");
-            Ok(Self::default())
+            Self::default()
         } else if let Some(config) = &options.global_config {
             // The user gave us a (legacy) global config file,
             // which takes precedence over any discovered config.
             tracing::debug!("config discovery: using global config: {config:?}");
-            Ok(config.clone())
+            config.clone()
         } else {
             // Attempt to discover a config file using the provided function.
-            discover_fn().await.map(|conf| conf.unwrap_or_default())
+            discover_fn().await?.unwrap_or_default()
+        };
+
+        for ident in &options.force_enabled_rules {
+            if let Some(rule_config) = config.raw.rules.get_mut(ident) {
+                rule_config.disable = false;
+            }
         }
+
+        Ok(config)
     }
 
     /// Discover a [`Config`] in the given directory.

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -932,33 +932,6 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         }
     }
 
-    if !app.audit.select.is_empty() {
-        let known: HashSet<&str> = AuditRegistry::all_default_idents()
-            .iter()
-            .copied()
-            .collect();
-        let unknown = app
-            .audit
-            .select
-            .iter()
-            .filter(|ident| !known.contains(ident.as_str()))
-            .collect::<Vec<_>>();
-
-        if !unknown.is_empty() {
-            let mut cmd = App::command();
-            let unknown_list = unknown
-                .iter()
-                .map(|ident| format!("'{ident}'"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            cmd.error(
-                clap::error::ErrorKind::InvalidValue,
-                format!("--select: unknown audit rule(s): {unknown_list}"),
-            )
-            .exit();
-        }
-    }
-
     let collection_mode_set = CollectionModeSet::from(app.input.collect.as_slice());
 
     let min_severity = match app.audit.min_severity {
@@ -995,6 +968,49 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         .map(|token| Client::new(&app.network.gh_hostname, token, &app.network.cache_dir))
         .transpose()?;
 
+    let state = AuditState::new(app.network.no_online_audits, gh_client);
+
+    let mut audit_registry = AuditRegistry::default_audits(&state).map_err(Error::AuditLoad)?;
+
+    if !app.audit.select.is_empty() {
+        let loaded: HashSet<&str> = audit_registry.idents().collect();
+        let skipped: HashSet<&str> = audit_registry.skipped_idents().iter().copied().collect();
+
+        let unknown = app
+            .audit
+            .select
+            .iter()
+            .filter(|ident| !loaded.contains(ident.as_str()) && !skipped.contains(ident.as_str()))
+            .collect::<Vec<_>>();
+
+        if !unknown.is_empty() {
+            let mut cmd = App::command();
+            let unknown_list = unknown
+                .iter()
+                .map(|ident| format!("'{ident}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            cmd.error(
+                clap::error::ErrorKind::InvalidValue,
+                format!("--select: unknown audit rule(s): {unknown_list}"),
+            )
+            .exit();
+        }
+
+        let selected: HashSet<&str> = app.audit.select.iter().map(String::as_str).collect();
+
+        for ident in &selected {
+            if skipped.contains(ident) {
+                warn!(
+                    "selected audit '{ident}' was not loaded; \
+                     it may require a GitHub API token or online access"
+                );
+            }
+        }
+
+        audit_registry.retain_selected(&selected);
+    }
+
     let collection_options = CollectionOptions {
         mode_set: collection_mode_set,
         strict: app.input.strict_collection,
@@ -1006,29 +1022,9 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
     let registry = collect_inputs(
         app.input.inputs.as_slice(),
         &collection_options,
-        gh_client.as_ref(),
+        state.gh_client.as_ref(),
     )
     .await?;
-
-    let state = AuditState::new(app.network.no_online_audits, gh_client);
-
-    let mut audit_registry = AuditRegistry::default_audits(&state).map_err(Error::AuditLoad)?;
-
-    if !app.audit.select.is_empty() {
-        let selected: HashSet<&str> = app.audit.select.iter().map(String::as_str).collect();
-
-        let loaded: HashSet<&str> = audit_registry.idents().collect();
-        for ident in &selected {
-            if !loaded.contains(ident) {
-                warn!(
-                    "selected audit '{ident}' was not loaded; \
-                     it may require a GitHub API token or online access"
-                );
-            }
-        }
-
-        audit_registry.retain_selected(&selected);
-    }
 
     let mut results = FindingRegistry::new(
         &registry,

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -183,6 +183,16 @@ struct AuditArgs {
     /// Don't honor ignore comments or ignore rules in configuration.
     #[arg(long)]
     no_ignores: bool,
+
+    /// Run only the selected audit rule(s).
+    ///
+    /// Can be repeated to select multiple rules. When set, only the
+    /// listed rules are evaluated; all other rules are skipped, regardless
+    /// of any ignore configuration.
+    ///
+    /// The argument is the audit rule's identifier, e.g. `template-injection`.
+    #[arg(long, value_name = "RULE", value_parser = NonEmptyStringValueParser::new())]
+    select: Vec<String>,
 }
 
 #[derive(Debug, Args)]
@@ -708,6 +718,10 @@ pub(crate) struct CollectionOptions {
     pub(crate) no_config: bool,
     /// Global configuration, if any.
     pub(crate) global_config: Option<Config>,
+    /// Audit rule identifiers that should be forced on, overriding any
+    /// `disable: true` in the loaded configuration. This is populated from
+    /// `--select`.
+    pub(crate) force_enabled_rules: HashSet<String>,
 }
 
 #[instrument(skip_all)]
@@ -918,6 +932,33 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         }
     }
 
+    if !app.audit.select.is_empty() {
+        let known: HashSet<&str> = AuditRegistry::all_default_idents()
+            .iter()
+            .copied()
+            .collect();
+        let unknown = app
+            .audit
+            .select
+            .iter()
+            .filter(|ident| !known.contains(ident.as_str()))
+            .collect::<Vec<_>>();
+
+        if !unknown.is_empty() {
+            let mut cmd = App::command();
+            let unknown_list = unknown
+                .iter()
+                .map(|ident| format!("'{ident}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            cmd.error(
+                clap::error::ErrorKind::InvalidValue,
+                format!("--select: unknown audit rule(s): {unknown_list}"),
+            )
+            .exit();
+        }
+    }
+
     let collection_mode_set = CollectionModeSet::from(app.input.collect.as_slice());
 
     let min_severity = match app.audit.min_severity {
@@ -959,6 +1000,7 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
         strict: app.input.strict_collection,
         no_config: app.args.no_config,
         global_config,
+        force_enabled_rules: app.audit.select.iter().cloned().collect(),
     };
 
     let registry = collect_inputs(
@@ -970,7 +1012,23 @@ async fn run(app: &mut App) -> Result<ExitCode, Error> {
 
     let state = AuditState::new(app.network.no_online_audits, gh_client);
 
-    let audit_registry = AuditRegistry::default_audits(&state).map_err(Error::AuditLoad)?;
+    let mut audit_registry = AuditRegistry::default_audits(&state).map_err(Error::AuditLoad)?;
+
+    if !app.audit.select.is_empty() {
+        let selected: HashSet<&str> = app.audit.select.iter().map(String::as_str).collect();
+
+        let loaded: HashSet<&str> = audit_registry.idents().collect();
+        for ident in &selected {
+            if !loaded.contains(ident) {
+                warn!(
+                    "selected audit '{ident}' was not loaded; \
+                     it may require a GitHub API token or online access"
+                );
+            }
+        }
+
+        audit_registry.retain_selected(&selected);
+    }
 
     let mut results = FindingRegistry::new(
         &registry,

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -16,75 +16,17 @@ pub(crate) mod input;
 
 pub(crate) struct AuditRegistry {
     pub(crate) audits: IndexMap<&'static str, Box<dyn Audit + Send + Sync>>,
+    /// Identifiers of audits that were known but skipped during loading
+    /// (e.g. because they require network access or a GitHub API token).
+    skipped: Vec<&'static str>,
 }
 
 impl AuditRegistry {
     fn empty() -> Self {
         Self {
             audits: Default::default(),
+            skipped: Default::default(),
         }
-    }
-
-    /// Returns the identifiers of every known default audit, including any
-    /// that may end up skipped at load time (e.g. because they require
-    /// network access or a GitHub API token).
-    pub(crate) fn all_default_idents() -> &'static [&'static str] {
-        use std::sync::OnceLock;
-
-        use crate::audit::AuditCore as _;
-
-        static IDENTS: OnceLock<Vec<&'static str>> = OnceLock::new();
-
-        IDENTS.get_or_init(|| {
-            macro_rules! idents {
-                ($($rule:path),* $(,)?) => {
-                    vec![$({
-                        use $rule as base;
-                        base::ident()
-                    }),*]
-                };
-            }
-
-            idents!(
-                audit::artipacked::Artipacked,
-                audit::unsound_contains::UnsoundContains,
-                audit::excessive_permissions::ExcessivePermissions,
-                audit::dangerous_triggers::DangerousTriggers,
-                audit::impostor_commit::ImpostorCommit,
-                audit::ref_confusion::RefConfusion,
-                audit::use_trusted_publishing::UseTrustedPublishing,
-                audit::template_injection::TemplateInjection,
-                audit::hardcoded_container_credentials::HardcodedContainerCredentials,
-                audit::self_hosted_runner::SelfHostedRunner,
-                audit::known_vulnerable_actions::KnownVulnerableActions,
-                audit::unpinned_uses::UnpinnedUses,
-                audit::undocumented_permissions::UndocumentedPermissions,
-                audit::insecure_commands::InsecureCommands,
-                audit::github_env::GitHubEnv,
-                audit::cache_poisoning::CachePoisoning,
-                audit::secrets_inherit::SecretsInherit,
-                audit::bot_conditions::BotConditions,
-                audit::overprovisioned_secrets::OverprovisionedSecrets,
-                audit::unredacted_secrets::UnredactedSecrets,
-                audit::forbidden_uses::ForbiddenUses,
-                audit::obfuscation::Obfuscation,
-                audit::stale_action_refs::StaleActionRefs,
-                audit::unpinned_images::UnpinnedImages,
-                audit::anonymous_definition::AnonymousDefinition,
-                audit::unsound_condition::UnsoundCondition,
-                audit::ref_version_mismatch::RefVersionMismatch,
-                audit::dependabot_execution::DependabotExecution,
-                audit::dependabot_cooldown::DependabotCooldown,
-                audit::concurrency_limits::ConcurrencyLimits,
-                audit::archived_uses::ArchivedUses,
-                audit::typosquat_uses::TyposquatUses,
-                audit::misfeature::Misfeature,
-                audit::secrets_outside_env::SecretsOutsideEnvironment,
-                audit::superfluous_actions::SuperfluousActions,
-                audit::github_app::GitHubApp,
-                audit::unpinned_tools::UnpinnedTools,
-            )
-        })
     }
 
     /// Constructs a new [`AuditRegistry`] with all default audits registered.
@@ -100,7 +42,8 @@ impl AuditRegistry {
                 match base::new(&audit_state) {
                     Ok(audit) => registry.register_audit(base::ident(), Box::new(audit)),
                     Err(AuditLoadError::Skip(e)) => {
-                        tracing::debug!("skipping {audit}: {e}", audit = base::ident())
+                        tracing::debug!("skipping {audit}: {e}", audit = base::ident());
+                        registry.skipped.push(base::ident());
                     }
                 }
             }};
@@ -154,6 +97,12 @@ impl AuditRegistry {
     /// Returns the identifiers of all registered audits, in registration order.
     pub(crate) fn idents(&self) -> impl Iterator<Item = &'static str> {
         self.audits.keys().copied()
+    }
+
+    /// Returns the identifiers of audits that were skipped at load time
+    /// (e.g. because they require a GitHub API token or online access).
+    pub(crate) fn skipped_idents(&self) -> &[&'static str] {
+        &self.skipped
     }
 
     /// Retain only the audits whose identifiers are in `selected`.

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -25,6 +25,68 @@ impl AuditRegistry {
         }
     }
 
+    /// Returns the identifiers of every known default audit, including any
+    /// that may end up skipped at load time (e.g. because they require
+    /// network access or a GitHub API token).
+    pub(crate) fn all_default_idents() -> &'static [&'static str] {
+        use std::sync::OnceLock;
+
+        use crate::audit::AuditCore as _;
+
+        static IDENTS: OnceLock<Vec<&'static str>> = OnceLock::new();
+
+        IDENTS.get_or_init(|| {
+            macro_rules! idents {
+                ($($rule:path),* $(,)?) => {
+                    vec![$({
+                        use $rule as base;
+                        base::ident()
+                    }),*]
+                };
+            }
+
+            idents!(
+                audit::artipacked::Artipacked,
+                audit::unsound_contains::UnsoundContains,
+                audit::excessive_permissions::ExcessivePermissions,
+                audit::dangerous_triggers::DangerousTriggers,
+                audit::impostor_commit::ImpostorCommit,
+                audit::ref_confusion::RefConfusion,
+                audit::use_trusted_publishing::UseTrustedPublishing,
+                audit::template_injection::TemplateInjection,
+                audit::hardcoded_container_credentials::HardcodedContainerCredentials,
+                audit::self_hosted_runner::SelfHostedRunner,
+                audit::known_vulnerable_actions::KnownVulnerableActions,
+                audit::unpinned_uses::UnpinnedUses,
+                audit::undocumented_permissions::UndocumentedPermissions,
+                audit::insecure_commands::InsecureCommands,
+                audit::github_env::GitHubEnv,
+                audit::cache_poisoning::CachePoisoning,
+                audit::secrets_inherit::SecretsInherit,
+                audit::bot_conditions::BotConditions,
+                audit::overprovisioned_secrets::OverprovisionedSecrets,
+                audit::unredacted_secrets::UnredactedSecrets,
+                audit::forbidden_uses::ForbiddenUses,
+                audit::obfuscation::Obfuscation,
+                audit::stale_action_refs::StaleActionRefs,
+                audit::unpinned_images::UnpinnedImages,
+                audit::anonymous_definition::AnonymousDefinition,
+                audit::unsound_condition::UnsoundCondition,
+                audit::ref_version_mismatch::RefVersionMismatch,
+                audit::dependabot_execution::DependabotExecution,
+                audit::dependabot_cooldown::DependabotCooldown,
+                audit::concurrency_limits::ConcurrencyLimits,
+                audit::archived_uses::ArchivedUses,
+                audit::typosquat_uses::TyposquatUses,
+                audit::misfeature::Misfeature,
+                audit::secrets_outside_env::SecretsOutsideEnvironment,
+                audit::superfluous_actions::SuperfluousActions,
+                audit::github_app::GitHubApp,
+                audit::unpinned_tools::UnpinnedTools,
+            )
+        })
+    }
+
     /// Constructs a new [`AuditRegistry`] with all default audits registered.
     pub(crate) fn default_audits(audit_state: &AuditState) -> anyhow::Result<Self> {
         let mut registry = Self::empty();
@@ -87,6 +149,16 @@ impl AuditRegistry {
 
     pub(crate) fn len(&self) -> usize {
         self.audits.len()
+    }
+
+    /// Returns the identifiers of all registered audits, in registration order.
+    pub(crate) fn idents(&self) -> impl Iterator<Item = &'static str> {
+        self.audits.keys().copied()
+    }
+
+    /// Retain only the audits whose identifiers are in `selected`.
+    pub(crate) fn retain_selected(&mut self, selected: &std::collections::HashSet<&str>) {
+        self.audits.retain(|ident, _| selected.contains(ident));
     }
 
     pub(crate) fn register_audit(

--- a/crates/zizmor/tests/integration/cli.rs
+++ b/crates/zizmor/tests/integration/cli.rs
@@ -806,6 +806,150 @@ fn test_stdin_valid_yaml_unknown_schema() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// `--select` runs only the specified audit rule.
+#[test]
+fn test_select_single_rule() -> anyhow::Result<()> {
+    let workflow = "\
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+";
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin(workflow)
+            .no_config(true)
+            .args(["--select=artipacked", "-"])
+            .run()?,
+        @r"
+    warning[artipacked]: credential persistence through GitHub Actions artifacts
+     --> <stdin>:6:9
+      |
+    6 |       - uses: actions/checkout@v3
+      |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
+      |
+      = note: audit confidence → Low
+      = note: this finding has an auto-fix
+
+    1 finding: 0 informational, 0 low, 1 medium, 0 high
+    "
+    );
+
+    Ok(())
+}
+
+/// `--select` can be repeated to select multiple rules.
+#[test]
+fn test_select_multiple_rules() -> anyhow::Result<()> {
+    let workflow = "\
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+";
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin(workflow)
+            .no_config(true)
+            .args(["--select=artipacked", "--select=unpinned-uses", "-"])
+            .run()?,
+        @r"
+    warning[artipacked]: credential persistence through GitHub Actions artifacts
+     --> <stdin>:6:9
+      |
+    6 |       - uses: actions/checkout@v3
+      |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
+      |
+      = note: audit confidence → Low
+      = note: this finding has an auto-fix
+
+    error[unpinned-uses]: unpinned action reference
+     --> <stdin>:6:15
+      |
+    6 |       - uses: actions/checkout@v3
+      |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
+      |
+      = note: audit confidence → High
+
+    2 findings: 0 informational, 0 low, 1 medium, 1 high
+    "
+    );
+
+    Ok(())
+}
+
+/// `--select` rejects unknown audit rule identifiers.
+#[test]
+fn test_select_unknown_rule() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .stdin("on: push")
+            .no_config(true)
+            .expects_failure(2)
+            .args(["--select=does-not-exist", "-"])
+            .run()?,
+        @"
+     INFO zizmor: 🌈 zizmor v@@VERSION@@
+    error: --select: unknown audit rule(s): 'does-not-exist'
+
+    Usage: zizmor [OPTIONS] <INPUT>...
+
+    For more information, try '--help'.
+    "
+    );
+
+    Ok(())
+}
+
+/// `--select` overrides `disable: true` from a config file for the
+/// selected rule.
+#[test]
+fn test_select_overrides_disable() -> anyhow::Result<()> {
+    let workflow = "\
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+";
+
+    let config_path =
+        std::env::temp_dir().join(format!("zizmor-test-select-{}.yml", std::process::id()));
+    std::fs::write(&config_path, "rules:\n  artipacked:\n    disable: true\n")?;
+    let config_path_str = config_path.to_string_lossy().into_owned();
+
+    let result = zizmor()
+        .stdin(workflow)
+        .config(config_path_str)
+        .args(["--select=artipacked", "-"])
+        .run();
+
+    let _ = std::fs::remove_file(&config_path);
+
+    insta::assert_snapshot!(
+        result?,
+        @r"
+    warning[artipacked]: credential persistence through GitHub Actions artifacts
+     --> <stdin>:6:9
+      |
+    6 |       - uses: actions/checkout@v3
+      |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
+      |
+      = note: audit confidence → Low
+      = note: this finding has an auto-fix
+
+    1 finding: 0 informational, 0 low, 1 medium, 0 high
+    "
+    );
+
+    Ok(())
+}
+
 /// Test that valid YAML matching no known schema fails in strict mode.
 #[test]
 fn test_stdin_valid_yaml_unknown_schema_strict() -> anyhow::Result<()> {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -671,6 +671,27 @@ to keep in mind:
   require online access (and a GitHub token) to fetch the latest commit
   SHA for pinning.
 
+## Selecting specific audit rules
+
+If you only want to run a subset of `zizmor`'s audit rules, you can use the
+`--select` flag, passing the identifier of an audit rule you want to run. The
+flag may be repeated to select multiple rules.
+
+```bash
+# only run the dependabot-cooldown audit
+zizmor --select=dependabot-cooldown .
+
+# run multiple selected audits
+zizmor --select=dependabot-cooldown --select=ref-version-mismatch .
+```
+
+When `--select` is given, only the listed audit rules are evaluated; all other
+rules are skipped. `--select` also overrides any `disable: true` setting from
+[the configuration file](./configuration.md) for the selected rules, so that
+the requested audits always run.
+
+Unknown rule identifiers cause `zizmor` to exit with an error.
+
 ## Filtering results
 
 There are two straightforward ways to filter `zizmor`'s results:


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy. --> I used Claude Code with Opus 4.7/4.8

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

Adds a repeatable `--select <RULE>` flag that restricts the run to the listed audit rules. Selected rules also override `disable: true` from the configuration.

xref #2076, #1713, https://github.com/orgs/zizmorcore/discussions/1726

Let's discuss the design from here!

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

Added integration tests.