### PR TITLE
feat: support parallel steps (background, wait, wait-all, cancel, parallel)

### DIFF
--- a/crates/github-actions-models/src/workflow/job.rs
+++ b/crates/github-actions-models/src/workflow/job.rs
@@ -1,7 +1,7 @@
 //! Workflow jobs.
 
 use indexmap::IndexMap;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use yaml_serde::Value;
 
 use crate::common::expr::{BoE, LoE};
@@ -110,35 +110,177 @@ pub struct Step {
     #[serde(default)]
     pub env: LoE<Env>,
 
+    /// An optional boolean or expression that, if `true`, runs this step
+    /// asynchronously so the job immediately continues to the next step.
+    ///
+    /// See <https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/>.
+    #[serde(default)]
+    pub background: BoE,
+
     /// The `run:` or `uses:` body for this step.
     #[serde(flatten)]
     pub body: StepBody,
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "kebab-case", untagged)]
+/// The body of a [`Step`], i.e. the action it performs.
+#[derive(Debug)]
 pub enum StepBody {
+    /// A step that runs an action.
     Uses {
         /// The GitHub Action being used.
-        #[serde(deserialize_with = "crate::common::step_uses")]
         uses: Uses,
-
         /// Any inputs to the action being used.
-        #[serde(default)]
         with: LoE<Env>,
     },
+    /// A step that runs a shell command.
     Run {
         /// The command to run.
-        #[serde(deserialize_with = "crate::common::bool_is_string")]
         run: String,
-
         /// An optional working directory to run [`StepBody::Run::run`] from.
         working_directory: Option<String>,
-
         /// An optional shell to run in. Defaults to the job or workflow's
         /// default shell.
         shell: Option<LoE<String>>,
     },
+    /// Runs a group of steps in parallel, then waits for all of them to finish.
+    ///
+    /// See <https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/>.
+    Parallel {
+        /// The group of steps to run in parallel.
+        parallel: Vec<Step>,
+    },
+    /// Pauses the job until one or more named background steps complete.
+    Wait {
+        /// One or more background step IDs to wait for.
+        wait: Vec<String>,
+    },
+    /// Pauses the job until all active background steps complete.
+    ///
+    /// The `wait-all` keyword takes no arguments.
+    WaitAll,
+    /// Gracefully terminates a single running background step by its ID.
+    Cancel {
+        /// The ID of the background step to cancel.
+        cancel: String,
+    },
+}
+
+impl<'de> Deserialize<'de> for StepBody {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        // A step body is identified by which of its mutually-exclusive keys is
+        // present. We dispatch on key presence rather than deriving an
+        // `untagged` enum, because the `wait-all:` step's value is the YAML
+        // null, which serde's untagged buffering cannot match against.
+        //
+        // These helper structs reuse the field-level custom deserializers.
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct UsesBody {
+            #[serde(deserialize_with = "crate::common::step_uses")]
+            uses: Uses,
+            #[serde(default)]
+            with: LoE<Env>,
+        }
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct RunBody {
+            #[serde(deserialize_with = "crate::common::bool_is_string")]
+            run: String,
+            working_directory: Option<String>,
+            shell: Option<LoE<String>>,
+        }
+        #[derive(Deserialize)]
+        struct ParallelBody {
+            parallel: Vec<Step>,
+        }
+        #[derive(Deserialize)]
+        struct WaitBody {
+            #[serde(deserialize_with = "crate::common::scalar_or_vector")]
+            wait: Vec<String>,
+        }
+        #[derive(Deserialize)]
+        struct CancelBody {
+            cancel: String,
+        }
+
+        let map: IndexMap<String, Value> = IndexMap::deserialize(deserializer)?;
+
+        enum Which {
+            Uses,
+            Run,
+            Parallel,
+            Wait,
+            WaitAll,
+            Cancel,
+        }
+        // Value-bearing keys are checked first to preserve their priority.
+        let which = if map.contains_key("uses") {
+            Which::Uses
+        } else if map.contains_key("run") {
+            Which::Run
+        } else if map.contains_key("parallel") {
+            Which::Parallel
+        } else if map.contains_key("wait") {
+            Which::Wait
+        } else if map.contains_key("wait-all") {
+            Which::WaitAll
+        } else if map.contains_key("cancel") {
+            Which::Cancel
+        } else {
+            return Err(D::Error::custom(
+                "step must define one of `uses`, `run`, `parallel`, `wait`, `wait-all`, or `cancel`",
+            ));
+        };
+
+        // `wait-all` carries no value, so it is determined purely by presence.
+        if let Which::WaitAll = which {
+            return Ok(StepBody::WaitAll);
+        }
+
+        let value = Value::Mapping(
+            map.into_iter()
+                .map(|(k, v)| (Value::String(k), v))
+                .collect(),
+        );
+        match which {
+            Which::Uses => {
+                let b: UsesBody = yaml_serde::from_value(value).map_err(D::Error::custom)?;
+                Ok(StepBody::Uses {
+                    uses: b.uses,
+                    with: b.with,
+                })
+            }
+            Which::Run => {
+                let b: RunBody = yaml_serde::from_value(value).map_err(D::Error::custom)?;
+                Ok(StepBody::Run {
+                    run: b.run,
+                    working_directory: b.working_directory,
+                    shell: b.shell,
+                })
+            }
+            Which::Parallel => {
+                let b: ParallelBody = yaml_serde::from_value(value).map_err(D::Error::custom)?;
+                Ok(StepBody::Parallel {
+                    parallel: b.parallel,
+                })
+            }
+            Which::Wait => {
+                let b: WaitBody = yaml_serde::from_value(value).map_err(D::Error::custom)?;
+                Ok(StepBody::Wait { wait: b.wait })
+            }
+            Which::Cancel => {
+                let b: CancelBody = yaml_serde::from_value(value).map_err(D::Error::custom)?;
+                Ok(StepBody::Cancel { cancel: b.cancel })
+            }
+            // Handled above by early return.
+            Which::WaitAll => unreachable!(),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -273,5 +415,42 @@ matrix:
                 .to_string(),
             "runs-on must provide either `group` or one or more `labels`"
         );
+    }
+
+    #[test]
+    fn test_parallel_steps() {
+        use super::{Step, StepBody};
+
+        // `background` is accepted on a run step.
+        let step: Step = yaml_serde::from_str("run: echo hi\nbackground: true").unwrap();
+        assert!(matches!(step.background, LoE::Literal(true)));
+        assert!(matches!(step.body, StepBody::Run { .. }));
+
+        // `wait` accepts a single ID or a list of IDs.
+        let step: Step = yaml_serde::from_str("wait: build").unwrap();
+        let StepBody::Wait { wait } = step.body else {
+            panic!("expected a wait step");
+        };
+        assert_eq!(wait.len(), 1);
+        assert_eq!(wait[0], "build");
+        let step: Step = yaml_serde::from_str("wait: [a, b]").unwrap();
+        assert!(matches!(step.body, StepBody::Wait { .. }));
+
+        // `wait-all` takes no arguments.
+        let step: Step = yaml_serde::from_str("wait-all:").unwrap();
+        assert!(matches!(step.body, StepBody::WaitAll));
+
+        // `cancel` targets a single background step.
+        let step: Step = yaml_serde::from_str("cancel: build").unwrap();
+        assert!(matches!(step.body, StepBody::Cancel { .. }));
+
+        // `parallel` groups nested steps, which are themselves parsed as steps.
+        let step: Step =
+            yaml_serde::from_str("parallel:\n  - run: echo a\n  - run: echo b").unwrap();
+        let StepBody::Parallel { parallel } = step.body else {
+            panic!("expected a parallel step");
+        };
+        assert_eq!(parallel.len(), 2);
+        assert!(matches!(parallel[0].body, StepBody::Run { .. }));
     }
 }

