### PR TITLE
docs: pin manual uvx zizmor examples

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -86,7 +86,7 @@ GitHub Actions setup:
 
     jobs:
       zizmor:
-        name: zizmor latest via PyPI
+        name: zizmor via PyPI
         runs-on: ubuntu-latest
         permissions:
           security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
@@ -102,7 +102,7 @@ GitHub Actions setup:
             uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
           - name: Run zizmor 🌈
-            run: uvx zizmor --format=sarif . > results.sarif # (2)!
+            run: uvx 'zizmor@<version>' --format=sarif . > results.sarif # (2)!
             env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (1)!
 
@@ -115,9 +115,12 @@ GitHub Actions setup:
 
     1. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
 
-    2. This installs the [zizmor package from PyPI], since it's pre-compiled
-       and therefore completes much faster. You could instead compile `zizmor`
-       within CI/CD with `cargo install zizmor`.
+    2. This installs a pinned [zizmor package from PyPI], since it's
+       pre-compiled and therefore completes much faster. You could instead
+       compile `zizmor` within CI/CD with
+       `cargo install 'zizmor@<version>'`. Replace `<version>` with the release
+       you want, and keep the pin current with your usual dependency update
+       tooling.
 
     For more inspiration, see `zizmor`'s own [repository workflow scan], as well
     as GitHub's example of [running ESLint] as a security workflow.
@@ -158,7 +161,7 @@ GitHub Actions setup:
 
     jobs:
       zizmor:
-        name: zizmor latest via PyPI
+        name: zizmor via PyPI
         runs-on: ubuntu-latest
         permissions:
           contents: read # Only needed for private repos. Needed to clone the repo.
@@ -172,16 +175,19 @@ GitHub Actions setup:
             uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
           - name: Run zizmor 🌈
-            run: uvx zizmor --format=github . # (2)!
+            run: uvx 'zizmor@<version>' --format=github . # (2)!
             env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (1)!
     ```
 
     1. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
 
-    2. This installs the [zizmor package from PyPI], since it's pre-compiled
-       and therefore completes much faster. You could instead compile `zizmor`
-       within CI/CD with `cargo install zizmor`.
+    2. This installs a pinned [zizmor package from PyPI], since it's
+       pre-compiled and therefore completes much faster. You could instead
+       compile `zizmor` within CI/CD with
+       `cargo install 'zizmor@<version>'`. Replace `<version>` with the release
+       you want, and keep the pin current with your usual dependency update
+       tooling.
 
     !!! warning
 
@@ -190,6 +196,11 @@ GitHub Actions setup:
         If your `zizmor` run produces more than 10 findings, only the first 10 will
         be rendered; all subsequent findings will be logged in the actions log but
         **will not be rendered** as annotations.
+
+!!! tip
+
+    If your project already manages tool dependencies with `uv`, you can keep
+    `zizmor` in a dependency group and run it with `uv run` instead.
 
 [zizmor package from PyPI]: https://pypi.org/p/zizmor
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -82,6 +82,9 @@ GitHub Actions setup:
       pull_request:
         branches: ["**"]
 
+    env:
+      ZIZMOR_VERSION: 1.25.2
+
     permissions: {}
 
     jobs:
@@ -102,7 +105,7 @@ GitHub Actions setup:
             uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
           - name: Run zizmor 🌈
-            run: uvx 'zizmor@<version>' --format=sarif . > results.sarif # (2)!
+            run: uvx "zizmor@${ZIZMOR_VERSION}" --format=sarif . > results.sarif # (2)!
             env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (1)!
 
@@ -155,6 +158,9 @@ GitHub Actions setup:
       pull_request:
         branches: ["**"]
 
+    env:
+      ZIZMOR_VERSION: 1.25.2
+
     jobs:
       zizmor:
         name: zizmor via PyPI
@@ -171,7 +177,7 @@ GitHub Actions setup:
             uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
           - name: Run zizmor 🌈
-            run: uvx 'zizmor@<version>' --format=github . # (2)!
+            run: uvx "zizmor@${ZIZMOR_VERSION}" --format=github . # (2)!
             env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (1)!
     ```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -189,11 +189,6 @@ GitHub Actions setup:
         be rendered; all subsequent findings will be logged in the actions log but
         **will not be rendered** as annotations.
 
-!!! tip
-
-    If your project already manages tool dependencies with `uv`, you can keep
-    `zizmor` in a dependency group and run it with `uv run` instead.
-
 [zizmor package from PyPI]: https://pypi.org/p/zizmor
 
 [SARIF]: https://sarifweb.azurewebsites.net/

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -116,11 +116,7 @@ GitHub Actions setup:
     1. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
 
     2. This installs a pinned [zizmor package from PyPI], since it's
-       pre-compiled and therefore completes much faster. You could instead
-       compile `zizmor` within CI/CD with
-       `cargo install 'zizmor@<version>'`. Replace `<version>` with the release
-       you want, and keep the pin current with your usual dependency update
-       tooling.
+       pre-compiled and therefore completes much faster.
 
     For more inspiration, see `zizmor`'s own [repository workflow scan], as well
     as GitHub's example of [running ESLint] as a security workflow.
@@ -183,11 +179,7 @@ GitHub Actions setup:
     1. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
 
     2. This installs a pinned [zizmor package from PyPI], since it's
-       pre-compiled and therefore completes much faster. You could instead
-       compile `zizmor` within CI/CD with
-       `cargo install 'zizmor@<version>'`. Replace `<version>` with the release
-       you want, and keep the pin current with your usual dependency update
-       tooling.
+       pre-compiled and therefore completes much faster.
 
     !!! warning
 


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [X] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes #2129.

Notes: 
 - I considered using the current released zizmor version in the examples, but that would need release-time docs bumping to avoid going stale. Since the project doesn't currently appear to have release tooling for version-bearing docs (e.g., [cargo-release](https://github.com/crate-ci/cargo-release), [rooster](https://github.com/zanieb/rooster)), this uses an explicit placeholder instead.
- Feel free to push any style/wording tweaks -- no need to roundtrip :^)

## Test Plan

N/A; docs-only change