### PR TITLE
Bump MSRV, set rust-toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 homepage = "https://docs.zizmor.sh"
 edition = "2024"
 license = "MIT"
-rust-version = "1.88.0"
+rust-version = "1.97.0"
 version = "1.27.0"
 
 [workspace.dependencies]

--- a/crates/tree-sitter-iter/src/lib.rs
+++ b/crates/tree-sitter-iter/src/lib.rs
@@ -24,10 +24,7 @@ impl<'tree> Iterator for TreeIter<'tree> {
     type Item = Node<'tree>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let cursor = match &mut self.cursor {
-            Some(cursor) => cursor,
-            None => return None,
-        };
+        let cursor = self.cursor.as_mut()?;
 
         let node = cursor.node();
 

--- a/crates/yamlpath/src/lib.rs
+++ b/crates/yamlpath/src/lib.rs
@@ -1137,9 +1137,9 @@ impl Document {
     fn query_node(&self, route: &Route, mode: QueryMode) -> Result<Node<'_>, QueryError> {
         let mut focus_node = self.top_object()?;
         for component in &route.route {
-            match self.descend(&focus_node, component) {
-                Ok(next) => focus_node = next,
-                Err(e) => return Err(e),
+            {
+                let next = self.descend(&focus_node, component)?;
+                focus_node = next
             }
         }
 

--- a/crates/zizmor/src/audit/impostor_commit.rs
+++ b/crates/zizmor/src/audit/impostor_commit.rs
@@ -167,7 +167,7 @@ impl ImpostorCommit {
             if self
                 .named_ref_contains_commit(
                     uses,
-                    &format!("refs/heads/{}", &branch.name),
+                    &format!("refs/heads/{}", branch.name),
                     candidate_sha,
                 )
                 .await?
@@ -178,7 +178,7 @@ impl ImpostorCommit {
 
         for tag in tags {
             if self
-                .named_ref_contains_commit(uses, &format!("refs/tags/{}", &tag.name), candidate_sha)
+                .named_ref_contains_commit(uses, &format!("refs/tags/{}", tag.name), candidate_sha)
                 .await?
             {
                 return Ok(IntermediateDetermination::NotImpostor);

--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -265,7 +265,7 @@ impl KnownVulnerableActions {
                     step.location()
                         .primary()
                         .with_keys(["uses".into()])
-                        .with_url(format!("https://github.com/advisories/{id}", id = &id))
+                        .with_url(format!("https://github.com/advisories/{id}", id = id))
                         .annotated(id),
                 );
 

--- a/crates/zizmor/src/output/plain.rs
+++ b/crates/zizmor/src/output/plain.rs
@@ -222,10 +222,7 @@ fn render_finding(
         title = title.id_url(finding.url);
     }
 
-    let confidence = format!(
-        "audit confidence → {:?}",
-        &finding.determinations.confidence
-    );
+    let confidence = format!("audit confidence → {:?}", finding.determinations.confidence);
 
     let mut group = Group::with_title(title)
         .elements(finding_snippets(registry, finding, render_links_mode))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.97.0"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.97.0"


### PR DESCRIPTION
1.96.1 still has a pretty critical `cargo publish` bug that breaks our publish steps semi-reliably.

Ref: https://github.com/rust-lang/cargo/issues/17093