### PR TITLE
dangerous-triggers: narrow mapping trigger locations

### DIFF
--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -1,10 +1,11 @@
 use github_actions_models::common::Uses;
-use github_actions_models::workflow::Job;
 use github_actions_models::workflow::job::StepBody;
+use github_actions_models::workflow::{Job, Trigger};
 
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::audit::AuditError;
 use crate::config::Config;
+use crate::finding::location::SymbolicLocation;
 use crate::finding::{Confidence, Finding, Severity};
 use crate::models::uses::RepositoryUsesExt as _;
 use crate::models::workflow::Workflow;
@@ -19,6 +20,18 @@ audit_meta!(
 );
 
 impl DangerousTriggers {
+    fn trigger_location<'doc>(
+        workflow: &'doc Workflow,
+        trigger: &'static str,
+    ) -> SymbolicLocation<'doc> {
+        let base = workflow.location().primary().with_keys(["on".into()]);
+
+        match &workflow.on {
+            Trigger::Events(_) => base.with_keys([trigger.into()]),
+            Trigger::BareEvent(_) | Trigger::BareEvents(_) => base,
+        }
+    }
+
     fn is_labeler_exception(workflow: &Workflow) -> bool {
         // If a workflow has exactly one job, that job has exactly one step,
         // and that step is `actions/labeler`, then we suppress any
@@ -58,10 +71,7 @@ impl Audit for DangerousTriggers {
                     .confidence(Confidence::Medium)
                     .severity(Severity::High)
                     .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(["on".into()])
+                        Self::trigger_location(workflow, "pull_request_target")
                             .annotated("pull_request_target is almost always used insecurely"),
                     )
                     .build(workflow)?,
@@ -73,10 +83,7 @@ impl Audit for DangerousTriggers {
                     .confidence(Confidence::Medium)
                     .severity(Severity::High)
                     .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(["on".into()])
+                        Self::trigger_location(workflow, "workflow_run")
                             .annotated("workflow_run is almost always used insecurely"),
                     )
                     .build(workflow)?,

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -16,3 +16,29 @@ fn test_actions_labeler_exception() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_precise_trigger_location() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/precise-trigger-location.yml"
+            ))
+            .run()?,
+        @r#"
+    error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:6:3
+      |
+    6 | /   pull_request_target:
+    7 | |     paths-ignore:
+    8 | |       - "docs/**"
+      | |_________________^ pull_request_target is almost always used insecurely
+      |
+      = note: audit confidence → Medium
+
+    2 findings (1 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/precise-trigger-location.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/precise-trigger-location.yml
@@ -1,0 +1,21 @@
+name: precise-trigger-location
+
+permissions: {}
+
+on:
+  pull_request_target:
+    paths-ignore:
+      - "docs/**"
+  push:
+    paths-ignore:
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"


### PR DESCRIPTION
## Summary

Route `dangerous-triggers` findings to the specific dangerous trigger key when the workflow uses mapping-form `on:` triggers.

This keeps scalar/list trigger handling unchanged, but improves the common mapping case from `on` to `on.pull_request_target` or `on.workflow_run`.

## Motivation

Fixes #1744.

The previous location covered the whole `on:` block, including unrelated triggers. A narrower location makes CLI output and SARIF/code-scanning locations more precise.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test integration audit::dangerous_triggers::test_precise_trigger_location`
- `cargo test --test integration audit::dangerous_triggers`
- `cargo clippy -- --deny warnings`

## AI disclosure

This PR was prepared with assistance from OpenAI Codex. I reviewed the patch, tests, and validation results before submission.
