### PR TITLE
dangerous-triggers: model trigger locations

### DIFF
--- a/crates/zizmor/src/audit/dangerous_triggers.rs
+++ b/crates/zizmor/src/audit/dangerous_triggers.rs
@@ -5,7 +5,7 @@ use github_actions_models::workflow::job::StepBody;
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::audit::AuditError;
 use crate::config::Config;
-use crate::finding::{Confidence, Finding, Severity};
+use crate::finding::{Confidence, Finding, Severity, location::Locatable as _};
 use crate::models::uses::RepositoryUsesExt as _;
 use crate::models::workflow::Workflow;
 use crate::state::AuditState;
@@ -52,35 +52,43 @@ impl Audit for DangerousTriggers {
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
         let mut findings = vec![];
-        if workflow.has_pull_request_target() && !Self::is_labeler_exception(workflow) {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::Medium)
-                    .severity(Severity::High)
-                    .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(["on".into()])
-                            .annotated("pull_request_target is almost always used insecurely"),
-                    )
-                    .build(workflow)?,
-            );
-        }
-        if workflow.has_workflow_run() {
-            findings.push(
-                Self::finding()
-                    .confidence(Confidence::Medium)
-                    .severity(Severity::High)
-                    .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(["on".into()])
-                            .annotated("workflow_run is almost always used insecurely"),
-                    )
-                    .build(workflow)?,
-            );
+        let mut reported_pull_request_target = false;
+        let mut reported_workflow_run = false;
+
+        for trigger in workflow.triggers() {
+            if trigger.is_pull_request_target()
+                && !reported_pull_request_target
+                && !Self::is_labeler_exception(workflow)
+            {
+                findings.push(
+                    Self::finding()
+                        .confidence(Confidence::Medium)
+                        .severity(Severity::High)
+                        .add_location(
+                            trigger
+                                .location()
+                                .primary()
+                                .annotated("pull_request_target is almost always used insecurely"),
+                        )
+                        .build(workflow)?,
+                );
+                reported_pull_request_target = true;
+            }
+            if trigger.is_workflow_run() && !reported_workflow_run {
+                findings.push(
+                    Self::finding()
+                        .confidence(Confidence::Medium)
+                        .severity(Severity::High)
+                        .add_location(
+                            trigger
+                                .location()
+                                .primary()
+                                .annotated("workflow_run is almost always used insecurely"),
+                        )
+                        .build(workflow)?,
+                );
+                reported_workflow_run = true;
+            }
         }
 
         Ok(findings)

--- a/crates/zizmor/src/models/workflow.rs
+++ b/crates/zizmor/src/models/workflow.rs
@@ -145,6 +145,71 @@ impl Workflow {
         Jobs::new(self)
     }
 