--- a/crates/zizmor/src/audit/misfeature.rs
+++ b/crates/zizmor/src/audit/misfeature.rs
@@ -106,6 +106,8 @@ impl Misfeature {
             }
             // No misfeature checks against non-actions `uses:` clauses, yet.
             StepBodyCommon::Uses { .. } => {}
+            // No misfeature checks against parallel-steps control steps.
+            StepBodyCommon::Other => {}
         }
 
         Ok(findings)

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -59,6 +59,9 @@ pub(crate) enum StepBodyCommon<'s> {
         _working_directory: Option<&'s str>,
         _shell: Option<&'s LoE<String>>,
     },
+    /// A step that is neither a `uses:` nor a `run:` step, such as a
+    /// parallel-steps control step (`wait`, `wait-all`, `cancel`, `parallel`).
+    Other,
 }
 
 /// Common interfaces between workflow and action steps.

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -548,6 +548,12 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
                 _working_directory: working_directory.as_deref(),
                 _shell: shell.as_ref(),
             },
+            // Parallel-steps control steps (`wait`, `wait-all`, `cancel`,
+            // `parallel`) are neither `uses:` nor `run:` steps.
+            StepBody::Parallel { .. }
+            | StepBody::Wait { .. }
+            | StepBody::WaitAll
+            | StepBody::Cancel { .. } => StepBodyCommon::Other,
         }
     }
 

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -473,12 +473,17 @@ impl<'doc> Iterator for Jobs<'doc> {
 /// provides access to the step's actual fields.
 #[derive(Clone)]
 pub(crate) struct Step<'doc> {
-    /// The step's index within its parent job.
+    /// The step's index within its immediate parent (the job's `steps`, or a
+    /// `parallel:` group it's nested in).
     pub(crate) index: usize,
     /// The inner step model.
     inner: &'doc workflow::job::Step,
     /// The parent [`Job`].
     pub(crate) parent: NormalJob<'doc>,
+    /// The yamlpath route from the parent job to this step, e.g. `[steps, 0]`
+    /// for a top-level step or `[steps, 0, parallel, 1]` for a step nested in a
+    /// `parallel:` group.
+    route: Vec<yamlpath::Component<'doc>>,
 }
 
 impl<'doc> std::ops::Deref for Step<'doc> {
@@ -494,7 +499,7 @@ impl<'doc> Locatable<'doc> for Step<'doc> {
     fn location(&self) -> SymbolicLocation<'doc> {
         self.parent
             .location()
-            .with_keys(["steps".into(), self.index.into()])
+            .with_keys(self.route.iter().cloned())
             .annotated("this step")
     }
 
