### PR TITLE
Use filepath instead of filename in error/warning output on Github Actions

### DIFF
--- a/crates/zizmor/src/output/github.rs
+++ b/crates/zizmor/src/output/github.rs
@@ -34,8 +34,7 @@ impl Finding<'_> {
         let title = self.ident;
 
         let message = format!(
-            "{filename}:{start_line}: {desc}: {annotation}",
-            filename = primary.symbolic.key.filename(),
+            "{filepath}:{start_line}: {desc}: {annotation}",
             desc = self.desc,
             annotation = primary.symbolic.annotation,
         );


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first). #2123 

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

This PR changes the output for github actions to display the full path inline instead of only the filename. There can be many workflows with the same name in a single repository. For example, for composite actions, the structure of files is always `composite-action-name/action.yml`. when there are many such composite actions, all errors will have the prefix `action.yml`, which is not enough determine in what specific composite action the error occurs in.

This is my first ever contribution to a rust repo. Any help would be appreciated. ;)

## Test Plan


