### PR TITLE
fix: make Remove patch op sound for flow collections and empty parents

### DIFF
--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -532,22 +532,16 @@ fn apply_single_patch(
                 ));
             }
 
-            let feature = route_to_feature_pretty(&patch.route, document)?;
-
-            // For removal, we need to remove the entire line including leading whitespace
-            // TODO: This isn't sound, e.g. removing `b:` from `{a: a, b: b}` will
-            // remove the entire line.
-            let start_pos = {
-                let range = line_span(document, feature.location.byte_span.0);
-                range.start
-            };
-            let end_pos = {
-                let range = line_span(document, feature.location.byte_span.1);
-                range.end
-            };
+            // Delegate to `yamlpath`, which computes the precise byte span
+            // to delete based on the value's *actual* container kind in the
+            // parse tree (block mapping/sequence vs. flow mapping/sequence).
+            // This keeps removal sound for values nested inside flow
+            // collections, where naive line-based removal would corrupt the
+            // surrounding structure.
+            let span = document.removal_span(&patch.route)?;
 
             let mut result = content.to_string();
-            result.replace_range(start_pos..end_pos, "");
+            result.replace_range(span, "");
 
             result
         }

--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -533,11 +533,7 @@ fn apply_single_patch(
             }
 
             // Delegate to `yamlpath`, which computes the precise byte span
-            // to delete based on the value's *actual* container kind in the
-            // parse tree (block mapping/sequence vs. flow mapping/sequence).
-            // This keeps removal sound for values nested inside flow
-            // collections, where naive line-based removal would corrupt the
-            // surrounding structure.
+            // to delete based on the value's  container kind.
             let span = document.removal_span(&patch.route)?;
 
             let mut result = content.to_string();

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -1432,6 +1432,45 @@ jobs:
 }
 
 #[test]
