### PR TITLE
test: update curl crater snapshot

### DIFF
--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
@@ -75,7 +75,7 @@ warning[ref-version-mismatch]: action's hash pin has mismatched or missing versi
   --> .github/workflows/windows.yml:57:87
    |
 57 |       - uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # v6
-   |         ---------------------------------------------------------------------------   ^^ points to commit 711d29f3da23
+   |         ---------------------------------------------------------------------------   ^^ points to commit 3f0a3f9f988f
    |         |
    |         is pointed to by tag v6.0.0
    |

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__libssh2.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__libssh2.snap
@@ -15,7 +15,7 @@ warning[ref-version-mismatch]: action's hash pin has mismatched or missing versi
    --> .github/workflows/ci.yml:658:87
     |
 658 |       - uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # v6
-    |         ---------------------------------------------------------------------------   ^^ points to commit 711d29f3da23
+    |         ---------------------------------------------------------------------------   ^^ points to commit 3f0a3f9f988f
     |         |
     |         is pointed to by tag v6.0.0
     |


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

CI is currently failing on main (see [job 81194374546](https://github.com/zizmorcore/zizmor/actions/runs/27468265953/job/81194374546)). 

The input under test, curl/curl@6c8956c1cbf5cffcd2fd4571cf277e2eec280578, contains an [imprecise version comment](https://github.com/curl/curl/blob/6c8956c1cbf5cffcd2fd4571cf277e2eec280578/.github/workflows/windows.yml#L57) `# v6` for [cygwin/cygwin-install-action](https://github.com/cygwin/cygwin-install-action). As a result, whenever cygwin-install-action's `v6` tag is force-pushed (e.g., when it's retargeted for a new minor/patch release), this causes churn for the snapshot's `ref-version-mismatch` rendered “points to commit …” annotation.

This occurred two days ago upon cygwin-install-action's v6.1 release; v6 was force-pushed to [3f0a3f9f988f7e96b8c18098ae05eaec175f5b52](https://github.com/cygwin/cygwin-install-action/commit/3f0a3f9f988f7e96b8c18098ae05eaec175f5b52), causing the existing crater snapshot to fail.

This PR resolves the acute issue by accepting the snapshot update. This can perhaps be made more resilient in the future by mocking live tag resolution in crater snapshots, or more simply by moving the curl ref under test; curl's current HEAD uses a more specific [patch version comment]( https://github.com/curl/curl/blob/8d3c4fe344d982c052917f20084c14001c3b9156/.github/workflows/windows.yml#L98) for this action, which should be less prone to this particular churn.

## Test Plan

1. Watch CI go from red 🔴 -> green 🟢 :)
2. ???
3. Profit :D