### PR TITLE
Detect falsy true arms in actions pseudo-ternaries

### DIFF
--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -56,6 +56,7 @@ pub(crate) mod unpinned_uses;
 pub(crate) mod unredacted_secrets;
 pub(crate) mod unsound_condition;
 pub(crate) mod unsound_contains;
+pub(crate) mod unsound_ternary;
 pub(crate) mod use_trusted_publishing;
 
 #[derive(Debug)]

--- a/crates/zizmor/src/audit/unsound_ternary.rs
+++ b/crates/zizmor/src/audit/unsound_ternary.rs
@@ -1,0 +1,197 @@
+use github_actions_expressions::{
+    Expr, SpannedExpr,
+    op::{BinExpr, BinOp},
+};
+use subfeature::Subfeature;
+
+use crate::{
+    audit::AuditError,
+    finding::{
+        Confidence, Severity,
+        location::{Feature, Location},
+    },
+    utils::parse_fenced_expressions_from_routable,
+};
+
+use super::{Audit, AuditInput, AuditLoadError, AuditState, audit_meta};
+
+pub(crate) struct UnsoundTernary;
+
+audit_meta!(
+    UnsoundTernary,
+    "unsound-ternary",
+    "unsound pseudo-ternary expression"
+);
+
+#[async_trait::async_trait]
+impl Audit for UnsoundTernary {
+    fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    async fn audit_raw<'doc>(
+        &self,
+        input: &'doc AuditInput,
+        _config: &crate::config::Config,
+    ) -> Result<Vec<super::Finding<'doc>>, AuditError> {
+        let mut findings = vec![];
+
+        for (expr, expr_span) in parse_fenced_expressions_from_routable(input) {
+            let Ok(parsed) = Expr::parse(expr.as_bare()) else {
+                tracing::warn!("couldn't parse expression: {expr}", expr = expr.as_bare());
+                continue;
+            };
+
+            for true_value in Self::unsound_true_values(&parsed) {
+                let after = expr_span.start + true_value.origin.span.start;
+                let subfeature = Subfeature::new(after, true_value.origin.raw);
+
+                findings.push(
+                    Self::finding()
+                        .confidence(Confidence::High)
+                        .severity(Severity::Low)
+                        .add_raw_location(Location::new(
+                            input
+                                .location()
+                                .annotated("pseudo-ternary has falsy true value")
+                                .primary(),
+                            Feature::from_subfeature(&subfeature, input),
+                        ))
+                        .build(input)?,
+                );
+            }
+        }
+
+        Ok(findings)
+    }
+}
+
+impl UnsoundTernary {
+    fn unsound_true_values<'src>(expr: &'src SpannedExpr<'src>) -> Vec<&'src SpannedExpr<'src>> {
+        if expr.constant_reducible() {
+            vec![]
+        } else {
+            Self::walk_tree_for_unsound_true_values(expr)
+        }
+    }
+
+    fn walk_tree_for_unsound_true_values<'src>(
+        expr: &'src SpannedExpr<'src>,
+    ) -> Vec<&'src SpannedExpr<'src>> {
+        if expr.constant_reducible() {
+            return vec![];
+        }
+
+        let mut values = vec![];
+
+        match &expr.inner {
+            Expr::Call(call) => {
+                for arg in &call.args {
+                    values.extend(Self::walk_tree_for_unsound_true_values(arg));
+                }
+            }
+            Expr::Context(context) => {
+                for part in &context.parts {
+                    values.extend(Self::walk_tree_for_unsound_true_values(part));
+                }
+            }
+            Expr::BinExpr(BinExpr { op: BinOp::Or, .. }) => {
+                let operands = Self::or_operands(expr);
+                for operand in &operands[..operands.len() - 1] {
+                    if let Expr::BinExpr(BinExpr {
+                        op: BinOp::And,
+                        rhs: true_value,
+                        ..
+                    }) = &operand.inner
+                        && Self::is_falsy(true_value)
+                    {
+                        values.push(true_value);
+                    }
+                }
+
+                for operand in operands {
+                    values.extend(Self::walk_tree_for_unsound_true_values(operand));
+                }
+            }
+            Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
+                values.extend(Self::walk_tree_for_unsound_true_values(lhs));
+                values.extend(Self::walk_tree_for_unsound_true_values(rhs));
+            }
+            Expr::UnExpr { op: _, expr } => {
+                values.extend(Self::walk_tree_for_unsound_true_values(expr));
+            }
+            Expr::Index(expr) => values.extend(Self::walk_tree_for_unsound_true_values(expr)),
+            _ => {}
+        }
+
+        values
+    }
+
+    fn or_operands<'src>(expr: &'src SpannedExpr<'src>) -> Vec<&'src SpannedExpr<'src>> {
+        let mut operands = vec![];
+        Self::push_or_operands(expr, &mut operands);
+        operands
+    }
+
+    fn push_or_operands<'src>(
+        expr: &'src SpannedExpr<'src>,
+        operands: &mut Vec<&'src SpannedExpr<'src>>,
+    ) {
+        if !expr.constant_reducible()
+            && let Expr::BinExpr(BinExpr {
+                lhs,
+                op: BinOp::Or,
+                rhs,
+            }) = &expr.inner
+        {
+            Self::push_or_operands(lhs, operands);
+            Self::push_or_operands(rhs, operands);
+        } else {
+            operands.push(expr);
+        }
+    }
+
+    fn is_falsy(expr: &SpannedExpr) -> bool {
+        expr.consteval()
+            .is_some_and(|evaluation| !evaluation.as_boolean())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unsound_true_values() {
+        #[track_caller]
+        fn case(expr: &str, expected: &[&str]) {
+            let parsed = Expr::parse(expr).unwrap();
+            let values = UnsoundTernary::unsound_true_values(&parsed)
+                .into_iter()
+                .map(|expr| expr.origin.raw)
+                .collect::<Vec<_>>();
+
+            assert_eq!(values, expected);
+        }
+
+        case("foo && '' || 'bar'", &["''"]);
+        case("foo && ('') || 'bar'", &["('')"]);
+        case("foo && 0 || 'bar'", &["0"]);
+        case("foo && false || 'bar'", &["false"]);
+        case("foo && null || 'bar'", &["null"]);
+        case("foo && fromJSON('false') || 'bar'", &["fromJSON('false')"]);
+        case("foo && format('{0}', '') || 'bar'", &["format('{0}', '')"]);
+        case("foo || bar && '' || 'baz'", &["''"]);
+        case("foo || (bar && '' || 'baz')", &["''"]);
+        case("(foo && '' || 'bar') || baz", &["''"]);
+        case("foo && '' || bar && 0 || 'baz'", &["''", "0"]);
+        case("foo || (true && '' || 'bar')", &[]);
+        case("!foo && 'bar' || ''", &[]);
+        case("foo && 'bar' || ''", &[]);
+        case("foo || bar && ''", &[]);
+        case("true && '' || 'bar'", &[]);
+    }
+}

