### PR TITLE
feat(unpinned-uses): pin to full version when fixing a major ref

### DIFF
--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -70,6 +70,20 @@ impl UnpinnedUses {
             }
         };
 
+        // Resolve the commit back to its longest tag so the version comment
+        // reflects the full version (e.g. `v6.0.2`) rather than the major ref
+        // (e.g. `v6`) the user wrote. Pinning to the full version avoids a
+        // later `ref-version-mismatch` finding when the major tag is moved
+        // forward by the upstream maintainers.
+        // Fall back to the original ref if the commit has no matching tag.
+        let comment_ref = match client
+            .longest_tag_for_commit(uses.owner(), uses.repo(), &commit)
+            .await
+        {
+            Ok(Some(tag)) => tag.name,
+            _ => uses.git_ref().to_string(),
+        };
+
         let action = if let Some(subpath) = uses.subpath() {
             format!("{}/{}", uses.slug(), subpath)
         } else {
@@ -91,7 +105,7 @@ impl UnpinnedUses {
                 Patch {
                     route: parent.route().with_key("uses"),
                     operation: Op::EmplaceComment {
-                        new: format!("# {ref}", ref = uses.git_ref()).into(),
+                        new: format!("# {comment_ref}").into(),
                     },
                 },
             ],
@@ -546,6 +560,65 @@ jobs:
             runs-on: ubuntu-latest
             steps:
               - uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_fix_major_version_pins_to_full_version() {
+        // `actions/checkout@v1` is an end-of-life major tag: it no longer
+        // moves, so its resolved commit and full version are stable. The fix
+        // should expand the `# v1` major ref to the full `# v1.2.0` version.
+        let workflow_content = r#"
+name: Test
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with major-only ref
+        uses: actions/checkout@v1
+"#;
+
+        let key = InputKey::local(
+            "fakegroup".into(),
+            "test_unpinned_uses_major.yml",
+            None::<&str>,
+        );
+        let workflow = Workflow::from_string(workflow_content.to_string(), key).unwrap();
+
+        let state = crate::state::AuditState::new(
+            false,
+            Some(
+                github::Client::new(
+                    &github::GitHubHost::default(),
+                    &github::GitHubToken::new(&std::env::var("GH_TOKEN").unwrap()).unwrap(),
+                    "/tmp".into(),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let audit = UnpinnedUses::new(&state).unwrap();
+
+        let input = workflow.into();
+        let findings = audit
+            .audit(UnpinnedUses::ident(), &input, &Config::default())
+            .await
+            .unwrap();
+
+        let new_doc = findings[0].fixes[0].apply(input.as_document()).unwrap();
+        insta::assert_snapshot!(new_doc.source(), @"
+
+        name: Test
+        on: push
+        permissions: {}
+        jobs:
+          test:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout with major-only ref
+                uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
         ");
     }
 

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use github_actions_models::common::Uses;
 use subfeature::Subfeature;
 use yamlpatch::{Op, Patch};
@@ -70,18 +72,17 @@ impl UnpinnedUses {
             }
         };
 
-        // Resolve the commit back to its longest tag so the version comment
-        // reflects the full version (e.g. `v6.0.2`) rather than the major ref
-        // (e.g. `v6`) the user wrote. Pinning to the full version avoids a
-        // later `ref-version-mismatch` finding when the major tag is moved
-        // forward by the upstream maintainers.
-        // Fall back to the original ref if the commit has no matching tag.
-        let comment_ref = match client
+        // Resolve the commit back to its longest tag; pinning to the full
+        // version avoids any later `ref-version-mismatch` findings when the
+        // major tag is mutated by the upstream.
+        let longest_tag = match client
             .longest_tag_for_commit(uses.owner(), uses.repo(), &commit)
             .await
         {
-            Ok(Some(tag)) => tag.name,
-            _ => uses.git_ref().to_string(),
+            Ok(Some(tag)) => Cow::Owned(tag.name),
+            // Our original tag -> commit lookup succeeded, but this reverse lookup
+            // failed, which makes no sense. Just fall back to what we know.
+            _ => Cow::Borrowed(uses.git_ref()),
         };
 
         let action = if let Some(subpath) = uses.subpath() {
@@ -105,7 +106,7 @@ impl UnpinnedUses {
                 Patch {
                     route: parent.route().with_key("uses"),
                     operation: Op::EmplaceComment {
-                        new: format!("# {comment_ref}").into(),
+                        new: format!("# {longest_tag}").into(),
                     },
                 },
             ],
@@ -563,11 +564,10 @@ jobs:
         ");
     }
 
+    /// Tests that we expand a major version ref like `@v1` to the full version `v1.2.0`
+    /// in the fix's inserted comment.
     #[tokio::test]
     async fn test_fix_major_version_pins_to_full_version() {
-        // `actions/checkout@v1` is an end-of-life major tag: it no longer
-        // moves, so its resolved commit and full version are stable. The fix
-        // should expand the `# v1` major ref to the full `# v1.2.0` version.
         let workflow_content = r#"
 name: Test
 on: push

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -37,6 +37,11 @@ of `zizmor`.
 
 * The [excessive-permissions] audit is now aware of the `code-quality` permission (#2088)
 
+* The [unpinned-uses] audit's auto-fix now pins to the full resolved version
+  (e.g. `# v6.0.2`) when fixing a major-version ref (e.g. `actions/checkout@v6`),
+  avoiding a follow-up [ref-version-mismatch] finding when the major tag is
+  later moved forward (#2093)
+
 ### Performance Improvements 🚄
 
 * Most online audits are significantly faster, thanks to more precise retry handling (#2036)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -37,10 +37,8 @@ of `zizmor`.
 
 * The [excessive-permissions] audit is now aware of the `code-quality` permission (#2088)
 
-* The [unpinned-uses] audit's auto-fix now pins to the full resolved version
-  (e.g. `# v6.0.2`) when fixing a major-version ref (e.g. `actions/checkout@v6`),
-  avoiding a follow-up [ref-version-mismatch] finding when the major tag is
-  later moved forward (#2093)
+* The [unpinned-uses] audit's auto-fix now uses the fully qualified version tag
+  (e.g. `# v6.0.2`) when fixing a major-version ref (e.g. `@v6`) (#2127)
 
 ### Performance Improvements 🚄
 


### PR DESCRIPTION
Closes #2093.

## What

When `zizmor --fix` pins an unpinned action that was referenced by a
major-version tag (e.g. `actions/checkout@v6`), the version comment now
reflects the **full** resolved version instead of the major ref:

```yaml
# before
- uses: actions/checkout@de0fac…83dd # v6

# after
- uses: actions/checkout@de0fac…83dd # v6.0.2
```

## Why

Pinning the comment to the major ref means that once upstream moves the `v6`
tag forward, the pinned SHA no longer matches what `v6` points at, and
`ref-version-mismatch` flags the workflow — requiring a second fix. Resolving
to the full version up front avoids that cascade.

## How

After resolving the ref to a commit SHA, `UnpinnedUses::attempt_fix` now
resolves that SHA back to its longest tag via the existing
`Client::longest_tag_for_commit` (the same primitive `ref-version-mismatch`
uses, which prefers `v1.2.3` over `v1`). It falls back to the original ref if
the commit has no matching tag. The hash pin and the fix title are unchanged.

## Tests

Adds a `gh-token-tests` snapshot test using `actions/checkout@v1` — an
end-of-life major tag that no longer moves, so the resolved SHA and full
version (`# v1.2.0`) are stable. Existing full-ref snapshot tests are
unchanged, confirming no regression for already-full refs.

## AI usage disclosure

Per the project's AI policy: this contribution was made with AI assistance
(Claude). The author has reviewed and understands the change.
