### PR TITLE
docs: add input to collect-workflows quickstart example

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,7 +58,7 @@ Here are some different ways you can run `zizmor` locally:
     zizmor repo-a/ ../../repo-b/
 
     # collect only workflows, not composite actions or Dependabot configs
-    zizmor --collect=workflows
+    zizmor --collect=workflows repo-a/
     ```
 
 === "On one or more remote repositories"


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

Closes #2099.

## Summary

Add the missing `repo-a/` input to the Quickstart example that collects only workflows. The CLI requires at least one input, and the surrounding examples establish `repo-a/` as the repository being audited.

## Test Plan

- Ran `make site`.
- Confirmed the generated CLI help requires `<INPUT>...`.