@@ -568,11 +573,17 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
 }
 
 impl<'doc> Step<'doc> {
-    fn new(index: usize, inner: &'doc workflow::job::Step, parent: NormalJob<'doc>) -> Self {
+    fn new(
+        index: usize,
+        inner: &'doc workflow::job::Step,
+        parent: NormalJob<'doc>,
+        route: Vec<yamlpath::Component<'doc>>,
+    ) -> Self {
         Self {
             index,
             inner,
             parent,
+            route,
         }
     }
 
@@ -665,16 +676,20 @@ impl<'doc> Step<'doc> {
 /// Steps whose `if:` condition is statically known to be false are skipped,
 /// since such steps cannot execute and therefore can't violate any audits.
 pub(crate) struct Steps<'doc> {
-    inner: std::iter::Enumerate<std::slice::Iter<'doc, github_actions_models::workflow::job::Step>>,
-    parent: NormalJob<'doc>,
+    inner: std::vec::IntoIter<Step<'doc>>,
 }
 
 impl<'doc> Steps<'doc> {
-    /// Create a new [`Steps`].
+    /// Create a new [`Steps`], flattening any steps nested in `parallel:`
+    /// groups so that they're audited like top-level steps.
     fn new(job: &NormalJob<'doc>) -> Self {
+        let mut steps = Vec::new();
+        let prefix = [yamlpath::Component::from("steps")];
+        for (idx, step) in job.steps.iter().enumerate() {
+            collect_step(idx, step, job, &prefix, &mut steps);
+        }
         Self {
-            inner: job.steps.iter().enumerate(),
-            parent: job.clone(),
+            inner: steps.into_iter(),
         }
     }
 }
@@ -683,15 +698,39 @@ impl<'doc> Iterator for Steps<'doc> {
     type Item = Step<'doc>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for (idx, step) in self.inner.by_ref() {
-            if let Some(cond) = step.r#if.as_ref()
-                && crate::models::if_is_statically_false(cond)
-            {
-                continue;
-            }
-            return Some(Step::new(idx, step, self.parent.clone()));
+        self.inner.next()
+    }
+}
+
+/// Recursively collects `step`, plus any steps nested in its `parallel:` group,
+/// into `acc`, building each step's yamlpath route from `prefix`.
+///
+/// Steps whose `if:` condition is statically known to be false are skipped (and
+/// not descended into), since such steps cannot execute and therefore can't
+/// violate any audits.
+fn collect_step<'doc>(
+    index: usize,
+    step: &'doc github_actions_models::workflow::job::Step,
+    job: &NormalJob<'doc>,
+    prefix: &[yamlpath::Component<'doc>],
+    acc: &mut Vec<Step<'doc>>,
+) {
+    if let Some(cond) = step.r#if.as_ref()
+        && crate::models::if_is_statically_false(cond)
+    {
+        return;
+    }
+
+    let mut route = prefix.to_vec();
+    route.push(index.into());
+    acc.push(Step::new(index, step, job.clone(), route.clone()));
+
+    // Descend into `parallel:` so the grouped steps are audited too.
+    if let StepBody::Parallel { parallel } = &step.body {
+        route.push("parallel".into());
+        for (child_index, child) in parallel.iter().enumerate() {
+            collect_step(child_index, child, job, &route, acc);
         }
-        None
     }
 }
 
@@ -746,6 +785,47 @@ jobs:
         // `workflow_dispatch` and `workflow_call` define it as a boolean.
         let bar_cap = workflow.get_input("bar").unwrap();
         assert_eq!(bar_cap, Capability::Fixed);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_steps_descend_into_parallel() -> anyhow::Result<()> {
+        use crate::models::{StepBodyCommon, StepCommon as _, workflow::Job};
+
+        let workflow = r#"
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo a
+      - parallel:
+          - run: echo b
+          - run: echo c
+"#;
+
+        let workflow = Workflow::from_string(
+            workflow.into(),
+            crate::InputKey::local("fakegroup".into(), "dummy", None, None),
+        )?;
+
+        let Some(Job::NormalJob(job)) = workflow.jobs().next() else {
+            panic!("expected a normal job");
+        };
+
+        let steps = job.steps().collect::<Vec<_>>();
+
+        // `run: echo a`, the `parallel:` step itself, then the two steps nested
+        // inside the `parallel:` group.
+        assert_eq!(steps.len(), 4);
+        assert!(matches!(steps[0].body(), StepBodyCommon::Run { .. }));
+        assert!(matches!(steps[1].body(), StepBodyCommon::Other));
+        assert!(matches!(steps[2].body(), StepBodyCommon::Run { .. }));
+        assert!(matches!(steps[3].body(), StepBodyCommon::Run { .. }));
+        // Nested steps carry their index within the `parallel:` group.
+        assert_eq!(steps[2].index(), 0);
+        assert_eq!(steps[3].index(), 1);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

[GitHub released parallel steps on 2026-06-25](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/), adding five new step keys: `background`, `wait`, `wait-all`, `cancel`, and `parallel`. Today zizmor can't parse a workflow that uses the new *step kinds* and bails out instead of auditing it:

```console
$ zizmor --offline pl.yml
 WARN ... failed to validate file://pl.yml as workflow: input does not match expected validation schema
fatal: no audit was performed
error: no inputs collected
```

(`background` alone already parsed, since serde ignores unknown fields; the `wait`/`wait-all`/`cancel`/`parallel` steps fail because they match neither the `Uses` nor `Run` body variant.)

With this change zizmor parses and audits them normally.

## Changes

In `github-actions-models` (`workflow/job.rs`), modeled after [`workflow-syntax.md`](https://github.com/github/docs/blob/main/content/actions/reference/workflows-and-actions/workflow-syntax.md):

- **`background`** → a new optional boolean field on `Step` (mirrors `continue-on-error`).
- **`wait`/`wait-all`**, **`cancel`**, **`parallel`** → new `StepBody` variants. Per the spec, `wait` is a single ID **or** a list, `cancel` is a **single** ID, and `parallel` holds a nested `Vec<Step>`.
- **`StepBody` now hand-implements `Deserialize`** (dispatching on key presence) instead of deriving an `untagged` enum. This is necessary because the `wait-all:` step's value is the YAML **null**, which serde's untagged buffering can't match against a struct variant (a derived untagged variant keyed on a null-valued field never matches; verified that the equivalent *non*-untagged struct does). Dispatching on key presence sidesteps that entirely.

In `zizmor`:

- The new control steps map to a new `StepBodyCommon::Other`, so the existing `uses:`/`run:` audits skip them.
- **Audits descend into `parallel:` groups.** When a job's steps are enumerated, the steps nested in a `parallel:` group are flattened in with the correct yamlpath route (e.g. `steps[0].parallel[1]`), so findings inside a parallel block point at the right location.

## Test plan

- New `github-actions-models` test (`test_parallel_steps`) covering `background`, `wait` (single + list), `wait-all`, `cancel`, and nested `parallel` — including the bare `wait-all:` form.
- New `zizmor` test (`test_steps_descend_into_parallel`) asserting `Steps` flattens the nested `parallel:` steps.
- `cargo test -p github-actions-models` (26) and `cargo test -p zizmor --bins` (118) green; `cargo fmt --check` clean; clippy clean on the changed files.
- Verified end-to-end: `template-injection` fires on a dangerous expression both at top level **and** in a nested `parallel:` step, each pointing at the correct line.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