--- a/crates/zizmor/src/audit/unsound_ternary.rs
+++ b/crates/zizmor/src/audit/unsound_ternary.rs
@@ -72,16 +72,6 @@ impl Audit for UnsoundTernary {
 impl UnsoundTernary {
     fn unsound_true_values<'src>(expr: &'src SpannedExpr<'src>) -> Vec<&'src SpannedExpr<'src>> {
         if expr.constant_reducible() {
-            vec![]
-        } else {
-            Self::walk_tree_for_unsound_true_values(expr)
-        }
-    }
-
-    fn walk_tree_for_unsound_true_values<'src>(
-        expr: &'src SpannedExpr<'src>,
-    ) -> Vec<&'src SpannedExpr<'src>> {
-        if expr.constant_reducible() {
             return vec![];
         }
 
@@ -90,12 +80,12 @@ impl UnsoundTernary {
         match &expr.inner {
             Expr::Call(call) => {
                 for arg in &call.args {
-                    values.extend(Self::walk_tree_for_unsound_true_values(arg));
+                    values.extend(Self::unsound_true_values(arg));
                 }
             }
             Expr::Context(context) => {
                 for part in &context.parts {
-                    values.extend(Self::walk_tree_for_unsound_true_values(part));
+                    values.extend(Self::unsound_true_values(part));
                 }
             }
             Expr::BinExpr(BinExpr { op: BinOp::Or, .. }) => {
@@ -113,33 +103,27 @@ impl UnsoundTernary {
                 }
 
                 for operand in operands {
-                    values.extend(Self::walk_tree_for_unsound_true_values(operand));
+                    values.extend(Self::unsound_true_values(operand));
                 }
             }
             Expr::BinExpr(BinExpr { lhs, op: _, rhs }) => {
-                values.extend(Self::walk_tree_for_unsound_true_values(lhs));
-                values.extend(Self::walk_tree_for_unsound_true_values(rhs));
+                values.extend(Self::unsound_true_values(lhs));
+                values.extend(Self::unsound_true_values(rhs));
             }
             Expr::UnExpr { op: _, expr } => {
-                values.extend(Self::walk_tree_for_unsound_true_values(expr));
+                values.extend(Self::unsound_true_values(expr));
             }
-            Expr::Index(expr) => values.extend(Self::walk_tree_for_unsound_true_values(expr)),
+            Expr::Index(expr) => values.extend(Self::unsound_true_values(expr)),
             _ => {}
         }
 
         values
     }
 
+    /// Recursively collects operands of `||` expressions.
     fn or_operands<'src>(expr: &'src SpannedExpr<'src>) -> Vec<&'src SpannedExpr<'src>> {
         let mut operands = vec![];
-        Self::push_or_operands(expr, &mut operands);
-        operands
-    }
 