+    /// A list of this workflow's declared triggers.
+    pub(crate) fn triggers(&self) -> Vec<WorkflowTrigger<'_>> {
+        match &self.on {
+            Trigger::BareEvent(event) => {
+                vec![WorkflowTrigger::new(
+                    self,
+                    bare_event_name(event),
+                    yamlpath::route!("on"),
+                )]
+            }
+            Trigger::BareEvents(events) => events
+                .iter()
+                .enumerate()
+                .map(|(idx, event)| {
+                    WorkflowTrigger::new(self, bare_event_name(event), yamlpath::route!("on", idx))
+                })
+                .collect(),
+            Trigger::Events(events) => {
+                let mut triggers = vec![];
+
+                macro_rules! push_if_present {
+                    ($field:ident, $name:literal) => {
+                        if !matches!(events.$field, OptionalBody::Missing) {
+                            triggers.push(WorkflowTrigger::new(
+                                self,
+                                $name,
+                                yamlpath::route!("on", $name),
+                            ));
+                        }
+                    };
+                }
+
+                push_if_present!(branch_protection_rule, "branch_protection_rule");
+                push_if_present!(check_run, "check_run");
+                push_if_present!(check_suite, "check_suite");
+                push_if_present!(discussion, "discussion");
+                push_if_present!(discussion_comment, "discussion_comment");
+                push_if_present!(issue_comment, "issue_comment");
+                push_if_present!(issues, "issues");
+                push_if_present!(label, "label");
+                push_if_present!(merge_group, "merge_group");
+                push_if_present!(milestone, "milestone");
+                push_if_present!(project, "project");
+                push_if_present!(project_card, "project_card");
+                push_if_present!(project_column, "project_column");
+                push_if_present!(pull_request, "pull_request");
+                push_if_present!(pull_request_comment, "pull_request_comment");
+                push_if_present!(pull_request_review, "pull_request_review");
+                push_if_present!(pull_request_review_comment, "pull_request_review_comment");
+                push_if_present!(pull_request_target, "pull_request_target");
+                push_if_present!(push, "push");
+                push_if_present!(registry_package, "registry_package");
+                push_if_present!(release, "release");
+                push_if_present!(repository_dispatch, "repository_dispatch");
+                push_if_present!(schedule, "schedule");
+                push_if_present!(watch, "watch");
+                push_if_present!(workflow_call, "workflow_call");
+                push_if_present!(workflow_dispatch, "workflow_dispatch");
+                push_if_present!(workflow_run, "workflow_run");
+
+                triggers
+            }
+        }
+    }
+
     /// Whether this workflow is triggered by pull_request_target.
     pub(crate) fn has_pull_request_target(&self) -> bool {
         match &self.on {
@@ -203,6 +268,79 @@ impl Workflow {
             feature_kind: SymbolicFeature::Normal,
             kind: Default::default(),
         }
+    }
+}
+
+fn bare_event_name(event: &BareEvent) -> &'static str {
+    match event {
+        BareEvent::BranchProtectionRule => "branch_protection_rule",
+        BareEvent::CheckRun => "check_run",
+        BareEvent::CheckSuite => "check_suite",
+        BareEvent::Create => "create",
+        BareEvent::Delete => "delete",
+        BareEvent::Deployment => "deployment",
+        BareEvent::DeploymentStatus => "deployment_status",
+        BareEvent::Discussion => "discussion",
+        BareEvent::DiscussionComment => "discussion_comment",
+        BareEvent::Fork => "fork",
+        BareEvent::Gollum => "gollum",
+        BareEvent::IssueComment => "issue_comment",
+        BareEvent::Issues => "issues",
+        BareEvent::Label => "label",
+        BareEvent::MergeGroup => "merge_group",
+        BareEvent::Milestone => "milestone",
+        BareEvent::PageBuild => "page_build",
+        BareEvent::Project => "project",
+        BareEvent::ProjectCard => "project_card",
+        BareEvent::ProjectColumn => "project_column",
+        BareEvent::Public => "public",
+        BareEvent::PullRequest => "pull_request",
+        BareEvent::PullRequestComment => "pull_request_comment",
+        BareEvent::PullRequestReview => "pull_request_review",
+        BareEvent::PullRequestReviewComment => "pull_request_review_comment",
+        BareEvent::PullRequestTarget => "pull_request_target",
+        BareEvent::Push => "push",
+        BareEvent::RegistryPackage => "registry_package",
+        BareEvent::Release => "release",
+        BareEvent::RepositoryDispatch => "repository_dispatch",
+        BareEvent::Status => "status",
+        BareEvent::Watch => "watch",
+        BareEvent::WorkflowCall => "workflow_call",
+        BareEvent::WorkflowDispatch => "workflow_dispatch",
+        BareEvent::WorkflowRun => "workflow_run",
+    }
+}
+
+/// A single declared workflow trigger.
+pub(crate) struct WorkflowTrigger<'doc> {
+    parent: &'doc Workflow,
+    name: &'static str,
+    route: yamlpath::Route<'doc>,
+}
+
+impl<'doc> WorkflowTrigger<'doc> {
+    fn new(parent: &'doc Workflow, name: &'static str, route: yamlpath::Route<'doc>) -> Self {
+        Self {
+            parent,
+            name,
+            route,
+        }
+    }
+
+    pub(crate) fn is_pull_request_target(&self) -> bool {
+        self.name == "pull_request_target"
+    }
+
+    pub(crate) fn is_workflow_run(&self) -> bool {
+        self.name == "workflow_run"
+    }
+}
+
+impl<'doc> Locatable<'doc> for WorkflowTrigger<'doc> {
+    fn location(&self) -> SymbolicLocation<'doc> {
+        let mut location = self.parent.location().annotated("this trigger");
+        location.route = self.route.clone();
+        location
     }
 }
 

