### PR TITLE
feat: Include `bundle add`, `yarn add`, and `pnpm add` in banned commands for the adhoc-packages rule.

### DIFF
--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -56,8 +56,7 @@ impl AdhocPackages {
             }
             "bundle" => {
                 // Disallow `bundle add` in CI, as it modifies the lockfile contents.
-                args.any(|arg| arg == "add")
-                    && args.any(|arg| !arg.starts_with('-'))
+                args.any(|arg| arg == "add") && args.any(|arg| !arg.starts_with('-'))
             }
             "npm" => {
                 // Looking for `npm install <pkg>` where
@@ -77,14 +76,12 @@ impl AdhocPackages {
             "yarn" => {
                 // Require at least one non-flag argument after `add` so we
                 // don't flag malformed invocations like `yarn add`.
-                args.any(|arg| arg == "add")
-                    && args.any(|arg| !arg.starts_with('-'))
+                args.any(|arg| arg == "add") && args.any(|arg| !arg.starts_with('-'))
             }
             "pnpm" => {
                 // Require at least one non-flag argument after `add` so we
                 // don't flag malformed invocations like `pnpm add`.
-                args.any(|arg| arg == "add")
-                    && args.any(|arg| !arg.starts_with('-'))
+                args.any(|arg| arg == "add") && args.any(|arg| !arg.starts_with('-'))
             }
             _ => false,
         }

--- a/crates/zizmor/src/audit/adhoc_packages.rs
+++ b/crates/zizmor/src/audit/adhoc_packages.rs
@@ -44,7 +44,7 @@ impl AdhocPackages {
     fn is_adhoc_install_command<'a>(cmd: &'a str, args: impl Iterator<Item = &'a str>) -> bool {
         let mut args = args;
         match cmd {
-            // TODO: Add support for `pip install pkg`, `yarn install pkg`, etc. later.
+            // TODO: Add support for `pip install pkg`, etc. later.
             "gem" => {
                 // Require at least one non-flag argument after `install` so we
                 // don't flag malformed invocations like `gem install`.
@@ -52,6 +52,11 @@ impl AdhocPackages {
                 // first non-flag argument and at least one package name follows.
                 // `gem i` is a documented alias for `gem install`.
                 args.any(|arg| arg == "install" || arg == "i")
+                    && args.any(|arg| !arg.starts_with('-'))
+            }
+            "bundle" => {
+                // Disallow `bundle add` in CI, as it modifies the lockfile contents.
+                args.any(|arg| arg == "add")
                     && args.any(|arg| !arg.starts_with('-'))
             }
             "npm" => {
@@ -68,6 +73,18 @@ impl AdhocPackages {
                     ) => args.any(|arg| !arg.starts_with('-')),
                     _ => false,
                 }
+            }
+            "yarn" => {
+                // Require at least one non-flag argument after `add` so we
+                // don't flag malformed invocations like `yarn add`.
+                args.any(|arg| arg == "add")
+                    && args.any(|arg| !arg.starts_with('-'))
+            }
+            "pnpm" => {
+                // Require at least one non-flag argument after `add` so we
+                // don't flag malformed invocations like `pnpm add`.
+                args.any(|arg| arg == "add")
+                    && args.any(|arg| !arg.starts_with('-'))
             }
             _ => false,
         }
@@ -258,6 +275,10 @@ mod tests {
             (&["gem", "env"][..], false),
             // `bundle install` is lockfile-aware, so it should stay false.
             (&["bundle", "install"][..], false),
+            // `bundle add` is disallowed, as it modifies the lockfile contents.
+            (&["bundle", "add", "rails"][..], true),
+            (&["bundle", "add", "rails:8.1.0"][..], true),
+            (&["bundle", "add", "rails", "--skip-install"][..], true),
             // `npm install pkg` is also disallowed.
             (&["npm", "install", "lodash"][..], true),
             (&["npm", "install", "oxlint@1.55.0"][..], true),
@@ -283,6 +304,20 @@ mod tests {
             (&["npx", "foobar@1.2.3"][..], false),
             // TODO: flip to `true` once `pip install` is covered.
             (&["pip", "install", "requests"][..], false),
+            // "yarn add" is banned.
+            (&["yarn", "add", "lodash"][..], true),
+            (&["yarn", "add", "--dev", "oxlint@1.55.0"][..], true),
+            (&["yarn", "add", "oxlint@^1.55.0"][..], true),
+            // "yarn install" is fine.
+            (&["yarn", "install"][..], false),
+            (&["yarn", "install", "--frozen-lockfile"][..], false),
+            // "pnpm add" is banned.
+            (&["pnpm", "add", "lodash"][..], true),
+            (&["pnpm", "add", "--no-fund", "oxlint@1.55.0"][..], true),
+            (&["pnpm", "add", "oxlint@^1.55.0"][..], true),
+            // "pnpm install" is fine.
+            (&["pnpm", "install"][..], false),
+            (&["pnpm", "install", "--frozen-lockfile"][..], false),
             // In the future we should consider catching wrapped commands, those using `sudo` and so on.
             // (&["sudo", "gem", "install", "rails"][..], true),
             // (&["bundle", "exec", "gem", "install", "rails"][..], true),

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -42,8 +42,8 @@ This audit currently detects ad-hoc installation patterns for the following ecos
 
 | Ecosystem | Tools |
 |-----------|-------|
-| JavaScript | `npm` |
-| Ruby | `gem` |
+| JavaScript | `npm`, `yarn`, `pnpm` |
+| Ruby | `gem`, `bundle` |
 
 ### Remediation
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -22,8 +22,8 @@ Legend:
 
 [adhoc-packages.yml]: https://github.com/zizmorcore/zizmor/blob/main/crates/zizmor/tests/integration/test-data/adhoc-packages.yml
 
-Detects `#!yaml run:` steps that install packages in an ad-hoc manner, i.e. outside of a managed
-and locked manifest.
+Detects `#!yaml run:` steps that install or manipulate packages in an ad-hoc
+manner, i.e. outside of a managed and locked manifest.
 
 Installing packages directly with commands like `#!bash gem install <pkg>` or
 `#!bash npm install <pkg>` represents a potential risk:
@@ -37,6 +37,9 @@ Installing packages directly with commands like `#!bash gem install <pkg>` or
   will install a specific version of `foo`, but `foo`'s dependencies
   will be newly resolved and may undermine the user's intent of a safe
   cutoff.
+
+Similarly, this audit flags commands like `#!bash bundle add` and `#!bash yarn add`,
+since they mutate the CI's ephemeral lockfile state.
 
 This audit currently detects ad-hoc installation patterns for the following ecosystems and tools:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,11 @@ of `zizmor`.
 
 * The [forbidden-uses] audit now supports pre-commit config inputs (#2263)
 
+* The [adhoc-packages] audit now detects more ad-hoc package management patterns,
+  including `bundle add` and `yarn add`
+
+    Many thanks to @connorshea for proposing and implementing this enhancement!
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Implements one part of #2128. This expands the adhoc-packages rule a bit to include `yarn add pkg`, `pnpm add pkg`, and `bundle add pkg`.

`bundle install pkg`, `yarn install pkg`, and `pnpm install pkg` all either error or just trigger a lockfile install without modifying it, as far as I've been able to tell from Googling. So only `add` needs to be handled. _Technically_ we could also add `bundle remove` and similar, but I don't think that's very common and I don't know if it's worth bothering with?

## Test Plan

- Tests have been added for various relevant patterns to ensure that we catch `yarn add pkg`, `pnpm add pkg`, and `bundle add pkg`.