-    fn push_or_operands<'src>(
-        expr: &'src SpannedExpr<'src>,
-        operands: &mut Vec<&'src SpannedExpr<'src>>,
-    ) {
         if !expr.constant_reducible()
             && let Expr::BinExpr(BinExpr {
                 lhs,
@@ -147,11 +131,13 @@ impl UnsoundTernary {
                 rhs,
             }) = &expr.inner
         {
-            Self::push_or_operands(lhs, operands);
-            Self::push_or_operands(rhs, operands);
+            operands.extend(Self::or_operands(lhs));
+            operands.extend(Self::or_operands(rhs));
         } else {
             operands.push(expr);
         }
+
+        operands
     }
 
     fn is_falsy(expr: &SpannedExpr) -> bool {

--- a/crates/zizmor/src/config/schema.rs
+++ b/crates/zizmor/src/config/schema.rs
@@ -107,6 +107,7 @@ macro_rules! define_audit_rules {
 define_audit_rules! {
     artipacked,
     unsound_contains,
+    unsound_ternary,
     excessive_permissions,
     dangerous_triggers,
     impostor_commit,

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -46,6 +46,7 @@ impl AuditRegistry {
 
         register_audit!(audit::artipacked::Artipacked);
         register_audit!(audit::unsound_contains::UnsoundContains);
+        register_audit!(audit::unsound_ternary::UnsoundTernary);
         register_audit!(audit::excessive_permissions::ExcessivePermissions);
         register_audit!(audit::dangerous_triggers::DangerousTriggers);
         register_audit!(audit::impostor_commit::ImpostorCommit);

--- a/crates/zizmor/tests/integration/audit/mod.rs
+++ b/crates/zizmor/tests/integration/audit/mod.rs
@@ -36,4 +36,5 @@ mod unpinned_uses;
 mod unredacted_secrets;
 mod unsound_condition;
 mod unsound_contains;
+mod unsound_ternary;
 mod use_trusted_publishing;

--- a/crates/zizmor/tests/integration/audit/unsound_ternary.rs
+++ b/crates/zizmor/tests/integration/audit/unsound_ternary.rs
@@ -1,0 +1,23 @@
+use crate::common::{input_under_test, zizmor};
+
+#[test]
+fn test_issue_746_repro() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("unsound-ternary/issue-746-repro.yml"))
+            .run()?,
+        @"
+    help[unsound-ternary]: unsound pseudo-ternary expression
+      --> @@INPUT@@:11:30
+       |
+    11 |       - run: echo ${{ foo && '' || 'bar' }}
+       |                              ^^ pseudo-ternary has falsy true value
+       |
+       = note: audit confidence → High
+
+    4 findings (3 suppressed): 0 informational, 1 low, 0 medium, 0 high
+    "
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/unsound-ternary/issue-746-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/unsound-ternary/issue-746-repro.yml
@@ -1,0 +1,11 @@
+on: pull_request
+
+name: issue-746-repro
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ foo && '' || 'bar' }}

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -2445,6 +2445,72 @@ Other resources:
                 if: contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref)
         ```
 
+## `unsound-ternary`
+
+| Type     | Examples              | Introduced in | Works offline | Auto-fixes available | Configurable |
+|----------|-----------------------|---------------|---------------|--------------------|--------------|
+| Workflow, Action | [issue-746-repro.yml] | v1.26.0      | ✅            | ❌                 | ❌           |
+
+[issue-746-repro.yml]: https://github.com/zizmorcore/zizmor/blob/main/crates/zizmor/tests/integration/test-data/unsound-ternary/issue-746-repro.yml
+
+Detects GitHub Actions expressions that use `&&` and `||` as a pseudo-ternary
+when the "true" value can evaluate to a falsy value.
+
+It's common to imitate the behavior of a ternary in GitHub Actions expressions
+like this:
+
+```yaml
+${{ condition && value || fallback }}
+```
+
+This only behaves like a ternary when `value` is truthy. If `value` is falsy,
+the expression falls through to `fallback` even when `condition` is true. For
+example, the following expression evaluates to `bar` when `foo` is truthy:
+
+```yaml
+${{ foo && '' || 'bar' }}
+```
+
+This audit detects pseudo-ternaries where the true arm statically evaluates to
+a falsy value, including `#!yaml ''`, `#!yaml 0`, `#!yaml false`, and
+`#!yaml null`.
+
+### Remediation
+
+Use the official `case(...)` function when a value may be falsy:
+
+```yaml
+${{ case(condition, value, fallback) }}
+```
+
+Alternatively, rewrite the expression so that the true arm cannot be falsy.
+
+!!! example
+
+    === "Before :warning:"
+
+        ```yaml title="unsound-ternary.yml" hl_lines="7"
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "value=${VALUE}"
+                env:
+                  VALUE: ${{ foo && '' || 'bar' }}
+        ```
+
+    === "After :white_check_mark:"
+
+        ```yaml title="unsound-ternary.yml" hl_lines="7"
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "value=${VALUE}"
+                env:
+                  VALUE: ${{ case(foo, '', 'bar') }}
+        ```
+
 
 ## `use-trusted-publishing`
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -2477,7 +2477,7 @@ a falsy value, including `#!yaml ''`, `#!yaml 0`, `#!yaml false`, and
 
 ### Remediation
 
-Use the official `case(...)` function when a value may be falsy:
+Use the `case(...)` function when a value may be falsy:
 
 ```yaml
 ${{ case(condition, value, fallback) }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,11 @@ of `zizmor`.
 
     Many thanks to @andrew for proposing and implementing this improvement!
 
+* **New audit**: [unsound-ternary] detects pseudo-ternary expressions that
+  don't evaluate as expected (#2085)
+
+    Many thanks to @terror for proposing and implementing this improvement!
+
 ### Enhancements 🌱
 
 * The [cache-poisoning] audit now detects additional cache disablement

--- a/support/zizmor.schema.json
+++ b/support/zizmor.schema.json
@@ -351,6 +351,9 @@
         "unsound-contains": {
           "$ref": "#/definitions/BaseRuleConfig"
         },
+        "unsound-ternary": {
+          "$ref": "#/definitions/BaseRuleConfig"
+        },
         "use-trusted-publishing": {
           "$ref": "#/definitions/BaseRuleConfig"
         }


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).
- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Resolves https://github.com/zizmorcore/zizmor/issues/746

This diff adds an `obfuscation` audit check for GitHub Actions expressions that use the common `condition && value || fallback` pseudo-ternary pattern when `value` statically evaluates as falsy. In those cases, GitHub Actions short-circuit semantics return the fallback even when the condition is true, so expressions like `foo && '' || 'bar'` do not behave like ternaries.

The check reports the falsy true arm directly and handles chained `||` expressions so later pseudo-ternaries are not missed. It covers falsy constants such as empty strings, `0`, `false`, `null`, and constant-foldable falsy expressions, while avoiding fine forms like `!condition && 'value' || ''` and non-falsy true arms.

**n.b.** This does _not_ add an auto-fix yet. A reasonable follow-up would be to rewrite eligible patterns to the official `case(...)` form, for example converting `condition && true_value || fallback` into
`case(condition, true_value, fallback)`. I'm open to getting this in here, but it may make the diff larger than ideal 🤔 

## Test Plan

`cargo test -p zizmor`