### PR TITLE
Add InputGroup::root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,6 +4314,7 @@ dependencies = [
  "serde_json",
  "subfeature",
  "tar",
+ "tempfile",
  "terminal-link",
  "thiserror 2.0.18",
  "tikv-jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ schemars = "1.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 yaml_serde = "0.10"
+tempfile = "3"
 tar = "0.4.46"
 terminal-link = "0.1.0"
 thiserror = "2.0.18"

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -90,3 +90,4 @@ fst.workspace = true
 [dev-dependencies]
 assert_cmd.workspace = true
 insta.workspace = true
+tempfile.workspace = true

--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -328,7 +328,7 @@ mod tests {
     /// 4. Executes the provided test closure with the findings
     macro_rules! test_workflow_audit {
         ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/bot_conditions.rs
+++ b/crates/zizmor/src/audit/bot_conditions.rs
@@ -421,7 +421,7 @@ mod tests {
     /// Macro for testing workflow audits with common boilerplate
     macro_rules! test_workflow_audit {
         ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -723,7 +723,7 @@ mod tests {
     /// 4. Executes the provided test closure with the findings
     macro_rules! test_workflow_audit {
         ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -206,7 +206,7 @@ mod tests {
     /// Macro for testing dependabot audits with common boilerplate
     macro_rules! test_dependabot_audit {
         ($audit_type:ty, $filename:expr, $dependabot_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let dependabot = Dependabot::from_string($dependabot_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/dependabot_execution.rs
+++ b/crates/zizmor/src/audit/dependabot_execution.rs
@@ -85,7 +85,7 @@ mod tests {
     /// Macro for testing dependabot audits with common boilerplate
     macro_rules! test_dependabot_audit {
         ($audit_type:ty, $filename:expr, $dependabot_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let dependabot = Dependabot::from_string($dependabot_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/insecure_commands.rs
+++ b/crates/zizmor/src/audit/insecure_commands.rs
@@ -204,7 +204,7 @@ mod tests {
     /// Macro for testing workflow audits with common boilerplate
     macro_rules! test_workflow_audit {
         ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -371,7 +371,7 @@ jobs:
         run: echo "hello"
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_checkout.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_checkout.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -422,7 +422,7 @@ jobs:
         run: npm install
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_setup_node.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_setup_node.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -475,7 +475,7 @@ jobs:
         run: echo "test"
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_third_party.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_third_party.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -535,7 +535,7 @@ jobs:
         run: npm install
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_multiple.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_multiple.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -610,7 +610,7 @@ jobs:
           param: value
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_subpath.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_subpath.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -658,7 +658,7 @@ jobs:
         uses: actions/checkout@v2
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_first_patched.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_first_patched.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -705,7 +705,7 @@ jobs:
         uses: actions/checkout@v2 # this comment stays
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_non_commit.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_non_commit.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
         let job = workflow.jobs().next().unwrap();
         let steps: Vec<_> = match job {
@@ -763,7 +763,7 @@ jobs:
         uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4  # v4.0.0
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "dummy.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "dummy.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(
@@ -816,7 +816,7 @@ jobs:
         - name: Run Trivy vulnerability scanner in repo mode
           uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # v0.34.0
 "#;
-        let key = InputKey::local("fakegroup".into(), "dummy.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "dummy.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(
@@ -876,7 +876,7 @@ jobs:
       - name: Commit pinned action
         uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4
 "#;
-        let key = InputKey::local("fakegroup".into(), "dummy.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "dummy.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(

--- a/crates/zizmor/src/audit/obfuscation.rs
+++ b/crates/zizmor/src/audit/obfuscation.rs
@@ -349,7 +349,7 @@ mod tests {
 
     /// Helper function to apply a fix and return the result for snapshot testing
     async fn apply_fix_for_snapshot(workflow_content: &str, _audit_name: &str) -> String {
-        let key = InputKey::local("dummy".into(), "test.yml", None::<&str>);
+        let key = InputKey::local("dummy".into(), "test.yml", None, None);
         let workflow =
             AuditInput::from(Workflow::from_string(workflow_content.to_string(), key).unwrap());
         let audit_state = AuditState {

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -272,7 +272,7 @@ mod tests {
 
     #[cfg(feature = "gh-token-tests")]
     fn workflow_from_string(workflow_content: &str, path: &str) -> Workflow {
-        let key = InputKey::local("fakegroup".into(), path, None::<&str>);
+        let key = InputKey::local("fakegroup".into(), path, None, None);
         Workflow::from_string(workflow_content.to_string(), key).unwrap()
     }
 
@@ -349,7 +349,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # some comment
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "action.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "action.yml", None, None);
         let action = Action::from_string(action_content.to_string(), key).unwrap();
         let step = action.steps().unwrap().next().unwrap();
         let uses_location = step
@@ -376,7 +376,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "action.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "action.yml", None, None);
         let action = Action::from_string(action_content.to_string(), key).unwrap();
         let step = action.steps().unwrap().next().unwrap();
 
@@ -741,7 +741,7 @@ jobs:
                     uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v9.9.9
         "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_nonexistent_ref.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_nonexistent_ref.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(

--- a/crates/zizmor/src/audit/template_injection.rs
+++ b/crates/zizmor/src/audit/template_injection.rs
@@ -651,7 +651,7 @@ mod tests {
     /// Macro for testing workflow audits with common boilerplate
     macro_rules! test_workflow_audit {
         ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -311,7 +311,7 @@ jobs:
         uses: actions/checkout@v6.0.1
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_unpinned_uses.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_unpinned_uses.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(
@@ -365,7 +365,7 @@ jobs:
 
         let workflow_content = workflow_content.replace("\n", "\r\n");
 
-        let key = InputKey::local("fakegroup".into(), "test_unpinned_uses.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_unpinned_uses.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(
@@ -420,7 +420,8 @@ jobs:
         let key = InputKey::local(
             "fakegroup".into(),
             "test_unpinned_uses_overwrites_comment.yml",
-            None::<&str>,
+            None,
+            None,
         );
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
@@ -472,7 +473,7 @@ jobs:
         uses: actions/checkout@v6.0.1
 "#;
 
-        let key = InputKey::local("fakegroup".into(), "test_unpinned_uses.yml", None::<&str>);
+        let key = InputKey::local("fakegroup".into(), "test_unpinned_uses.yml", None, None);
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
         let state = crate::state::AuditState::new(
@@ -526,7 +527,8 @@ jobs:
         let key = InputKey::local(
             "fakegroup".into(),
             "test_unpinned_uses_subpath.yml",
-            None::<&str>,
+            None,
+            None,
         );
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
@@ -583,7 +585,8 @@ jobs:
         let key = InputKey::local(
             "fakegroup".into(),
             "test_unpinned_uses_major.yml",
-            None::<&str>,
+            None,
+            None,
         );
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
@@ -639,7 +642,8 @@ jobs:
         let key = InputKey::local(
             "fakegroup".into(),
             "test_no_fix_for_already_pinned.yml",
-            None::<&str>,
+            None,
+            None,
         );
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 
@@ -681,7 +685,8 @@ jobs:
         let key = InputKey::local(
             "fakegroup".into(),
             "test_no_fix_for_non_version_ref.yml",
-            None::<&str>,
+            None,
+            None,
         );
         let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
 

--- a/crates/zizmor/src/audit/unsound_condition.rs
+++ b/crates/zizmor/src/audit/unsound_condition.rs
@@ -192,7 +192,7 @@ mod tests {
     /// Macro for testing workflow audits with common boilerplate
     macro_rules! test_workflow_audit {
         ($audit_type:ty, $filename:expr, $workflow_content:expr, $test_fn:expr) => {{
-            let key = InputKey::local("fakegroup".into(), $filename, None::<&str>);
+            let key = InputKey::local("fakegroup".into(), $filename, None, None);
             let workflow = Workflow::from_string($workflow_content.to_string(), key).unwrap();
             let audit_state = AuditState::default();
             let audit = <$audit_type>::new(&audit_state).unwrap();

--- a/crates/zizmor/src/lsp.rs
+++ b/crates/zizmor/src/lsp.rs
@@ -265,17 +265,17 @@ impl Backend {
         let input = if matches!(path.file_name(), Some("action.yml" | "action.yaml")) {
             AuditInput::from(Action::from_string(
                 params.text,
-                InputKey::local("lsp".into(), path, None),
+                InputKey::local("lsp".into(), path, None, None),
             )?)
         } else if matches!(path.file_name(), Some("dependabot.yml" | "dependabot.yaml")) {
             AuditInput::from(Dependabot::from_string(
                 params.text,
-                InputKey::local("lsp".into(), path, None),
+                InputKey::local("lsp".into(), path, None, None),
             )?)
         } else if matches!(path.extension(), Some("yml" | "yaml")) {
             AuditInput::from(Workflow::from_string(
                 params.text,
-                InputKey::local("lsp".into(), path, None),
+                InputKey::local("lsp".into(), path, None, None),
             )?)
         } else {
             anyhow::bail!("asked to audit unexpected file: {path}");
@@ -314,7 +314,10 @@ impl Backend {
             config
         };
 
-        let mut group = InputGroup::new(config);
+        // Note: we don't bother discovering the root directory
+        // for LSP inputs, since LSP diagnostics are always tied
+        // to a specific file, identified by an opaque URI.
+        let mut group = InputGroup::new(config, None);
         group.register_input(input)?;
         let mut input_registry = InputRegistry::new();
         input_registry.groups.insert("lsp".into(), group);

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -487,7 +487,7 @@ mod tests {
 
         let workflow = Workflow::from_string(
             workflow.into(),
-            InputKey::local("fakegroup".into(), "dummy", None),
+            InputKey::local("fakegroup".into(), "dummy", None, None),
         )
         .unwrap();
 

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -727,7 +727,7 @@ jobs:
 
         let workflow = Workflow::from_string(
             workflow.into(),
-            crate::InputKey::local("fakegroup".into(), "dummy", None),
+            crate::InputKey::local("fakegroup".into(), "dummy", None, None),
         )?;
 
         // `foo` unifies in favor of the more permissive capability,

--- a/crates/zizmor/src/models/workflow/matrix.rs
+++ b/crates/zizmor/src/models/workflow/matrix.rs
@@ -317,7 +317,7 @@ jobs:
 
         let workflow = Workflow::from_string(
             workflow_yaml.into(),
-            InputKey::local("fakegroup".into(), "test.yml", None),
+            InputKey::local("fakegroup".into(), "test.yml", None, None),
         )
         .unwrap();
 
@@ -344,8 +344,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -385,8 +385,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -426,8 +426,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -467,8 +467,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -508,8 +508,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -549,8 +549,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -590,8 +590,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -634,8 +634,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -678,8 +678,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -722,8 +722,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -766,8 +766,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -810,8 +810,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -854,8 +854,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -901,8 +901,8 @@ jobs:
                             group: Group(
                                 "fakegroup",
                             ),
-                            prefix: None,
                             given_path: "test.yml",
+                            best_relative_path: "test.yml",
                         },
                     ),
                     annotation: "this expansion",
@@ -974,7 +974,7 @@ jobs:
 
         let workflow = Workflow::from_string(
             workflow_yaml.into(),
-            InputKey::local("fakegroup".into(), "test.yml", None),
+            InputKey::local("fakegroup".into(), "test.yml", None, None),
         )?;
 
         let job = {
@@ -1025,7 +1025,7 @@ jobs:
 
         let workflow = Workflow::from_string(
             workflow_yaml.into(),
-            InputKey::local("fakegroup".into(), "test.yml", None),
+            InputKey::local("fakegroup".into(), "test.yml", None, None),
         )?;
 
         let job = {

--- a/crates/zizmor/src/output/github.rs
+++ b/crates/zizmor/src/output/github.rs
@@ -5,7 +5,6 @@
 use std::io;
 
 use anyhow::Result;
-use camino::Utf8Path;
 
 use crate::{Severity, finding::Finding};
 
@@ -29,7 +28,7 @@ impl Finding<'_> {
         // NOTE: We intentionally only use the start line, since our spans
         // sometimes end at EOF and GitHub's annotations don't handle that
         // gracefully.
-        let filepath = Utf8Path::new(primary.symbolic.key.presentation_path());
+        let filepath = primary.symbolic.key.best_relative_path();
         let start_line = primary.concrete.location.start_point.row + 1;
         let title = self.ident;
 

--- a/crates/zizmor/src/output/plain.rs
+++ b/crates/zizmor/src/output/plain.rs
@@ -69,7 +69,6 @@ pub(crate) fn finding_snippets<'doc>(
     let mut snippets = vec![];
     for (input_key, locations) in locations_by_workflow {
         let input = registry.get_input(input_key);
-
         let path = match render_links_mode {
             RenderLinks::Always => input.link().unwrap_or(input_key.presentation_path()),
             RenderLinks::Never => input_key.presentation_path(),

--- a/crates/zizmor/src/output/sarif.rs
+++ b/crates/zizmor/src/output/sarif.rs
@@ -92,7 +92,7 @@ fn build_rule(finding: &Finding) -> ReportingDescriptor {
 }
 
 fn build_results(findings: &[Finding]) -> Vec<SarifResult> {
-    findings.iter().map(|f| build_result(f)).collect()
+    findings.iter().map(build_result).collect()
 }
 
 fn build_result(finding: &Finding<'_>) -> SarifResult {
@@ -166,7 +166,7 @@ fn build_result(finding: &Finding<'_>) -> SarifResult {
 fn build_physical_location(location: &Location<'_>) -> PhysicalLocation {
     PhysicalLocation {
         artifact_location: ArtifactLocation {
-            uri: location.symbolic.key.sarif_path().into(),
+            uri: location.symbolic.key.best_relative_path().into(),
         },
         region: Region {
             // NOTE: SARIF lines/columns are 1-based.

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -447,6 +447,7 @@ impl InputGroup {
                 break;
             }
 
+            // TODO: Handle worktrees?
             tracing::trace!("checking if {candidate} is a Git repository root");
             if candidate.join(".git").is_dir() {
                 return Some(candidate);

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -1,10 +1,11 @@
 //! Input registry and associated types.
 
 use std::{
-    collections::{BTreeMap, btree_map},
+    collections::{BTreeMap, HashSet, btree_map},
     io::Read as _,
     path::PathBuf,
     str::FromStr as _,
+    sync::LazyLock,
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -181,10 +182,47 @@ pub(crate) struct LocalKey {
     /// The group this input belongs to.
     #[serde(skip)]
     group: Group,
-    /// The path's nondeterministic prefix, if any.
-    prefix: Option<Utf8PathBuf>,
     /// The given path to the input. This can be absolute or relative.
     pub(crate) given_path: Utf8PathBuf,
+    #[serde(skip)]
+    best_relative_path: String,
+}
+
+impl LocalKey {
+    /// Produce the "best" relative path for a given path.
+    ///
+    /// This path is the "best" in the sense that it's intended to be maximally
+    /// compatible with the assumptions that consumers make. Specifically, many
+    /// consumers (like GitHub's "Advanced Security") expect paths to be relative
+    /// to the root of the repository, even if the user supplied them to the tool
+    /// as absolute or relative to some other directory.
+    fn best_relative_path<P: AsRef<Utf8Path>>(
+        given_path: P,
+        prefix: Option<P>,
+        root: Option<P>,
+    ) -> String {
+        // Happy path: we have a root directory and the input
+        // is relative to it once canonicalized.
+        if let Some(root) = root
+            && let Ok(canonical) = given_path.as_ref().canonicalize_utf8()
+            && let Ok(relative) = canonical.strip_prefix(root.as_ref())
+        {
+            return relative.as_str().to_owned();
+        }
+
+        // Semi-happy path: we don't have a root directory,
+        // but we have a known prefix that we can strip from the
+        // input path.
+        if let Some(prefix) = prefix
+            && let Ok(stripped) = given_path.as_ref().strip_prefix(prefix.as_ref())
+        {
+            return stripped.as_str().to_owned();
+        }
+
+        // Sad path: no root or known prefix, so we return the
+        // given path as-is and hope for the best.
+        given_path.as_ref().as_str().to_owned()
+    }
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, PartialOrd, Ord)]
@@ -238,11 +276,26 @@ impl std::fmt::Display for InputKey {
 }
 
 impl InputKey {
-    pub(crate) fn local<P: AsRef<Utf8Path>>(group: Group, path: P, prefix: Option<P>) -> Self {
+    /// Constructs a local InputKey.
+    ///
+    /// `prefix` and `root` are used to derive the input's
+    /// "best" relative path for output rendering purposes.
+    pub(crate) fn local<P: AsRef<Utf8Path>>(
+        group: Group,
+        path: P,
+        prefix: Option<P>,
+        root: Option<P>,
+    ) -> Self {
+        let path = path.as_ref();
+        let best_relative_path = LocalKey::best_relative_path(
+            path,
+            prefix.as_ref().map(P::as_ref),
+            root.as_ref().map(P::as_ref),
+        );
         Self::Local(LocalKey {
             group,
-            prefix: prefix.map(|p| p.as_ref().to_path_buf()),
-            given_path: path.as_ref().to_path_buf(),
+            given_path: path.to_path_buf(),
+            best_relative_path,
         })
     }
 
@@ -260,28 +313,15 @@ impl InputKey {
         })
     }
 
-    /// Returns a path for this [`InputKey`] that's suitable for SARIF
-    /// outputs.
+    /// Returns the "best" relative path for this [`InputKey`].
     ///
-    /// This is similar to [`InputKey::presentation_path`] in terms of being
-    /// a relative path (if the input is relative), but it also strips
-    /// the prefix from local paths, if one is present.
-    ///
-    /// For example, if the user runs `zizmor .`, then an input at
-    /// `./.github/workflows/foo.yml` will be returned as `.github/workflows/foo.yml`,
-    /// rather than `./.github/workflows/foo.yml`.
-    ///
-    /// This is needed for GitHub's interpretation of SARIF, which is brittle
-    /// with absolute paths but _also_ doesn't like relative paths that
-    /// start with relative directory markers.
-    pub(crate) fn sarif_path(&self) -> &str {
+    /// Unlike [`InputKey::presentation_path`], local input paths are made
+    /// relative to the root of their group's Git repository when possible.
+    /// This matches what SARIF consumers like GitHub's "Advanced Security"
+    /// expect.
+    pub(crate) fn best_relative_path(&self) -> &str {
         match self {
-            InputKey::Local(local) => local
-                .prefix
-                .as_ref()
-                .and_then(|pfx| local.given_path.strip_prefix(pfx).ok())
-                .unwrap_or_else(|| &local.given_path)
-                .as_str(),
+            InputKey::Local(local) => &local.best_relative_path,
             InputKey::Remote(remote) => remote.path.as_str(),
             InputKey::Stdin(_) => "<stdin>",
         }
@@ -344,17 +384,20 @@ impl From<&RepoSlug> for Group {
 
 /// A group of inputs collected from the same source.
 pub(crate) struct InputGroup {
-    /// The collected inputs.
-    inputs: BTreeMap<InputKey, AuditInput>,
     /// The configuration for this group.
     config: Config,
+    /// The group's root directory (as an absolute path), if applicable and inferable.
+    root: Option<Utf8PathBuf>,
+    /// The collected inputs.
+    inputs: BTreeMap<InputKey, AuditInput>,
 }
 
 impl InputGroup {
-    pub(crate) fn new(config: Config) -> Self {
+    pub(crate) fn new(config: Config, root: Option<Utf8PathBuf>) -> Self {
         Self {
-            inputs: Default::default(),
             config,
+            root,
+            inputs: Default::default(),
         }
     }
 
@@ -366,6 +409,58 @@ impl InputGroup {
         self.inputs.insert(input.key().clone(), input);
 
         Ok(())
+    }
+
+    /// Given a path to an input file, attempt to discover the Git repository root that it belongs
+    /// to, if any.
+    ///
+    /// This is a rough approximation of what `git rev-parse --show-toplevel` does.
+    ///
+    /// Returns `None` if the path is not within a Git repository or if the root can't be determined for any reason.
+    pub(crate) fn discover_root(path: &Utf8Path) -> Option<Utf8PathBuf> {
+        Self::discover_root_with_ceilings(path, &GIT_CEILING_DIRECTORIES)
+    }
+
+    fn discover_root_with_ceilings(
+        path: &Utf8Path,
+        ceilings: &HashSet<Utf8PathBuf>,
+    ) -> Option<Utf8PathBuf> {
+        // Canonicalize first; this also avoids a `parent()` of `Some("")`
+        // for inputs like `foo.yml`.
+        let canonical = match path.canonicalize_utf8() {
+            Ok(canonical) => canonical,
+            Err(_) => {
+                tracing::trace!("failed to find a canonical path for {path}");
+                return None;
+            }
+        };
+
+        let mut candidate = if canonical.is_file() {
+            canonical.parent()?.to_path_buf()
+        } else {
+            canonical
+        };
+
+        loop {
+            if ceilings.contains(&candidate) {
+                tracing::trace!("hit a GIT_CEILING_DIRECTORIES entry at {candidate}");
+                break;
+            }
+
+            tracing::trace!("checking if {candidate} is a Git repository root");
+            if candidate.join(".git").is_dir() {
+                return Some(candidate);
+            }
+
+            if let Some(parent) = candidate.parent() {
+                candidate = parent.to_path_buf();
+            } else {
+                break;
+            }
+        }
+
+        tracing::trace!("no Git repository root found for {path}");
+        None
     }
 
     pub(crate) fn register(
@@ -414,21 +509,22 @@ impl InputGroup {
             .parent()
             .is_some_and(|parent| parent.ends_with(".github/workflows"));
 
-        let mut group = Self::new(config);
+        let mut group = Self::new(config, Self::discover_root(path));
+        let root = group.root.as_deref();
 
         // When collecting individual files, we don't know which part
         // of the input path is the prefix.
         let (key, kind) = match (path.file_stem(), path.extension()) {
             (Some("dependabot"), Some("yml" | "yaml")) if !is_workflow_path => (
-                InputKey::local(Group(path.as_str().into()), path, None),
+                InputKey::local(Group(path.as_str().into()), path, None, root),
                 InputKind::Dependabot,
             ),
             (Some("action"), Some("yml" | "yaml")) if !is_workflow_path => (
-                InputKey::local(Group(path.as_str().into()), path, None),
+                InputKey::local(Group(path.as_str().into()), path, None, root),
                 InputKind::Action,
             ),
             (Some(_), Some("yml" | "yaml")) => (
-                InputKey::local(Group(path.as_str().into()), path, None),
+                InputKey::local(Group(path.as_str().into()), path, None, root),
                 InputKind::Workflow,
             ),
             _ => return Err(CollectionError::InvalidExtension),
@@ -448,7 +544,7 @@ impl InputGroup {
     ) -> Result<Self, CollectionError> {
         let config = Config::discover(options, || Config::discover_local(path)).await?;
 
-        let mut group = Self::new(config);
+        let mut group = Self::new(config, Self::discover_root(path));
 
         // Start with all filters disabled, i.e. walk everything.
         let mut walker = ignore::WalkBuilder::new(path);
@@ -473,10 +569,14 @@ impl InputGroup {
                 .git_exclude(true);
         }
 
+        // Clone once outside the loop so each iteration's `key` construction
+        // doesn't conflict with the mutable borrow `group.register(..)` takes.
+        let root = group.root.clone();
         for entry in walker.build() {
             let entry = entry?;
             let entry = <&Utf8Path>::try_from(entry.path())
                 .map_err(|e| CollectionError::InvalidPath(e, entry.path().into()))?;
+            let root = root.as_deref();
 
             if options.mode_set.workflows()
                 && entry.is_file()
@@ -485,7 +585,7 @@ impl InputGroup {
                     .parent()
                     .is_some_and(|dir| dir.ends_with(".github/workflows"))
             {
-                let key = InputKey::local(Group(path.as_str().into()), entry, Some(path));
+                let key = InputKey::local(Group(path.as_str().into()), entry, Some(path), root);
                 let contents = std::fs::read_to_string(entry).map_err(|e| {
                     CollectionError::Inner(
                         CollectionError::Io(e).into(),
@@ -500,7 +600,7 @@ impl InputGroup {
                 && entry.is_file()
                 && matches!(entry.file_name(), Some("action.yml" | "action.yaml"))
             {
-                let key = InputKey::local(Group(path.as_str().into()), entry, Some(path));
+                let key = InputKey::local(Group(path.as_str().into()), entry, Some(path), root);
                 let contents = std::fs::read_to_string(entry).map_err(|e| {
                     CollectionError::Inner(
                         CollectionError::Io(e).into(),
@@ -518,7 +618,7 @@ impl InputGroup {
                     Some("dependabot.yml" | "dependabot.yaml")
                 )
             {
-                let key = InputKey::local(Group(path.as_str().into()), entry, Some(path));
+                let key = InputKey::local(Group(path.as_str().into()), entry, Some(path), root);
                 let contents = std::fs::read_to_string(entry).map_err(|e| {
                     CollectionError::Inner(
                         CollectionError::Io(e).into(),
@@ -541,7 +641,7 @@ impl InputGroup {
         let client = gh_client.ok_or_else(|| CollectionError::NoGitHubClient(slug.clone()))?;
 
         let config = Config::discover(options, || Config::discover_remote(client, &slug)).await?;
-        let mut group = Self::new(config);
+        let mut group = Self::new(config, None);
 
         if options.mode_set.workflows_only() {
             // Performance: if we're *only* collecting workflows, then we
@@ -572,7 +672,7 @@ impl InputGroup {
             .read_to_string(&mut contents)
             .map_err(CollectionError::Io)?;
 
-        let mut group = Self::new(Config::default());
+        let mut group = Self::new(Config::default(), None);
         let key = InputKey::stdin();
 
         // Infer the input type by trying each parser in order.
@@ -625,6 +725,39 @@ impl InputGroup {
         self.inputs.len()
     }
 }
+
+/// Cached parse of the process's `GIT_CEILING_DIRECTORIES`.
+static GIT_CEILING_DIRECTORIES: LazyLock<HashSet<Utf8PathBuf>> = LazyLock::new(|| {
+    let Ok(raw) = std::env::var("GIT_CEILING_DIRECTORIES") else {
+        return HashSet::new();
+    };
+
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    let mut resolve = true;
+    let mut ceilings = HashSet::new();
+    for entry in raw.split(separator) {
+        // Per `git` docs, an empty entry means that all subsequent
+        // entries are not resolved.
+        // See: <https://git-scm.com/docs/git#Documentation/git.txt-GITCEILINGDIRECTORIES>
+        if entry.is_empty() {
+            resolve = false;
+            continue;
+        }
+        let path = Utf8Path::new(entry);
+        if !path.is_absolute() {
+            continue;
+        }
+        let resolved = if resolve {
+            path.canonicalize_utf8().ok()
+        } else {
+            Some(path.to_path_buf())
+        };
+        if let Some(p) = resolved {
+            ceilings.insert(p);
+        }
+    }
+    ceilings
+});
 
 pub(crate) struct InputRegistry {
     // NOTE: We use a BTreeMap here to ensure that registered inputs
@@ -681,20 +814,24 @@ impl InputRegistry {
         &self
             .groups
             .get(group)
-            .expect("API misuse: requested config for an un-registered input")
+            .expect("API misuse: requested an un-registered input group")
             .config
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr as _;
+    use std::{collections::HashSet, str::FromStr as _};
+
+    use camino::Utf8PathBuf;
+
+    use crate::registry::input::InputGroup;
 
     use super::{InputKey, RepoSlug};
 
     #[test]
     fn test_input_key_display() {
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", None);
+        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", None, None);
         assert_eq!(local.to_string(), "file:///foo/bar/baz.yml");
 
         // No ref
@@ -716,19 +853,25 @@ mod tests {
 
     #[test]
     fn test_input_key_local_presentation_path() {
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", None);
+        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", None, None);
         assert_eq!(local.presentation_path(), "/foo/bar/baz.yml");
 
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", Some("/foo"));
+        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", Some("/foo"), None);
         assert_eq!(local.presentation_path(), "/foo/bar/baz.yml");
 
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", Some("/foo/bar/"));
+        let local = InputKey::local(
+            "fakegroup".into(),
+            "/foo/bar/baz.yml",
+            Some("/foo/bar/"),
+            None,
+        );
         assert_eq!(local.presentation_path(), "/foo/bar/baz.yml");
 
         let local = InputKey::local(
             "fakegroup".into(),
             "/home/runner/work/repo/repo/.github/workflows/baz.yml",
             Some("/home/runner/work/repo/repo"),
+            None,
         );
         assert_eq!(
             local.presentation_path(),
@@ -737,24 +880,93 @@ mod tests {
     }
 
     #[test]
-    fn test_input_key_local_sarif_path() {
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", None);
-        assert_eq!(local.sarif_path(), "/foo/bar/baz.yml");
+    fn test_input_key_local_best_relative_path() {
+        // "Rootless" cases: with no group root, best_relative_path falls back to
+        // stripping the input's own prefix (if any), else returns the path
+        // as-is.
+        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", None, None);
+        assert_eq!(local.best_relative_path(), "/foo/bar/baz.yml");
 
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", Some("/foo"));
-        assert_eq!(local.sarif_path(), "bar/baz.yml");
+        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", Some("/foo"), None);
+        assert_eq!(local.best_relative_path(), "bar/baz.yml");
 
-        let local = InputKey::local("fakegroup".into(), "/foo/bar/baz.yml", Some("/foo/bar/"));
-        assert_eq!(local.sarif_path(), "baz.yml");
+        let local = InputKey::local(
+            "fakegroup".into(),
+            "/foo/bar/baz.yml",
+            Some("/foo/bar/"),
+            None,
+        );
+        assert_eq!(local.best_relative_path(), "baz.yml");
 
         let local = InputKey::local(
             "fakegroup".into(),
             "/home/runner/work/repo/repo/.github/workflows/baz.yml",
             Some("/home/runner/work/repo/repo"),
+            None,
         );
-        assert_eq!(local.sarif_path(), ".github/workflows/baz.yml");
+        assert_eq!(local.best_relative_path(), ".github/workflows/baz.yml");
 
-        let local = InputKey::local("fakegroup".into(), "./.github/workflows/baz.yml", Some("."));
-        assert_eq!(local.sarif_path(), ".github/workflows/baz.yml");
+        let local = InputKey::local(
+            "fakegroup".into(),
+            "./.github/workflows/baz.yml",
+            Some("."),
+            None,
+        );
+        assert_eq!(local.best_relative_path(), ".github/workflows/baz.yml");
+
+        // "Rooted" case: with a real root, best_relative_path is canonical-then-strip.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())
+            .unwrap()
+            .canonicalize_utf8()
+            .unwrap();
+
+        let child = temp_path.join("foo/bar/baz.yml");
+        std::fs::create_dir_all(child.parent().unwrap()).unwrap();
+        std::fs::write(&child, "contents").unwrap();
+
+        let local = InputKey::local("fakegroup".into(), child, None, Some(temp_path));
+        assert_eq!(local.best_relative_path(), "foo/bar/baz.yml");
+    }
+
+    #[test]
+    fn test_discover_root_respects_ceiling() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())
+            .unwrap()
+            .canonicalize_utf8()
+            .unwrap();
+
+        std::fs::create_dir(temp_path.join(".git")).unwrap();
+        let child = temp_path.join("project/subdir");
+        std::fs::create_dir_all(&child).unwrap();
+
+        // No ceiling: the walk finds the fake repo.
+        assert_eq!(
+            InputGroup::discover_root_with_ceilings(&child, &HashSet::new()),
+            Some(temp_path.clone()),
+        );
+
+        // The repo itself is a ceiling: the walk stops before examining it.
+        assert_eq!(
+            InputGroup::discover_root_with_ceilings(&child, &HashSet::from([temp_path.clone()]),),
+            None,
+        );
+
+        // An ancestor above the repo is the ceiling, so the repo is still found.
+        let parent_ceiling = temp_path.parent().unwrap().to_path_buf();
+        assert_eq!(
+            InputGroup::discover_root_with_ceilings(&child, &HashSet::from([parent_ceiling]),),
+            Some(temp_path.clone()),
+        );
+
+        // File inputs: canonicalize then walk from the file's parent.
+        let workflow_file = temp_path.join(".github/workflows/test.yml");
+        std::fs::create_dir_all(workflow_file.parent().unwrap()).unwrap();
+        std::fs::write(&workflow_file, "").unwrap();
+        assert_eq!(
+            InputGroup::discover_root_with_ceilings(&workflow_file, &HashSet::new()),
+            Some(temp_path),
+        );
     }
 }

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -569,8 +569,6 @@ impl InputGroup {
                 .git_exclude(true);
         }
 
-        // Clone once outside the loop so each iteration's `key` construction
-        // doesn't conflict with the mutable borrow `group.register(..)` takes.
         let root = group.root.clone();
         for entry in walker.build() {
             let entry = entry?;

--- a/crates/zizmor/src/utils.rs
+++ b/crates/zizmor/src/utils.rs
@@ -848,7 +848,7 @@ runs:
 
         let action = AuditInput::from(Action::from_string(
             action.into(),
-            InputKey::local("fakegroup".into(), "fake", None),
+            InputKey::local("fakegroup".into(), "fake", None, None),
         )?);
 
         let exprs = parse_fenced_expressions_from_routable(&action);
@@ -879,7 +879,7 @@ jobs:
 
         let workflow = AuditInput::from(Workflow::from_string(
             workflow.into(),
-            InputKey::local("fakegroup".into(), "fake", None),
+            InputKey::local("fakegroup".into(), "fake", None, None),
         )?);
 
         let exprs = parse_fenced_expressions_from_routable(&workflow)
@@ -922,7 +922,7 @@ jobs:
 
         let workflow = AuditInput::from(Workflow::from_string(
             workflow_content.into(),
-            InputKey::local("fakegroup".into(), "fake", None),
+            InputKey::local("fakegroup".into(), "fake", None, None),
         )?);
         let exprs = parse_fenced_expressions_from_routable(&workflow)
             .into_iter()

--- a/crates/zizmor/tests/integration/common.rs
+++ b/crates/zizmor/tests/integration/common.rs
@@ -5,29 +5,43 @@ use std::{env::current_dir, io::ErrorKind, sync::LazyLock};
 
 use assert_cmd::{Command, cargo};
 
-static TEST_PREFIX: LazyLock<Utf8PathBuf> = LazyLock::new(|| {
-    let current_dir = current_dir().expect("Cannot figure out current directory");
+/// The absolute path to the zizmor crate's root directory.
+static ZIZMOR_ROOT: LazyLock<Utf8PathBuf> =
+    LazyLock::new(|| Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")));
 
-    let file_path = current_dir
+/// The absolute path to the repository's root directory.
+///
+/// This is `ZIZMOR_ROOT/../..` since the `zizmor` crate
+/// lives at `repo_root/crates/zizmor`.
+static REPO_ROOT: LazyLock<Utf8PathBuf> =
+    LazyLock::new(|| ZIZMOR_ROOT.parent().unwrap().parent().unwrap().into());
+
+static CURRENT_DIR: LazyLock<Utf8PathBuf> = LazyLock::new(|| {
+    let current_dir = current_dir().expect("Cannot figure out current directory");
+    Utf8PathBuf::try_from(current_dir).expect("Cannot create UTF-8 path from current directory")
+});
+
+static TEST_PREFIX: LazyLock<Utf8PathBuf> = LazyLock::new(|| {
+    let file_path = ZIZMOR_ROOT
         .join("tests")
         .join("integration")
         .join("test-data");
 
     if !file_path.exists() {
-        panic!("Cannot find test data directory: {}", file_path.display());
+        panic!("Cannot find test data directory: {file_path}");
     }
 
     Utf8PathBuf::try_from(file_path).expect("Cannot create UTF-8 path from test data directory")
 });
 
-pub fn input_under_test(name: &str) -> String {
+pub fn input_under_test(name: &str) -> Utf8PathBuf {
     let file_path = TEST_PREFIX.join(name);
 
     if !file_path.exists() {
         panic!("Cannot find input under test: {file_path}");
     }
 
-    file_path.to_string()
+    file_path
 }
 
 pub enum OutputMode {
@@ -43,7 +57,8 @@ pub struct Zizmor {
     unbuffer: bool,
     offline: bool,
     gh_token: bool,
-    inputs: Vec<String>,
+    inputs: Vec<Utf8PathBuf>,
+    working_dir: Utf8PathBuf,
     config: Option<String>,
     no_config: bool,
     output: OutputMode,
@@ -68,6 +83,7 @@ impl Zizmor {
             offline: true,
             gh_token: true,
             inputs: vec![],
+            working_dir: CURRENT_DIR.clone(),
             config: None,
             no_config: false,
             output: OutputMode::Stdout,
@@ -91,7 +107,7 @@ impl Zizmor {
         self
     }
 
-    pub fn input(mut self, input: impl Into<String>) -> Self {
+    pub fn input(mut self, input: impl Into<Utf8PathBuf>) -> Self {
         self.inputs.push(input.into());
         self
     }
@@ -256,14 +272,20 @@ impl Zizmor {
             // }
         }
 
-        let config_placeholder = "@@CONFIG@@";
         if let Some(config) = &self.config {
-            raw = raw.replace(config, config_placeholder);
+            raw = raw.replace(config, "@@CONFIG@@");
         }
 
         let input_placeholder = "@@INPUT@@";
         for input in &self.inputs {
-            raw = raw.replace(input, input_placeholder);
+            raw = raw.replace(input.as_str(), input_placeholder);
+
+            // Some output formats emit root-relative paths; redact those too.
+            if let Ok(abs) = input.canonicalize_utf8()
+                && let Ok(relative) = abs.strip_prefix(&*REPO_ROOT)
+            {
+                raw = raw.replace(relative.as_str(), input_placeholder);
+            }
         }
 
         // Normalize Windows '\' file paths to using '/', to get consistent snapshot test outputs
@@ -276,11 +298,28 @@ impl Zizmor {
                 .into_owned();
         }
 
-        // Fallback: replace any lingering absolute paths.
+        let working_dir_placeholder = "@@WORKING_DIR@@";
+        // Replace any absolute references to the working directory.
+        raw = raw.replace(self.working_dir.as_str(), working_dir_placeholder);
+
+        // Replace any relative references to the working directory.
+        if let Ok(relative) = self.working_dir.strip_prefix(&*REPO_ROOT) {
+            raw = raw.replace(relative.as_str(), working_dir_placeholder);
+        }
+
+        // Fallback: replace any lingering test prefix paths.
         // TODO: Maybe just use this everywhere instead of the special
         // replacements above?
         let test_prefix_placeholder = "@@TEST_PREFIX@@";
         raw = raw.replace(TEST_PREFIX.as_str(), test_prefix_placeholder);
+
+        if let Ok(relative) = TEST_PREFIX.strip_prefix(&*REPO_ROOT) {
+            raw = raw.replace(relative.as_str(), test_prefix_placeholder);
+        }
+
+        if let Ok(relartive) = TEST_PREFIX.strip_prefix(&*ZIZMOR_ROOT) {
+            raw = raw.replace(relartive.as_str(), test_prefix_placeholder);
+        }
 
         let version_placeholder = "@@VERSION@@";
         raw = raw.replace(env!("CARGO_PKG_VERSION"), version_placeholder);

--- a/crates/zizmor/tests/integration/config.rs
+++ b/crates/zizmor/tests/integration/config.rs
@@ -40,8 +40,8 @@ fn test_discovers_config_in_root_from_file_input() -> anyhow::Result<()> {
             .run()?,
         @"
     DEBUG zizmor::config: discovering config for local input `@@INPUT@@`
-    DEBUG zizmor::config: attempting config discovery in `@@TEST_PREFIX@@/config-scenarios/config-in-root/.github/workflows`
-    DEBUG zizmor::config: found config candidate at `@@TEST_PREFIX@@/config-scenarios/config-in-root/zizmor.yml`
+    DEBUG zizmor::config: attempting config discovery in `@@WORKING_DIR@@/@@TEST_PREFIX@@/config-scenarios/config-in-root/.github/workflows`
+    DEBUG zizmor::config: found config candidate at `@@WORKING_DIR@@/@@TEST_PREFIX@@/config-scenarios/config-in-root/zizmor.yml`
     No findings to report. Good job! (1 ignored, 1 suppressed)
     "
     );
@@ -66,7 +66,7 @@ fn test_discovers_config_in_root_from_child_dir() -> anyhow::Result<()> {
         @"
     DEBUG zizmor::config: discovering config for local input `@@INPUT@@`
     DEBUG zizmor::config: attempting config discovery in `@@INPUT@@`
-    DEBUG zizmor::config: found config candidate at `@@TEST_PREFIX@@/config-scenarios/config-in-root/zizmor.yml`
+    DEBUG zizmor::config: found config candidate at `@@WORKING_DIR@@/@@TEST_PREFIX@@/config-scenarios/config-in-root/zizmor.yml`
     No findings to report. Good job! (1 ignored, 1 suppressed)
     "
     );
@@ -191,8 +191,8 @@ fn test_discovers_config_in_dotgithub_from_file_input() -> anyhow::Result<()> {
             .run()?,
         @"
     DEBUG zizmor::config: discovering config for local input `@@INPUT@@`
-    DEBUG zizmor::config: attempting config discovery in `@@TEST_PREFIX@@/config-scenarios/config-in-dotgithub/.github/workflows`
-    DEBUG zizmor::config: found config candidate at `@@TEST_PREFIX@@/config-scenarios/config-in-dotgithub/.github/zizmor.yml`
+    DEBUG zizmor::config: attempting config discovery in `@@WORKING_DIR@@/@@TEST_PREFIX@@/config-scenarios/config-in-dotgithub/.github/workflows`
+    DEBUG zizmor::config: found config candidate at `@@WORKING_DIR@@/@@TEST_PREFIX@@/config-scenarios/config-in-dotgithub/.github/zizmor.yml`
     No findings to report. Good job! (1 ignored, 1 suppressed)
     "
     );

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -96,11 +96,11 @@ fn issue_1907() -> Result<()> {
             .working_dir(working_dir)
             .input("./workflows")
             .run()?,
-        @r"
-         INFO zizmor: 🌈 zizmor v@@VERSION@@
-         INFO audit: zizmor: 🌈 completed @@INPUT@@/test.yml
-        No findings to report. Good job! (1 suppressed)
-        "
+        @"
+     INFO zizmor: 🌈 zizmor v@@VERSION@@
+     INFO audit: zizmor: 🌈 completed @@INPUT@@/test.yml
+    No findings to report. Good job! (1 suppressed)
+    "
     );
 
     Ok(())
@@ -642,12 +642,13 @@ fn issue_1745() -> Result<()> {
             .offline(true)
             .no_config(true)
             .working_dir(input_under_test("issue-1745-repro"))
-            .args([".github", "--format=github"])
+            .input(".github")
+            .args(["--format=github"])
             .run()?,
-        @r#"
-    ::warning file=.github/workflows/test.yml,line=10,title=artipacked::test.yml:10: credential persistence through GitHub Actions artifacts: does not set persist-credentials: false
-    ::error file=.github/workflows/test.yml,line=10,title=unpinned-uses::test.yml:10: unpinned action reference: action is not pinned to a hash (required by blanket policy)
-    "#
+        @"
+    ::warning file=@@WORKING_DIR@@/@@TEST_PREFIX@@/issue-1745-repro/@@INPUT@@/workflows/test.yml,line=10,title=artipacked::test.yml:10: credential persistence through GitHub Actions artifacts: does not set persist-credentials: false
+    ::error file=@@WORKING_DIR@@/@@TEST_PREFIX@@/issue-1745-repro/@@INPUT@@/workflows/test.yml,line=10,title=unpinned-uses::test.yml:10: unpinned action reference: action is not pinned to a hash (required by blanket policy)
+    "
     );
 
     insta::assert_snapshot!(
@@ -658,8 +659,8 @@ fn issue_1745() -> Result<()> {
             .args([".", "--format=github"])
             .run()?,
         @"
-    ::warning file=./.github/workflows/test.yml,line=10,title=artipacked::test.yml:10: credential persistence through GitHub Actions artifacts: does not set persist-credentials: false
-    ::error file=./.github/workflows/test.yml,line=10,title=unpinned-uses::test.yml:10: unpinned action reference: action is not pinned to a hash (required by blanket policy)
+    ::warning file=@@WORKING_DIR@@/@@TEST_PREFIX@@/issue-1745-repro/.github/workflows/test.yml,line=10,title=artipacked::test.yml:10: credential persistence through GitHub Actions artifacts: does not set persist-credentials: false
+    ::error file=@@WORKING_DIR@@/@@TEST_PREFIX@@/issue-1745-repro/.github/workflows/test.yml,line=10,title=unpinned-uses::test.yml:10: unpinned action reference: action is not pinned to a hash (required by blanket policy)
     "
     );
 

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__json_v1__json_v1.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__json_v1__json_v1.snap
@@ -17,7 +17,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -66,7 +65,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -126,7 +124,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -178,7 +175,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -244,7 +240,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -314,7 +309,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -384,7 +378,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -454,7 +447,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -517,7 +509,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -580,7 +571,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -643,7 +633,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },
@@ -706,7 +695,6 @@ expression: output
         "symbolic": {
           "key": {
             "Local": {
-              "prefix": null,
               "given_path": "@@INPUT@@"
             }
           },

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__sarif_zizmor_properties.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__sarif_zizmor_properties.snap
@@ -29,8 +29,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                                 "feature_kind": "Normal",
                                 "key": {
                                   "Local": {
-                                    "given_path": "@@INPUT@@",
-                                    "prefix": null
+                                    "given_path": "@@INPUT@@"
                                   }
                                 },
                                 "kind": "Related",
@@ -79,8 +78,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                                 "feature_kind": "Normal",
                                 "key": {
                                   "Local": {
-                                    "given_path": "@@INPUT@@",
-                                    "prefix": null
+                                    "given_path": "@@INPUT@@"
                                   }
                                 },
                                 "kind": "Primary",
@@ -138,8 +136,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                       "feature_kind": "Normal",
                       "key": {
                         "Local": {
-                          "given_path": "@@INPUT@@",
-                          "prefix": null
+                          "given_path": "@@INPUT@@"
                         }
                       },
                       "kind": "Primary",
@@ -207,8 +204,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                                 "feature_kind": "Normal",
                                 "key": {
                                   "Local": {
-                                    "given_path": "@@INPUT@@",
-                                    "prefix": null
+                                    "given_path": "@@INPUT@@"
                                   }
                                 },
                                 "kind": "Primary",
@@ -260,8 +256,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                       "feature_kind": "Normal",
                       "key": {
                         "Local": {
-                          "given_path": "@@INPUT@@",
-                          "prefix": null
+                          "given_path": "@@INPUT@@"
                         }
                       },
                       "kind": "Primary",
@@ -330,8 +325,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                                 },
                                 "key": {
                                   "Local": {
-                                    "given_path": "@@INPUT@@",
-                                    "prefix": null
+                                    "given_path": "@@INPUT@@"
                                   }
                                 },
                                 "kind": "Primary",
@@ -389,8 +383,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                                 "feature_kind": "KeyOnly",
                                 "key": {
                                   "Local": {
-                                    "given_path": "@@INPUT@@",
-                                    "prefix": null
+                                    "given_path": "@@INPUT@@"
                                   }
                                 },
                                 "kind": "Related",
@@ -461,8 +454,7 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                       },
                       "key": {
                         "Local": {
-                          "given_path": "@@INPUT@@",
-                          "prefix": null
+                          "given_path": "@@INPUT@@"
                         }
                       },
                       "kind": "Primary",

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -64,20 +64,25 @@ of `zizmor`.
 * Fixed a bug where [ref-version-mismatch] would fail to identify some valid
   version comments (#2073)
 
-* Fixed a bug where `zizmor` would present partial paths for some inputs
-  when using `--format=github` (#1748)
-
 * Fixed a bug where [unpinned-images] would incorrectly flag empty matrix
   expansions as unpinned container image references (#2102)
 
 * Fixed a bug where [unpinned-images] would incorrectly flag some `matrix`
   expansions as unpinned (#2098)
 
+* The SARIF (`--format=sarif`) and GitHub Annotations (`--format=github`)
+  output formats now provide more correct/useful paths, particularly when
+  the user provides a relative path as input to `zizmor` rather than
+  `zizmor .` (#1748, #2095)
+
 ### Changes ⚠️
 
 * The [impostor-commit] audit no longer suggests auto-fixes,
   to avoid incorrectly minimizing the amount of manual remediation
   work needed (#2054)
+
+* The JSON and SARIF outputs no longer contain a misleading `prefix`
+  key (#2095)
 
 ## 1.25.2
 


### PR DESCRIPTION
Every input group now tracks its "root", i.e. the repository root it belongs to (if it has one). We then use this to opportunistically provide a better "SARIF path" for both the SARIF and GH annotations output formats.

~~WIP, not plumbed yet. The idea here is to address a class of recurring problems where users run `zizmor .github` or similar and get relative paths in their outputs that they don't expect (or that their tools don't expect).~~

TODO:

- [x] Plumb this into the GitHub annotations format as well
- [x] Clean up more


Context: #1745 #2046 #2113 and probably several others. Augments the initial fix in #1748.