+fn test_remove_first_step_key_slides_nested_sibling_onto_marker() {
+    // The sibling that slides onto the `- ` marker keeps its own nested
+    // block correctly indented.
+    let yaml = "\
+steps:
+  - env:
+      X: 1
+    uses:
+      a: b
+";
+    insta::assert_snapshot!(remove(yaml, route!("steps", 0, "env")), @"
+    --- PATCH ---
+    steps:
+      - uses:
+          a: b
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_non_first_step_key_keeps_marker() {
+    // Removing a key that does not share the `- ` line uses ordinary
+    // whole-line removal, leaving the marker (and first key) intact.
+    let yaml = "\
+steps:
+  - env: prod
+    run: echo hi
+";
+    insta::assert_snapshot!(remove(yaml, route!("steps", 0, "run")), @"
+    --- PATCH ---
+    steps:
+      - env: prod
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
 fn test_multiple_operations_preserve_comments() {
     let original = r#"
 # Main configuration

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -1401,6 +1401,37 @@ fn test_remove_sole_flow_member_does_not_collapse_parent() {
 }
 
 #[test]
+fn test_remove_sole_env_key_preserves_step_sequence_marker() {
+    // Regression: removing the only key under a *step-level* `env:` collapses
+    // `env` (good), but here `env:` is the first key of a `-` step item, so
+    // whole-line block removal also eats the `- ` marker. That turns the
+    // `steps:` list into a mapping and silently corrupts the document.
+    let yaml = "\
+jobs:
+  build:
+    steps:
+      - env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        run: echo hi
+";
+    insta::assert_snapshot!(
+        remove(
+            yaml,
+            route!("jobs", "build", "steps", 0, "env", "ACTIONS_ALLOW_UNSECURE_COMMANDS")
+        ),
+        @"
+    --- PATCH ---
+    jobs:
+      build:
+        steps:
+          - run: echo hi
+
+    --- END PATCH ---
+    "
+    );
+}
+
+#[test]
 fn test_multiple_operations_preserve_comments() {
     let original = r#"
 # Main configuration

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -1094,6 +1094,312 @@ permissions:
     ");
 }
 
+/// Apply a single `Op::Remove` at `route` to `yaml` and return the
+/// resulting source wrapped with `format_patch` for snapshotting.
+fn remove(yaml: &str, route: yamlpath::Route) -> String {
+    let document = yamlpath::Document::new(yaml).unwrap();
+    let result = apply_yaml_patches(
+        &document,
+        &[Patch {
+            route,
+            operation: Op::Remove,
+        }],
+    )
+    .unwrap();
+    format_patch(result.source())
+}
+
+#[test]
+fn test_remove_block_sequence_member() {
+    insta::assert_snapshot!(remove("items:\n  - a\n  - b\n  - c\n", route!("items", 1)), @"
+    --- PATCH ---
+    items:
+      - a
+      - c
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_flow_mapping_member() {
+    // The flow mapping stays intact; only the targeted member (and its
+    // separator) is removed.
+
+    // First member: the following comma and space go with it.
+    insta::assert_snapshot!(remove("m: { a: 1, b: 2, c: 3 }\n", route!("m", "a")), @"
+    --- PATCH ---
+    m: { b: 2, c: 3 }
+
+    --- END PATCH ---
+    ");
+
+    // Middle member.
+    insta::assert_snapshot!(remove("m: { a: 1, b: 2, c: 3 }\n", route!("m", "b")), @"
+    --- PATCH ---
+    m: { a: 1, c: 3 }
+
+    --- END PATCH ---
+    ");
+
+    // Last member: the preceding comma goes with it.
+    insta::assert_snapshot!(remove("m: { a: 1, b: 2, c: 3 }\n", route!("m", "c")), @"
+    --- PATCH ---
+    m: { a: 1, b: 2 }
+
+    --- END PATCH ---
+    ");
+
+    // Only member: collapses to an empty flow mapping.
+    insta::assert_snapshot!(remove("m: {a: 1}\n", route!("m", "a")), @"
+    --- PATCH ---
+    m: {}
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_flow_sequence_member() {
+    insta::assert_snapshot!(remove("s: [a, b, c]\n", route!("s", 0)), @"
+    --- PATCH ---
+    s: [b, c]
+
+    --- END PATCH ---
+    ");
+
+    insta::assert_snapshot!(remove("s: [a, b, c]\n", route!("s", 1)), @"
+    --- PATCH ---
+    s: [a, c]
+
+    --- END PATCH ---
+    ");
+
+    insta::assert_snapshot!(remove("s: [a, b, c]\n", route!("s", 2)), @"
+    --- PATCH ---
+    s: [a, b]
+
+    --- END PATCH ---
+    ");
+
+    // Only element: collapses to an empty flow sequence.
+    insta::assert_snapshot!(remove("s: [a]\n", route!("s", 0)), @"
+    --- PATCH ---
+    s: []
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_nested_flow_collections() {
+    // These are the cases that token-sniffing (`contains('{')` /
+    // `contains('[')`) cannot handle: the container kind is resolved from
+    // the parse tree, not from which bracket characters happen to appear.
+
+    // A flow mapping nested inside a flow sequence.
+    insta::assert_snapshot!(remove("matrix: [{os: linux}, {os: windows}]\n", route!("matrix", 0)), @"
+    --- PATCH ---
+    matrix: [{os: windows}]
+
+    --- END PATCH ---
+    ");
+
+    // Removing a key from a flow mapping that is itself an element of a
+    // flow sequence.
+    insta::assert_snapshot!(remove("s: [{a: 1, b: 2}]\n", route!("s", 0, "a")), @"
+    --- PATCH ---
+    s: [{b: 2}]
+
+    --- END PATCH ---
+    ");
+
+    // A flow sequence nested inside a flow mapping.
+    insta::assert_snapshot!(remove("m: {x: [1, 2, 3]}\n", route!("m", "x", 1)), @"
+    --- PATCH ---
+    m: {x: [1, 3]}
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_multiline_flow_mapping_member() {
+    let yaml = "m: {\n  a: 1,\n  b: 2,\n  c: 3\n}\n";
+
+    // Middle member keeps the surrounding indentation well-formed.
+    insta::assert_snapshot!(remove(yaml, route!("m", "b")), @"
+    --- PATCH ---
+    m: {
+      a: 1,
+      c: 3
+    }
+
+    --- END PATCH ---
+    ");
+
+    // Last member drops the preceding comma and its line.
+    insta::assert_snapshot!(remove(yaml, route!("m", "c")), @"
+    --- PATCH ---
+    m: {
+      a: 1,
+      b: 2
+    }
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_sole_flow_member_collapses_with_spaces() {
+    // Interior whitespace around the sole member is dropped too.
+    insta::assert_snapshot!(remove("m: { a: 1 }\n", route!("m", "a")), @"
+    --- PATCH ---
+    m: {}
+
+    --- END PATCH ---
+    ");
+    insta::assert_snapshot!(remove("s: [ a ]\n", route!("s", 0)), @"
+    --- PATCH ---
+    s: []
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_does_not_follow_final_alias() {
+    // Removing `b` (whose value is the alias `*x`) must delete `b: *x`, not
+    // the anchor definition `a: &x 1` that the alias resolves to.
+    let yaml = "m:\n  a: &x 1\n  b: *x\n";
+    insta::assert_snapshot!(remove(yaml, route!("m", "b")), @"
+    --- PATCH ---
+    m:
+      a: &x 1
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_block_valued_key_removes_subtree() {
+    let yaml = "a:\n  x: 1\n  y: 2\nb: 3\n";
+    insta::assert_snapshot!(remove(yaml, route!("a")), @"
+    --- PATCH ---
+    b: 3
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_flow_sequence_member_nested_in_block_mapping() {
+    // The value is a flow sequence on the same line as its block-mapping
+    // key; only the flow element is removed, not the whole line.
+    let yaml = "a: [1, 2, 3]\nb: 4\n";
+    insta::assert_snapshot!(remove(yaml, route!("a", 1)), @"
+    --- PATCH ---
+    a: [1, 3]
+    b: 4
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_flow_member_preserves_trailing_line_comment() {
+    let yaml = "s: [a, b, c]  # tail\n";
+    insta::assert_snapshot!(remove(yaml, route!("s", 1)), @"
+    --- PATCH ---
+    s: [a, c]  # tail
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_collapses_empty_block_mapping_parent() {
+    // Removing the only key under `env:` would leave a dangling `env:`
+    // (null value), so the whole `env:` block is removed instead.
+    let yaml = "env:\n  ONLY: 1\nother: 2\n";
+    insta::assert_snapshot!(remove(yaml, route!("env", "ONLY")), @"
+    --- PATCH ---
+    other: 2
+
+    --- END PATCH ---
+    ");
+
+    // With a sibling present, only the targeted key is removed.
+    let yaml = "env:\n  A: 1\n  B: 2\nother: 3\n";
+    insta::assert_snapshot!(remove(yaml, route!("env", "A")), @"
+    --- PATCH ---
+    env:
+      B: 2
+    other: 3
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_collapses_nested_block_chain() {
+    // A chain of single-key mappings collapses all the way up to the first
+    // ancestor that retains other content.
+    let yaml = "a:\n  b:\n    c: 1\nd: 2\n";
+    insta::assert_snapshot!(remove(yaml, route!("a", "b", "c")), @"
+    --- PATCH ---
+    d: 2
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_collapses_empty_block_sequence_parent() {
+    let yaml = "list:\n  - x\nother: 2\n";
+    insta::assert_snapshot!(remove(yaml, route!("list", 0)), @"
+    --- PATCH ---
+    other: 2
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_collapse_stops_at_populated_ancestor() {
+    // Realistic case: collapsing `env` must not disturb its sibling
+    // `runs-on` under the same job.
+    let yaml = "jobs:\n  build:\n    env:\n      ONLY: 1\n    runs-on: ubuntu\n";
+    insta::assert_snapshot!(remove(yaml, route!("jobs", "build", "env", "ONLY")), @"
+    --- PATCH ---
+    jobs:
+      build:
+        runs-on: ubuntu
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_remove_sole_flow_member_does_not_collapse_parent() {
+    // Flow containers are valid when empty, so they are left as `{}`/`[]`
+    // rather than collapsing the enclosing key.
+    insta::assert_snapshot!(remove("env: {ONLY: 1}\nother: 2\n", route!("env", "ONLY")), @"
+    --- PATCH ---
+    env: {}
+    other: 2
+
+    --- END PATCH ---
+    ");
+    insta::assert_snapshot!(remove("tags: [only]\nother: 2\n", route!("tags", 0)), @"
+    --- PATCH ---
+    tags: []
+    other: 2
+
+    --- END PATCH ---
+    ");
+}
+
 #[test]
 fn test_multiple_operations_preserve_comments() {
     let original = r#"

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -844,6 +844,51 @@ impl Document {
             .any(|child| child.id() != element.id() && Self::is_content_node(&child))
     }
 
+    /// If `element` is the first key of a block mapping that is the inline
+    /// value of a block sequence item (so it shares its line with the
+    /// item's `- ` marker), return the next sibling key, which should slide
+    /// onto the marker's line when `element` is removed. Returns `None` in
+    /// every other case, where ordinary whole-line removal is correct.
+    fn sequence_item_inline_next_sibling<'b>(element: &Node<'b>) -> Option<Node<'b>> {
+        if !element.is_block_mapping_pair() {
+            return None;
+        }
+
+        // The mapping pair must live directly inside a block mapping that is
+        // itself the inline value of a block sequence item:
+        //   block_sequence_item -> block_node -> block_mapping -> (element)
+        let container = element.parent()?;
+        if !container.is_block_mapping() {
+            return None;
+        }
+        let block_node = container.parent()?;
+        if !block_node.is_block_node() {
+            return None;
+        }
+        let item = block_node.parent()?;
+        if !item.is_block_sequence_item() {
+            return None;
+        }
+
+        // Only the mapping's first key shares the item's `- ` line; for any
+        // other key, whole-line removal does not touch the marker.
+        let dash = item.child(0)?;
+        if dash.start_position().row != element.start_position().row {
+            return None;
+        }
+
+        // Return the content sibling that follows `element` (the key that
+        // slides onto the marker's line). If there is none, `element` is the
+        // mapping's sole key and the caller would have collapsed the whole
+        // item instead, so fall back to ordinary removal.
+        let mut cursor = container.walk();
+        let mut content = container
+            .named_children(&mut cursor)
+            .filter(|child| Self::is_content_node(child));
+        content.find(|child| child.id() == element.id())?;
+        content.next()
+    }
+
     /// Walk up from a resolved node to the element node that is a direct
     /// child of its enclosing mapping or sequence, returning the
     /// `(element, container)` pair.
@@ -865,10 +910,21 @@ impl Document {
         }
     }
 
-    /// Compute the whole-line(s) removal span for an `element` in a block
-    /// container, including leading indentation, any trailing same-line
-    /// comment, and the trailing newline.
+    /// Compute the removal span for an `element` in a block container.
+    ///
+    /// Normally this removes the element's entire line(s), including leading
+    /// indentation, any trailing same-line comment, and the trailing
+    /// newline. There is one special case: when `element` is the first key
+    /// of a block mapping that is the inline value of a block sequence item,
+    /// it shares its line with the item's `- ` marker. Naive whole-line
+    /// removal would delete that marker and silently turn the sequence into
+    /// a mapping, so instead we remove up to the next sibling key's start,
+    /// which preserves the `- ` marker and slides that key onto its line.
     fn block_removal_span(&self, element: &Node) -> core::ops::Range<usize> {
+        if let Some(next) = Self::sequence_item_inline_next_sibling(element) {
+            return element.start_byte()..next.start_byte();
+        }
+
         let start_byte = element.start_byte();
         let end_byte = element.end_byte();
 

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     ops::{Deref, RangeBounds},
 };
 
-use line_index::LineIndex;
+use line_index::{LineIndex, TextSize};
 use serde::Serialize;
 use thiserror::Error;
 use tree_sitter::{Language, Node, Parser};
@@ -707,6 +707,250 @@ impl Document {
         }
 
         self.query_node(route, QueryMode::KeyOnly).map(|n| n.into())
+    }
+
+    /// Computes the byte range that should be deleted from the document's
+    /// [`Self::source`] in order to remove the value at `route`, together
+    /// with the structural "affixes" appropriate to the value's container.
+    ///
+    /// Unlike naive line-based removal, this is aware of the value's
+    /// *actual* container kind (block mapping, block sequence, flow
+    /// mapping, or flow sequence) as determined by the parse tree. This
+    /// makes removal sound even for values nested inside flow collections,
+    /// where line-based removal would corrupt the document. For example,
+    /// removing `b` from `{a: 1, b: 2}` yields `{a: 1}` rather than
+    /// deleting the whole line, and the container kind is resolved from
+    /// the tree rather than by sniffing for `{`/`[` tokens, so deeply
+    /// nested mixtures like `[{a: 1}, {b: 2}]` or `{x: [1, 2]}` resolve
+    /// correctly.
+    ///
+    /// The affixes removed depend on the container:
+    ///
+    /// - In block mappings and sequences, the value's entire line (or
+    ///   lines, for multi-line values) is removed, including leading
+    ///   indentation, any trailing same-line comment, and the trailing
+    ///   newline.
+    /// - In flow mappings and sequences, the value is removed along with a
+    ///   single adjacent comma (the following one if present, otherwise
+    ///   the preceding one) and any whitespace separating it from its
+    ///   neighbor, so the surrounding flow collection stays well-formed. A
+    ///   sole remaining member collapses cleanly to `{}` or `[]`.
+    ///
+    /// The element is resolved at its own lexical site: a final alias is
+    /// **not** followed, so removing `b` from `{a: &x 1, b: *x}` deletes
+    /// `b: *x` rather than the anchor definition it points to.
+    ///
+    /// When removing the sole member of a *block* container would leave a
+    /// dangling null parent (e.g. removing the only key under `env:` would
+    /// leave `env:` with a null value), the enclosing element is removed
+    /// instead, repeating upward. Flow containers are left as explicit
+    /// `{}`/`[]`, which are valid, so they are not collapsed.
+    ///
+    /// The returned range is a half-open `[start, end)` byte range into
+    /// [`Self::source`].
+    pub fn removal_span(&self, route: &Route) -> Result<core::ops::Range<usize>, QueryError> {
+        let Some(last) = route.route.last() else {
+            return Err(QueryError::Other(
+                "cannot compute a removal span for the empty (root) route".into(),
+            ));
+        };
+
+        // Resolve the element to remove at its own lexical site. Crucially,
+        // we do not follow a final alias: `query_node(.., Exact)` would
+        // resolve a terminal `*alias` to the anchor definition elsewhere in
+        // the document, so removing it would corrupt an unrelated location.
+        let seed = match last {
+            // For a key, the key node sits at the reference site, and its
+            // enclosing pair is the element to remove. `KeyOnly` navigates
+            // the reference site even when the value is an alias.
+            Component::Key(_) => self.query_node(route, QueryMode::KeyOnly)?,
+            // For an index, select the item node directly from the parent
+            // sequence (via `flatten_sequence`, which keeps aliased items
+            // as-is) so an aliased element isn't resolved away.
+            Component::Index(idx) => {
+                let parent_route = route
+                    .parent()
+                    .expect("non-empty route always has a parent route");
+                let parent = self.query_node(&parent_route, QueryMode::Exact)?;
+
+                let sequence = if parent.is_sequence() {
+                    parent
+                } else {
+                    let mut cursor = parent.walk();
+                    parent
+                        .named_children(&mut cursor)
+                        .find(|child| child.is_sequence())
+                        .ok_or(QueryError::ExpectedList(*idx))?
+                };
+
+                let items = self.flatten_sequence(&sequence)?;
+                *items
+                    .get(*idx)
+                    .ok_or(QueryError::ExhaustedList(*idx, items.len()))?
+            }
+        };
+
+        let (mut element, mut container) = Self::walk_to_container(seed)?;
+
+        // Collapse dangling block parents: if `element` is the only content
+        // member of a *block* container, removing it would leave that
+        // container empty, which serializes to a null-valued parent (e.g.
+        // `env:` with nothing under it). In that case, remove the
+        // container's enclosing element instead, repeating upward. Block
+        // containers only ever nest inside other block containers, so this
+        // never crosses into flow. Flow containers are left as explicit
+        // `{}`/`[]`, which are valid, so they are not collapsed.
+        while (container.is_block_mapping() || container.is_block_sequence())
+            && Self::is_sole_content_child(&container, &element)
+        {
+            match Self::walk_to_container(container) {
+                Ok((outer_element, outer_container)) => {
+                    element = outer_element;
+                    container = outer_container;
+                }
+                // Reached the top-level container, which has no enclosing
+                // element to collapse into; remove the element as-is.
+                Err(_) => break,
+            }
+        }
+
+        // NOTE: `container` is always one of `block_mapping`,
+        // `block_sequence`, `flow_mapping`, or `flow_sequence` by
+        // construction in `walk_to_container`.
+        let span = if container.is_block_mapping() || container.is_block_sequence() {
+            self.block_removal_span(&element)
+        } else {
+            self.flow_removal_span(&element, &container)
+        };
+
+        Ok(span)
+    }
+
+    /// Returns whether `node` is a "content" member of a collection, i.e. a
+    /// mapping pair, a block sequence item, or a flow node (a flow sequence
+    /// element or a bare flow-mapping key). Punctuation, comments, and
+    /// anchors are not content members.
+    fn is_content_node(node: &Node) -> bool {
+        node.is_pair() || node.is_block_sequence_item() || node.is_flow_node()
+    }
+
+    /// Returns whether `element` is the only content member of `container`,
+    /// i.e. removing it would leave `container` empty. Comments, anchors,
+    /// and punctuation do not count as content.
+    fn is_sole_content_child(container: &Node, element: &Node) -> bool {
+        let mut cursor = container.walk();
+        !container
+            .named_children(&mut cursor)
+            .any(|child| child.id() != element.id() && Self::is_content_node(&child))
+    }
+
+    /// Walk up from a resolved node to the element node that is a direct
+    /// child of its enclosing mapping or sequence, returning the
+    /// `(element, container)` pair.
+    ///
+    /// The container kind is derived from the parse tree, so this is
+    /// robust against arbitrary nesting of flow and block collections.
+    fn walk_to_container(seed: Node<'_>) -> Result<(Node<'_>, Node<'_>), QueryError> {
+        let mut element = seed;
+        loop {
+            let parent = element.parent().ok_or_else(|| {
+                QueryError::Other("value to remove has no enclosing container".into())
+            })?;
+
+            if parent.is_mapping() || parent.is_sequence() {
+                return Ok((element, parent));
+            }
+
+            element = parent;
+        }
+    }
+
+    /// Compute the whole-line(s) removal span for an `element` in a block
+    /// container, including leading indentation, any trailing same-line
+    /// comment, and the trailing newline.
+    fn block_removal_span(&self, element: &Node) -> core::ops::Range<usize> {
+        let start_byte = element.start_byte();
+        let end_byte = element.end_byte();
+
+        let start_line = self
+            .line_index
+            .line_col(TextSize::new(start_byte as u32))
+            .line;
+        // `end_byte` is exclusive, so the last byte that actually belongs
+        // to the element is `end_byte - 1`. Empty elements can't occur
+        // here, but guard against underflow regardless.
+        let last_byte = end_byte.saturating_sub(1).max(start_byte);
+        let end_line = self
+            .line_index
+            .line_col(TextSize::new(last_byte as u32))
+            .line;
+
+        let start = self
+            .line_index
+            .line(start_line)
+            .map(|range| usize::from(range.start()))
+            .unwrap_or(start_byte);
+        let end = self
+            .line_index
+            .line(end_line)
+            .map(|range| usize::from(range.end()))
+            .unwrap_or(end_byte);
+
+        start..end
+    }
+
+    /// Compute the removal span for an `element` in a flow container,
+    /// removing the element plus a single adjacent comma separator (and
+    /// the whitespace up to the next neighbor) so the collection remains
+    /// well-formed.
+    fn flow_removal_span(&self, element: &Node, container: &Node) -> core::ops::Range<usize> {
+        let source = self.source().as_bytes();
+
+        // Collect the container's children, including the anonymous comma
+        // and bracket tokens, so we can locate the separators adjacent to
+        // the element.
+        let mut cursor = container.walk();
+        let children: Vec<Node> = container.children(&mut cursor).collect();
+
+        // The element is always a direct child of its container here, so
+        // this lookup is infallible in practice.
+        let pos = children
+            .iter()
+            .position(|child| child.id() == element.id())
+            .unwrap_or(0);
+
+        let following_comma = children[pos + 1..].iter().find(|child| child.kind() == ",");
+        let preceding_comma = children[..pos]
+            .iter()
+            .rev()
+            .find(|child| child.kind() == ",");
+
+        if let Some(comma) = following_comma {
+            // Not the last element: remove the element, the following
+            // comma, and any whitespace up to the next neighbor (which may
+            // include a newline and indentation for multi-line flows).
+            let start = element.start_byte();
+            let mut end = comma.end_byte();
+            while end < source.len() && matches!(source[end], b' ' | b'\t' | b'\r' | b'\n') {
+                end += 1;
+            }
+            start..end
+        } else if let Some(comma) = preceding_comma {
+            // Last element: remove the preceding comma through the element.
+            comma.start_byte()..element.end_byte()
+        } else {
+            // Only element in the container: drop everything between the
+            // delimiters so the collection collapses cleanly to `{}`/`[]`,
+            // including any interior whitespace around the element. The
+            // first and last children of a flow collection are always its
+            // opening and closing delimiter tokens.
+            match (children.first(), children.last()) {
+                (Some(open), Some(close)) if open.end_byte() <= close.start_byte() => {
+                    open.end_byte()..close.start_byte()
+                }
+                _ => element.start_byte()..element.end_byte(),
+            }
+        }
     }
 
     /// Returns a string slice of the original document corresponding to

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -713,16 +713,8 @@ impl Document {
     /// [`Self::source`] in order to remove the value at `route`, together
     /// with the structural "affixes" appropriate to the value's container.
     ///
-    /// Unlike naive line-based removal, this is aware of the value's
-    /// *actual* container kind (block mapping, block sequence, flow
-    /// mapping, or flow sequence) as determined by the parse tree. This
-    /// makes removal sound even for values nested inside flow collections,
-    /// where line-based removal would corrupt the document. For example,
-    /// removing `b` from `{a: 1, b: 2}` yields `{a: 1}` rather than
-    /// deleting the whole line, and the container kind is resolved from
-    /// the tree rather than by sniffing for `{`/`[` tokens, so deeply
-    /// nested mixtures like `[{a: 1}, {b: 2}]` or `{x: [1, 2]}` resolve
-    /// correctly.
+    /// This is aware of the value's container kind as determined by the
+    /// parse tree.
     ///
     /// The affixes removed depend on the container:
     ///


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes #2122. Reworks the `Remove` patch op so it is sound for flow collections and nested structures, addressing the soundness concern raised in #1020 and following the "re-think within `yamlpath`" direction of #1000. Relates to META #876.

Previously `Remove` deleted whole lines, which:

- corrupted flow mappings and sequences (removing `b` from `{a: 1, b: 2}` deleted the whole line), and
- left dangling null parents (removing the only key under `env:` left `env:` with no value).

The earlier flow handling in #1020 detected the container by sniffing for `{`/`[` tokens, which is brittle because it cannot distinguish nesting like `{[ ... ]}` from `[{ ... }]`.

Removal span computation now lives in `yamlpath` as `Document::removal_span`, which uses the parse tree rather than token heuristics:

- Dispatches on the value's actual container kind (block vs flow) as reported by tree-sitter, so nested mixtures like `[{a: 1}, {b: 2}]` and `{x: [1, 2]}` resolve correctly.
- For flow members, removes the element plus a single adjacent comma and the whitespace up to its neighbor, and collapses a sole member cleanly to `{}` or `[]`.
- Resolves the element at its own lexical site, so a terminal alias is not followed: removing `b: *x` deletes `b: *x` rather than the anchor definition `a: &x 1` it points to.
- Collapses dangling empty block parents upward to the first ancestor that still has other content. Flow containers are left as valid `{}`/`[]`, and block containers only nest inside block containers, so collapse never crosses styles.

`yamlpatch`'s `Op::Remove` is now a thin call into `Document::removal_span`.

Verified outputs match the (draft) expectations in #1000: `foo: { a: a, b: b }` with `/foo/b` removed gives `foo: { a: a }`; an empty key `foo/baz` removal preserves the rest; and `foo: [1, 2, 3: {abc: def}]` with `/foo/2` removed gives `foo: [1, 2]`.

Design note: #1000 leaned toward extending `QueryMode::Pretty` in `query_node` and deleting that span. I added a dedicated `removal_span` instead, because removal has needs that pretty extraction does not (separator handling, sole-member collapse, parent collapse) and `query_pretty` is shared with `Op::Replace`. Happy to fold this into `query_pretty` if you prefer.

## Test Plan

- `cargo test -p yamlpath -p yamlpatch` (added snapshot coverage for block/flow mappings and sequences, nested flow collections, multiline flow, alias safety, and block parent collapse)
- `cargo test -p zizmor --bins insecure_commands` (the only current `Op::Remove` consumer)
- `cargo fmt --check`
- `cargo clippy -- --deny warnings`