### PR TITLE
dependabot-cooldown: honor GitHub's new default

### DIFF
--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -1,6 +1,7 @@
 use crate::{
     audit::{Audit, AuditError, audit_meta},
     finding::{Confidence, Fix, FixDisposition, Persona, Severity, location::Locatable as _},
+    models::dependabot,
 };
 use yamlpatch::{Op, Patch};
 
@@ -15,7 +16,8 @@ pub(crate) struct DependabotCooldown;
 impl DependabotCooldown {
     /// Creates a fix that adds default-days to an existing cooldown block
     fn create_add_default_days_fix<'doc>(
-        update: crate::models::dependabot::Update<'doc>,
+        update: dependabot::Update<'doc>,
+        minimum_days: u64,
     ) -> Fix<'doc> {
         Fix {
             title: "add default-days to cooldown".to_string(),
@@ -25,7 +27,7 @@ impl DependabotCooldown {
                 route: update.location().route.with_keys(["cooldown".into()]),
                 operation: Op::Add {
                     key: "default-days".to_string(),
-                    value: yaml_serde::Value::Number(7.into()),
+                    value: yaml_serde::Value::Number(minimum_days.into()),
                 },
             }],
         }
@@ -33,7 +35,7 @@ impl DependabotCooldown {
 
     /// Creates a fix that increases an insufficient default-days value
     fn create_increase_default_days_fix<'doc>(
-        update: crate::models::dependabot::Update<'doc>,
+        update: dependabot::Update<'doc>,
         minimum_days: u64,
     ) -> Fix<'doc> {
         Fix {
@@ -51,7 +53,10 @@ impl DependabotCooldown {
     }
 
     /// Creates a fix that adds a cooldown block with default-days
-    fn create_add_cooldown_fix<'doc>(update: crate::models::dependabot::Update<'doc>) -> Fix<'doc> {
+    fn create_add_cooldown_fix<'doc>(
+        update: dependabot::Update<'doc>,
+        minimum_days: u64,
+    ) -> Fix<'doc> {
         Fix {
             title: "add cooldown configuration".to_string(),
             key: update.location().key,
@@ -64,7 +69,7 @@ impl DependabotCooldown {
                         let mut map = yaml_serde::Mapping::new();
                         map.insert(
                             yaml_serde::Value::String("default-days".to_string()),
-                            yaml_serde::Value::Number(7.into()),
+                            yaml_serde::Value::Number(minimum_days.into()),
                         );
                         map
                     }),
@@ -85,7 +90,7 @@ impl Audit for DependabotCooldown {
 
     async fn audit_dependabot<'doc>(
         &self,
-        dependabot: &'doc crate::models::dependabot::Dependabot,
+        dependabot: &'doc dependabot::Dependabot,
         config: &crate::config::Config,
     ) -> Result<Vec<crate::finding::Finding<'doc>>, AuditError> {
         let mut findings = vec![];
