### PR TITLE
fix(unpinned-images): ignore empty matrix containers

### DIFF
--- a/crates/zizmor/src/audit/unpinned_images.rs
+++ b/crates/zizmor/src/audit/unpinned_images.rs
@@ -125,6 +125,9 @@ impl UnpinnedImages {
                         } else {
                             // Try and parse the expanded value as an image reference.
                             let image = DockerUses::parse(&expansion.value);
+                            if image.image().is_empty() {
+                                continue;
+                            }
                             match (image.tag(), image.hash()) {
                                 // Image is pinned by hash.
                                 (_, Some(_)) => continue,

--- a/crates/zizmor/tests/integration/audit/unpinned_images.rs
+++ b/crates/zizmor/tests/integration/audit/unpinned_images.rs
@@ -203,6 +203,36 @@ fn test_matrix_in_image_regular() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_urllib3_empty_matrix_container_regular() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "unpinned-images/urllib3-empty-matrix-container.yml"
+            ))
+            .run()?,
+        @"
+    error[unpinned-images]: unpinned image references
+      --> @@INPUT@@:51:5
+       |
+    20 |       matrix:
+       |       ------ this matrix
+    ...
+    41 |             container: python
+       |             ----------------- this expansion of matrix.container
+    ...
+    51 |     container: ${{ matrix.container }}
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is unpinned
+       |
+       = note: audit confidence → High
+
+    2 findings (1 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_issue_1942_repro() -> anyhow::Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/test-data/unpinned-images/urllib3-empty-matrix-container.yml
+++ b/crates/zizmor/tests/integration/test-data/unpinned-images/urllib3-empty-matrix-container.yml
@@ -1,0 +1,56 @@
+# minimized from urllib3/urllib3's CI workflow:
+# https://github.com/urllib3/urllib3/blob/f4c411c09119f7999b29300b306d156992d699e6/.github/workflows/ci.yml#L37-L97
+
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: "read"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15"]
+        os:
+          - macos-15
+          - windows-latest
+          - ubuntu-24.04
+        nox-session: ['']
+        container: ['']
+        include:
+          - experimental: false
+          # Test with the minimum supported pyOpenSSL for OpenSSL 1.1.1.
+          # Debian Bullseye was the last release with OpenSSL 1.1.1, and
+          # 3.13-bullseye was the last published image.
+          - python-version: "3.13"
+            os: ubuntu-24.04
+            container: python:3.13-bullseye
+            experimental: false
+            nox-session: test_min_pyopenssl
+          # NOT OK: unpinned
+          - python-version: "3.13"
+            os: ubuntu-24.04
+            container: python
+            experimental: false
+            nox-session: test_unpinned_container
+          # OK: missing container
+          - python-version: "3.13"
+            os: ubuntu-24.04
+            experimental: false
+            nox-session: test_missing_container
+
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 10
+    steps:
+      - name: Noop
+        run: true

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -59,6 +59,9 @@ of `zizmor`.
 * Fixed a bug where `zizmor` would present partial paths for some inputs
   when using `--format=github` (#1748)
 
+* Fixed a bug where [unpinned-images] would incorrectly flag empty matrix
+  expansions as unpinned container image references (#2102)
+
 ### Changes ⚠️
 
 * The [impostor-commit] audit no longer suggests auto-fixes,


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes https://github.com/zizmorcore/zizmor/issues/2101 by skipping when the image itself is empty.


## Test Plan

Tested regression test with and without the change. Also tested manually that the pedantic persona still catches the referenced container in the matrix.