--- a/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
+++ b/crates/zizmor/tests/integration/audit/dangerous_triggers.rs
@@ -16,3 +16,121 @@ fn test_actions_labeler_exception() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_scalar_trigger_location() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("dangerous-triggers/scalar-trigger.yml"))
+            .run()?,
+        @r#"
+    error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:2:1
+      |
+    2 | on: pull_request_target
+      | ^^^^^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
+      |
+      = note: audit confidence → Medium
+
+    3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_flow_sequence_trigger_location() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/flow-sequence-trigger.yml"
+            ))
+            .run()?,
+        @r#"
+    error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:2:12
+      |
+    2 | on: [push, pull_request_target]
+      |            ^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
+      |
+      = note: audit confidence → Medium
+
+    3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_block_sequence_trigger_location() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/block-sequence-trigger.yml"
+            ))
+            .run()?,
+        @r#"
+    error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:4:5
+      |
+    4 |   - pull_request_target
+      |     ^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
+      |
+      = note: audit confidence → Medium
+
+    3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_mapping_trigger_location() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("dangerous-triggers/mapping-trigger.yml"))
+            .run()?,
+        @r#"
+    error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:4:3
+      |
+    4 |   pull_request_target:
+      |   ^^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
+      |
+      = note: audit confidence → Medium
+
+    3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_workflow_run_trigger_location() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test(
+                "dangerous-triggers/workflow-run-trigger.yml"
+            ))
+            .run()?,
+        @r#"
+    error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+     --> @@INPUT@@:3:3
+      |
+    3 | /   workflow_run:
+    4 | |     workflows: ["Build"]
+    5 | |     types: [completed]
+      | |______________________^ workflow_run is almost always used insecurely
+      |
+      = note: audit confidence → Medium
+
+    3 findings (2 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    "#
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -728,7 +728,7 @@ fn test_github_output() -> Result<()> {
         @"
     ::error file=@@INPUT@@,line=5,title=excessive-permissions::several-vulnerabilities.yml:5: overly broad permissions: uses write-all permissions
     ::error file=@@INPUT@@,line=11,title=excessive-permissions::several-vulnerabilities.yml:11: overly broad permissions: uses write-all permissions
-    ::error file=@@INPUT@@,line=2,title=dangerous-triggers::several-vulnerabilities.yml:2: use of fundamentally insecure workflow trigger: pull_request_target is almost always used insecurely
+    ::error file=@@INPUT@@,line=3,title=dangerous-triggers::several-vulnerabilities.yml:3: use of fundamentally insecure workflow trigger: pull_request_target is almost always used insecurely
     ::error file=@@INPUT@@,line=16,title=template-injection::several-vulnerabilities.yml:16: code injection via template expansion: may expand into attacker-controllable code
     ::warning file=@@INPUT@@,line=2,title=concurrency-limits::several-vulnerabilities.yml:2: insufficient job-level concurrency limits: workflow is missing concurrency setting
     "

--- a/crates/zizmor/tests/integration/e2e/anchors.rs
+++ b/crates/zizmor/tests/integration/e2e/anchors.rs
@@ -139,16 +139,13 @@ fn test_trigger_paths_anchor() -> Result<()> {
             .run()?,
         @r#"
     error[dangerous-triggers]: use of fundamentally insecure workflow trigger
-     --> @@INPUT@@:2:1
+     --> @@INPUT@@:3:3
       |
-    2 | / on:
-    3 | |   pull_request_target:
+    3 | /   pull_request_target:
     4 | |     paths-ignore: &ignore
     5 | |       - "docs/**"
     6 | |       - "**.md"
-    7 | |   push:
-    8 | |     paths-ignore: *ignore
-      | |_________________________^ pull_request_target is almost always used insecurely
+      | |_______________^ pull_request_target is almost always used insecurely
       |
       = note: audit confidence → Medium
 
@@ -167,15 +164,10 @@ fn test_trigger_block_alias() -> Result<()> {
             .run()?,
         @r#"
     error[dangerous-triggers]: use of fundamentally insecure workflow trigger
-     --> @@INPUT@@:2:1
+     --> @@INPUT@@:7:3
       |
-    2 | / on:
-    3 | |   push: &trigger
-    4 | |     branches: [main]
-    5 | |     paths-ignore:
-    6 | |       - "**.md"
-    7 | |   pull_request_target: *trigger
-      | |_______________________________^ pull_request_target is almost always used insecurely
+    7 |   pull_request_target: *trigger
+      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
       |
       = note: audit confidence → Medium
 

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__sarif_zizmor_properties.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__sarif_zizmor_properties.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/zizmor/tests/integration/e2e.rs
+assertion_line: 742
 expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabilities.yml\")).args([\"--format=sarif\"]).run()?"
 ---
 {
@@ -212,6 +213,9 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                                   "route": [
                                     {
                                       "Key": "on"
+                                    },
+                                    {
+                                      "Key": "pull_request_target"
                                     }
                                   ]
                                 }
@@ -230,11 +234,11 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                             "endColumn": 23,
                             "endLine": 3,
                             "snippet": {
-                              "text": "on:\n  pull_request_target:"
+                              "text": "  pull_request_target:"
                             },
                             "sourceLanguage": "yaml",
-                            "startColumn": 1,
-                            "startLine": 2
+                            "startColumn": 3,
+                            "startLine": 3
                           }
                         }
                       }
@@ -264,6 +268,9 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                         "route": [
                           {
                             "Key": "on"
+                          },
+                          {
+                            "Key": "pull_request_target"
                           }
                         ]
                       }