@@ -97,15 +102,22 @@ impl Audit for DependabotCooldown {
             // When cooldown is applied to an update in a multi-ecosystem group,
             // it produces only one ecosystem update every N days instead of
             // batching all ecosystem updates together, which is rarely intended.
-            if update.multi_ecosystem_group.is_some()
-                && let Some(cooldown) = &update.cooldown
-            {
+            if update.multi_ecosystem_group.is_some() {
+                // As of 2026-07-14, all Dependabot updates have a default cooldown
+                // of 3 days. A user might explicitly disable this with `default-days: 0`,
+                // so we still need to check whether there's an effective cooldown.
+                let cooldown = update.cooldown.as_ref();
+                let default_days =
+                    cooldown.map_or(3, |cooldown| cooldown.default_days.unwrap_or(3));
+
                 // Only flag if there's an effective cooldown (default_days > 0
                 // or any semver-specific days set).
-                let has_effective_cooldown = cooldown.default_days.is_some_and(|d| d > 0)
-                    || cooldown.semver_major_days.is_some()
-                    || cooldown.semver_minor_days.is_some()
-                    || cooldown.semver_patch_days.is_some();
+                let has_effective_cooldown = default_days > 0
+                    || cooldown.map_or(false, |cooldown| {
+                        cooldown.semver_major_days.is_some()
+                            || cooldown.semver_minor_days.is_some()
+                            || cooldown.semver_patch_days.is_some()
+                    });
 
                 if has_effective_cooldown {
                     findings.push(
@@ -134,59 +146,58 @@ impl Audit for DependabotCooldown {
                 }
             }
 
-            match &update.cooldown {
-                // TODO(ww): Should we have opinions about the other
-                // cooldown settings?
-                Some(cooldown) => match cooldown.default_days {
-                    // NOTE(ww): if not set, `default-days` is 0,
-                    // which is equivalent to no cooldown by default.
-                    // See: https://github.com/dependabot/dependabot-core/blob/01385be/updater/lib/dependabot/job.rb#L536-L547
-                    None => findings.push(
-                        Self::finding()
-                            .add_location(
-                                update
-                                    .location()
-                                    .with_keys(["cooldown".into()])
-                                    .primary()
-                                    .annotated("no default-days configured"),
-                            )
-                            .confidence(Confidence::High)
-                            .severity(Severity::Medium)
-                            .fix(Self::create_add_default_days_fix(update))
-                            .build(dependabot)?,
-                    ),
-                    Some(default_days) if default_days < minimum_days => findings.push(
-                        Self::finding()
-                            .add_location(
-                                update
-                                    .location()
-                                    .with_keys(["cooldown".into(), "default-days".into()])
-                                    .primary()
-                                    .annotated(format!(
-                                        "insufficient default-days configured (less than {minimum_days})",
-                                    )),
-                            )
-                            .confidence(Confidence::Medium)
-                            .severity(Severity::Low)
-                            .fix(Self::create_increase_default_days_fix(update, minimum_days))
-                            .build(dependabot)?,
-                    ),
-                    Some(_) => {}
-                },
-                None => findings.push(
-                    Self::finding()
-                        .add_location(
-                            update
-                                .location_with_grip()
-                                .primary()
-                                .annotated("missing cooldown configuration"),
-                        )
-                        .confidence(Confidence::High)
-                        .severity(Severity::Medium)
-                        .fix(Self::create_add_cooldown_fix(update))
-                        .build(dependabot)?,
-                ),
+            // If not set, `cooldown.default-days` is 3.
+            // TODO: Should we have opinions about the other cooldown settings?
+            let default_days = update
+                .cooldown
+                .as_ref()
+                .map_or(3, |cooldown| cooldown.default_days.unwrap_or(3));
+
+            // Nothing to do if the configured cooldown is at least our minimum.
+            if default_days >= minimum_days {
+                return Ok(findings);
             }
+
+            // Otherwise, we need to build the right location and fix.
+            let (location, fix) = match update.cooldown.as_ref() {
+                Some(cooldown) => match cooldown.default_days {
+                    Some(_) => (
+                        update
+                            .location()
+                            .with_keys(["cooldown".into(), "default-days".into()])
+                            .primary()
+                            .annotated(format!(
+                                "insufficient default-days configured (less than {minimum_days})",
+                            )),
+                        Self::create_increase_default_days_fix(update, minimum_days),
+                    ),
+                    None => (
+                        update
+                            .location()
+                            .with_keys(["cooldown".into()])
+                            .primary()
+                            .annotated(format!(
+                                "insufficient implicit default-days (less than {minimum_days})"
+                            )),
+                        Self::create_add_default_days_fix(update, minimum_days),
+                    ),
+                },
+                None => (
+                    update.location_with_grip().primary().annotated(format!(
+                        "insufficient default-days configured (less than {minimum_days})"
+                    )),
+                    Self::create_add_cooldown_fix(update, minimum_days),
+                ),
+            };
+
+            findings.push(
+                Self::finding()
+                    .add_location(location)
+                    .confidence(Confidence::High)
+                    .severity(Severity::Medium)
+                    .fix(fix)
+                    .build(dependabot)?,
+            );
         }
 
         Ok(findings)

--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -1,6 +1,6 @@
 use crate::{
     audit::{Audit, AuditError, audit_meta},
-    finding::{Confidence, Fix, FixDisposition, Persona, Severity, location::Locatable as _},
+    finding::{Confidence, Fix, FixDisposition, Severity, location::Locatable as _},
     models::dependabot,
 };
 use yamlpatch::{Op, Patch};
@@ -98,54 +98,6 @@ impl Audit for DependabotCooldown {
         let minimum_days = config.dependabot_cooldown_config.days.get() as u64;
 
         for update in dependabot.updates() {
-            // Check for cooldown + multi-ecosystem-group interaction.
-            // When cooldown is applied to an update in a multi-ecosystem group,
-            // it produces only one ecosystem update every N days instead of
-            // batching all ecosystem updates together, which is rarely intended.
-            if update.multi_ecosystem_group.is_some() {
-                // As of 2026-07-14, all Dependabot updates have a default cooldown
-                // of 3 days. A user might explicitly disable this with `default-days: 0`,
-                // so we still need to check whether there's an effective cooldown.
-                let cooldown = update.cooldown.as_ref();
-                let default_days =
-                    cooldown.map_or(3, |cooldown| cooldown.default_days.unwrap_or(3));
-
-                // Only flag if there's an effective cooldown (default_days > 0
-                // or any semver-specific days set).
-                let has_effective_cooldown = default_days > 0
-                    || cooldown.map_or(false, |cooldown| {
-                        cooldown.semver_major_days.is_some()
-                            || cooldown.semver_minor_days.is_some()
-                            || cooldown.semver_patch_days.is_some()
-                    });
-
-                if has_effective_cooldown {
-                    findings.push(
-                        Self::finding()
-                            .add_location(
-                                update
-                                    .location()
-                                    .with_keys(["cooldown".into()])
-                                    .primary()
-                                    .annotated(
-                                        "multi-ecosystem-group cooldowns do not batch updates correctly",
-                                    ),
-                            )
-                            .add_location(
-                                update
-                                    .location()
-                                    .with_keys(["multi-ecosystem-group".into()])
-                                    .key_only()
-                                    .annotated("multi-ecosystem-group configured here"),
-                            )
-                            .confidence(Confidence::High)
-                            .severity(Severity::Low)
-                            .persona(Persona::Pedantic)
-                            .build(dependabot)?,
-                    );
-                }
-            }
-
             // If not set, `cooldown.default-days` is 3.
             // TODO: Should we have opinions about the other cooldown settings?
             let default_days = update
@@ -409,72 +361,6 @@ updates:
                     schedule:
                       interval: weekly
                 ");
-            }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_multi_ecosystem_group_with_cooldown() {
-        let dependabot_content = r#"
-version: 2
-multi-ecosystem-groups:
-  all:
-    schedule:
-      interval: weekly
-updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    multi-ecosystem-group: all
-    patterns:
-      - "*"
-    cooldown:
-      default-days: 7
-"#;
-
-        test_dependabot_audit!(
-            DependabotCooldown,
-            "test_multi_ecosystem_group_with_cooldown.yml",
-            dependabot_content,
-            |_dependabot: &Dependabot, findings: Vec<crate::finding::Finding>| {
-                // Should have one finding for cooldown + multi-ecosystem-group interaction
-                assert_eq!(
-                    findings.len(),
-                    1,
-                    "Expected 1 finding for multi-ecosystem-group + cooldown"
-                );
-                // No autofix for this case
-                assert!(findings[0].fixes.is_empty(), "Expected no fixes");
-            }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_multi_ecosystem_group_without_cooldown() {
-        let dependabot_content = r#"
-version: 2
-multi-ecosystem-groups:
-  all:
-    schedule:
-      interval: weekly
-updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    multi-ecosystem-group: all
-    patterns:
-      - "*"
-"#;
-
-        test_dependabot_audit!(
-            DependabotCooldown,
-            "test_multi_ecosystem_group_without_cooldown.yml",
-            dependabot_content,
-            |_dependabot: &Dependabot, findings: Vec<crate::finding::Finding>| {
-                // Should have one finding for missing cooldown, but NOT for multi-ecosystem interaction
-                assert_eq!(findings.len(), 1, "Expected 1 finding for missing cooldown");
-                assert!(
-                    !findings[0].fixes.is_empty(),
-                    "Expected a fix for missing cooldown"
-                );
             }
         );
     }

--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -113,6 +113,8 @@ impl Audit for DependabotCooldown {
             // Otherwise, we need to build the right location and fix.
             let (location, fix) = match update.cooldown.as_ref() {
                 Some(cooldown) => match cooldown.default_days {
+                    // `cooldown.default-days` is present.
+                    // Our fix needs to rewrite just the `default-days` value.
                     Some(_) => (
                         update
                             .location()
@@ -123,6 +125,8 @@ impl Audit for DependabotCooldown {
                             )),
                         Self::create_increase_default_days_fix(update, minimum_days),
                     ),
+                    // `cooldown` is present, but `default-days` is not.
+                    // Our fix needs to insert just `default-days` into the existing object.
                     None => (
                         update
                             .location()
@@ -134,6 +138,8 @@ impl Audit for DependabotCooldown {
                         Self::create_add_default_days_fix(update, minimum_days),
                     ),
                 },
+                // `cooldown` is not present.
+                // Our fix needs to insert the entire `cooldown` object, not just `default-days`.
                 None => (
                     update.location_with_grip().primary().annotated(format!(
                         "insufficient implicit default-days (less than {minimum_days})"

--- a/crates/zizmor/src/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/src/audit/dependabot_cooldown.rs
@@ -136,7 +136,7 @@ impl Audit for DependabotCooldown {
                 },
                 None => (
                     update.location_with_grip().primary().annotated(format!(
-                        "insufficient default-days configured (less than {minimum_days})"
+                        "insufficient implicit default-days (less than {minimum_days})"
                     )),
                     Self::create_add_cooldown_fix(update, minimum_days),
                 ),

--- a/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
@@ -15,7 +15,7 @@ fn test_missing_cooldown() -> anyhow::Result<()> {
      --> @@INPUT@@:4:5
       |
     4 |   - package-ecosystem: pip
-      |     ^^^^^^^^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
+      |     ^^^^^^^^^^^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix
@@ -197,7 +197,7 @@ fn test_opentofu_cooldown() -> anyhow::Result<()> {
      --> @@INPUT@@:5:5
       |
     5 |   - package-ecosystem: opentofu
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
+++ b/crates/zizmor/tests/integration/audit/dependabot_cooldown.rs
@@ -15,7 +15,7 @@ fn test_missing_cooldown() -> anyhow::Result<()> {
      --> @@INPUT@@:4:5
       |
     4 |   - package-ecosystem: pip
-      |     ^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+      |     ^^^^^^^^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix
@@ -40,7 +40,7 @@ fn test_no_default_days() -> anyhow::Result<()> {
      --> @@INPUT@@:6:5
       |
     6 |     cooldown: {}
-      |     ^^^^^^^^^^^^ no default-days configured
+      |     ^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix
@@ -60,16 +60,16 @@ fn test_default_days_too_short() -> anyhow::Result<()> {
             ))
             .run()?,
         @"
-    help[dependabot-cooldown]: insufficient cooldown in Dependabot updates
+    warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
      --> @@INPUT@@:7:7
       |
     7 |       default-days: 2
       |       ^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
       |
-      = note: audit confidence → Medium
+      = note: audit confidence → High
       = note: this finding has an auto-fix
 
-    1 findings (1 safe fixes): 0 informational, 1 low, 0 medium, 0 high
+    1 findings (1 safe fixes): 0 informational, 0 low, 1 medium, 0 high
     ");
 
     Ok(())
@@ -180,33 +180,7 @@ fn test_multi_ecosystem_group_with_cooldown() -> anyhow::Result<()> {
             ))
             .args(["--pedantic"])
             .run()?,
-        @"
-    help[dependabot-cooldown]: insufficient cooldown in Dependabot updates
-      --> @@INPUT@@:13:5
-       |
-    10 |       multi-ecosystem-group: all
-       |       --------------------- multi-ecosystem-group configured here
-    ...
-    13 | /     cooldown:
-    14 | |       default-days: 7
-       | |_____________________^ multi-ecosystem-group cooldowns do not batch updates correctly
-       |
-       = note: audit confidence → High
-
-    help[dependabot-cooldown]: insufficient cooldown in Dependabot updates
-      --> @@INPUT@@:20:5
-       |
-    17 |       multi-ecosystem-group: all
-       |       --------------------- multi-ecosystem-group configured here
-    ...
-    20 | /     cooldown:
-    21 | |       default-days: 7
-       | |______________________^ multi-ecosystem-group cooldowns do not batch updates correctly
-       |
-       = note: audit confidence → High
-
-    2 findings: 0 informational, 2 low, 0 medium, 0 high
-    "
+        @"No findings to report. Good job!"
     );
 
     Ok(())
@@ -223,7 +197,7 @@ fn test_opentofu_cooldown() -> anyhow::Result<()> {
      --> @@INPUT@@:5:5
       |
     5 |   - package-ecosystem: opentofu
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/cli.rs
+++ b/crates/zizmor/tests/integration/cli.rs
@@ -115,7 +115,7 @@ updates:
      --> <stdin>:3:5
       |
     3 |   - package-ecosystem: github-actions
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/cli.rs
+++ b/crates/zizmor/tests/integration/cli.rs
@@ -115,7 +115,7 @@ updates:
      --> <stdin>:3:5
       |
     3 |   - package-ecosystem: github-actions
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
       |
       = note: audit confidence → High
       = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__pyca_cryptography.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__pyca_cryptography.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zizmor/tests/integration/e2e/crater.rs
-expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"pyca/cryptography@43eb178ee3aae8d0060221118437b03c23570a41\").run()?"
+expression: "zizmor().offline(NetworkMode::AssertOnline).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"pyca/cryptography@43eb178ee3aae8d0060221118437b03c23570a41\").run()?"
 ---
  INFO zizmor: 🌈 zizmor v@@VERSION@@
  INFO collect_inputs: zizmor::registry::input: collected 15 inputs from pyca/cryptography
@@ -79,24 +79,6 @@ error[template-injection]: code injection via template expansion
    |
 65 |       run: .venv-pip-test/bin/pip install --require-hashes -r "${{ inputs.build-requirements-path }}"
    |       --- this run block                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
-   |
-   = note: audit confidence → High
-   = note: this finding has an auto-fix
-
-warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
-  --> .github/dependabot.yml:17:5
-   |
-17 |   - package-ecosystem: cargo
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
-   |
-   = note: audit confidence → High
-   = note: this finding has an auto-fix
-
-warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
-  --> .github/dependabot.yml:28:5
-   |
-28 |   - package-ecosystem: uv
-   |     ^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix
@@ -789,4 +771,4 @@ info[superfluous-actions]: action functionality is already included by the runne
    |
    = note: audit confidence → Low
 
-80 findings (9 suppressed): 19 informational, 35 low, 7 medium, 10 high
+78 findings (9 suppressed): 19 informational, 35 low, 5 medium, 10 high

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__warehouse.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__warehouse.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zizmor/tests/integration/e2e/crater.rs
-expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"pypi/warehouse@9ed30d191788fcfa9c5be56bcce9b743e758903e\").run()?"
+expression: "zizmor().offline(NetworkMode::AssertOnline).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"pypi/warehouse@9ed30d191788fcfa9c5be56bcce9b743e758903e\").run()?"
 ---
  INFO zizmor: 🌈 zizmor v@@VERSION@@
  INFO collect_inputs: zizmor::registry::input: collected 8 inputs from pypi/warehouse
@@ -16,7 +16,7 @@ warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
  --> .github/dependabot.yml:4:3
   |
 4 | - package-ecosystem: pip
-  |   ^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+  |   ^^^^^^^^^^^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix
@@ -25,7 +25,7 @@ warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
   --> .github/dependabot.yml:29:3
    |
 29 | - package-ecosystem: github-actions
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix
@@ -34,7 +34,7 @@ warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
   --> .github/dependabot.yml:33:3
    |
 33 | - package-ecosystem: docker
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^ insufficient implicit default-days (less than 7)
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix
@@ -357,4 +357,3 @@ help[concurrency-limits]: insufficient job-level concurrency limits
    = note: audit confidence → High
 
 34 findings (2 suppressed): 4 informational, 14 low, 8 medium, 6 high
-

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,9 @@ of `zizmor`.
 * The JSON (v1) output format now includes metadata for each finding's fixes,
   if the finding has fixes (#2186)
 
+* The [dependabot-cooldown] audit is now aware of GitHub's new three-day default
+  cooldown (#2193)
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where the [template-injection] audit would incorrectly flag


### PR DESCRIPTION
~~WIP. This is not bug-free yet, since I need to fix `test_multi_ecosystem_group_without_cooldown`. The underlying problem there is that I've loosened the implicit structure in the multi-ecosystem check so now we're attempting to access YAML keys that aren't guaranteed to be present.~~

I decided to "fix" the multi-ecosystem stuff by assuming that GitHub has fixed it on their own end, given that cooldowns are now the default. If they haven't, that part of this PR will require a strategic revert.

Closes #2192.