### PR TITLE
fix: normalize path separators on Windows to ensure consistent output

### DIFF
--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -291,9 +291,7 @@ impl InputKey {
         // Normalize path separators on Windows to ensure consistent output
         // See: https://github.com/zizmorcore/zizmor/issues/2146
         #[cfg(windows)]
-        let given_path = {
-            Utf8PathBuf::from(path.as_str().replace('\\', "/"))
-        };
+        let given_path = { Utf8PathBuf::from(path.as_str().replace('\\', "/")) };
 
         #[cfg(not(windows))]
         let given_path = path.to_path_buf();
@@ -978,5 +976,28 @@ mod tests {
             InputGroup::discover_root_with_ceilings(&workflow_file, &HashSet::new()),
             Some(temp_path),
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_input_key_windows_path_normalization() {
+        let local = InputKey::local(
+            "fakegroup".into(),
+            r".github\workflows\test.yaml",
+            None,
+            None,
+        );
+        assert_eq!(local.presentation_path(), ".github/workflows/test.yaml");
+
+        let local = InputKey::local("fakegroup".into(), r".github/", None, None);
+        assert_eq!(local.presentation_path(), ".github/");
+
+        let local = InputKey::local(
+            "fakegroup".into(),
+            r".github/workflows\test.yaml",
+            None,
+            None,
+        );
+        assert_eq!(local.presentation_path(), ".github/workflows/test.yaml");
     }
 }

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -287,6 +287,17 @@ impl InputKey {
         root: Option<P>,
     ) -> Self {
         let path = path.as_ref();
+
+        // Normalize path separators on Windows to ensure consistent output
+        // See: https://github.com/zizmorcore/zizmor/issues/2146
+        #[cfg(windows)]
+        let given_path = {
+            Utf8PathBuf::from(path.as_str().replace('\\', "/"))
+        };
+
+        #[cfg(not(windows))]
+        let given_path = path.to_path_buf();
+
         let best_relative_path = LocalKey::best_relative_path(
             path,
             prefix.as_ref().map(P::as_ref),
@@ -294,7 +305,7 @@ impl InputKey {
         );
         Self::Local(LocalKey {
             group,
-            given_path: path.to_path_buf(),
+            given_path,
             best_relative_path,
         })
     }


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

## Test Plan

Added test `test_input_key_windows_path_normalization` and run PR version `zizmor` locally:
<img width="1522" height="671" alt="изображение" src="https://github.com/user-attachments/assets/672f4891-8abf-464a-9d8b-f3693a92c8ec" />