@@ -282,11 +289,11 @@ expression: "zizmor().offline(true).input(input_under_test(\"several-vulnerabili
                   "endColumn": 23,
                   "endLine": 3,
                   "snippet": {
-                    "text": "on:\n  pull_request_target:"
+                    "text": "  pull_request_target:"
                   },
                   "sourceLanguage": "yaml",
-                  "startColumn": 1,
-                  "startLine": 2
+                  "startColumn": 3,
+                  "startLine": 3
                 }
               }
             }

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/block-sequence-trigger.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/block-sequence-trigger.yml
@@ -1,0 +1,12 @@
+name: block-sequence-trigger
+on:
+  - push
+  - pull_request_target
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/flow-sequence-trigger.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/flow-sequence-trigger.yml
@@ -1,0 +1,10 @@
+name: flow-sequence-trigger
+on: [push, pull_request_target]
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/mapping-trigger.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/mapping-trigger.yml
@@ -1,0 +1,12 @@
+name: mapping-trigger
+on:
+  push:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/scalar-trigger.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/scalar-trigger.yml
@@ -1,0 +1,10 @@
+name: scalar-trigger
+on: pull_request_target
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"

--- a/crates/zizmor/tests/integration/test-data/dangerous-triggers/workflow-run-trigger.yml
+++ b/crates/zizmor/tests/integration/test-data/dangerous-triggers/workflow-run-trigger.yml
@@ -1,0 +1,13 @@
+name: workflow-run-trigger
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Fixes #1744.

This models workflow triggers as locatable trigger occurrences and uses those
locations in `dangerous-triggers` findings. The goal is to narrow diagnostics
from the whole `on:` block to the specific dangerous trigger that caused the
finding.

This covers scalar, sequence, mapping, and existing anchor/alias layouts. The
audit semantics are unchanged: severity, confidence, messages, and the
`actions/labeler` exception are preserved.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test --test integration audit::dangerous_triggers`
- `cargo test --test integration e2e::anchors::test_trigger_paths_anchor`
- `cargo test --test integration e2e::anchors::test_trigger_block_alias`
- `cargo clippy -- --deny warnings`
- `git diff --check`
- `cargo test --test integration`
- `cargo test --workspace`
