### PR TITLE
zizmor 1.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "github-actions-expressions"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "insta",
  "serde",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "github-actions-models"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "indexmap",
  "insta",
@@ -2734,7 +2734,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subfeature"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "memchr",
  "regex",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-iter"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "tree-sitter",
  "tree-sitter-yaml",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "yamlpatch"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "indexmap",
  "insta",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "yamlpath"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "line-index",
  "self_cell",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "zizmor"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "zizmor-sarif"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ homepage = "https://docs.zizmor.sh"
 edition = "2024"
 license = "MIT"
 rust-version = "1.88.0"
-version = "1.26.0"
+version = "1.26.1"
 
 [workspace.dependencies]
-github-actions-expressions = { path = "crates/github-actions-expressions", version = "1.26.0" }
-github-actions-models = { path = "crates/github-actions-models", version = "1.26.0" }
-subfeature = { path = "crates/subfeature", version = "1.26.0" }
-tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.26.0" }
-yamlpath = { path = "crates/yamlpath", version = "1.26.0" }
-yamlpatch = { path = "crates/yamlpatch", version = "1.26.0" }
-zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.26.0" }
+github-actions-expressions = { path = "crates/github-actions-expressions", version = "1.26.1" }
+github-actions-models = { path = "crates/github-actions-models", version = "1.26.1" }
+subfeature = { path = "crates/subfeature", version = "1.26.1" }
+tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.26.1" }
+yamlpath = { path = "crates/yamlpath", version = "1.26.1" }
+yamlpatch = { path = "crates/yamlpatch", version = "1.26.1" }
+zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.26.1" }
 
 anyhow = "1.0.102"
 itertools = "0.14.0"

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -83,7 +83,7 @@ GitHub Actions setup:
         branches: ["**"]
 
     env:
-      ZIZMOR_VERSION: 1.26.0
+      ZIZMOR_VERSION: 1.26.1
 
     permissions: {}
 
@@ -159,7 +159,7 @@ GitHub Actions setup:
         branches: ["**"]
 
     env:
-      ZIZMOR_VERSION: 1.26.0
+      ZIZMOR_VERSION: 1.26.1
 
     jobs:
       zizmor:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,10 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+## 1.26.1
+
+This is a small corrective release for [1.26.0](#1260).
+
 ## 1.26.0
 
 ### New Features 🌈


### PR DESCRIPTION
1.26.0 failed to publish to crates.io because of PEBKAC.