### PR TITLE
Initial pre-commit modeling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "pre-commit-models"
-version = "1.27.0"
+version = "0.0.1"
 dependencies = [
  "indexmap",
  "serde",
@@ -4317,6 +4317,7 @@ dependencies = [
  "jsonschema",
  "line-index",
  "owo-colors",
+ "pre-commit-models",
  "regex",
  "reqwest",
  "reqwest-middleware",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "pre-commit-models"
-version = "0.0.1"
+version = "1.28.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pre-commit-models"
+version = "1.27.0"
+dependencies = [
+ "indexmap",
+ "serde",
+ "yaml_serde",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
     "crates/github-actions-expressions",
-    "crates/github-actions-models",
+    "crates/github-actions-models", "crates/pre-commit-models",
     "crates/subfeature",
     "crates/tree-sitter-iter",
     "crates/yamlpatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.28.0" }
 yamlpath = { path = "crates/yamlpath", version = "1.28.0" }
 yamlpatch = { path = "crates/yamlpatch", version = "1.28.0" }
 zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.28.0" }
-pre-commit-models = { path = "crates/pre-commit-models", version = "1.27.0" }
+pre-commit-models = { path = "crates/pre-commit-models", version = "1.28.0" }
 
 anyhow = "1.0.102"
 itertools = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.28.0" }
 yamlpath = { path = "crates/yamlpath", version = "1.28.0" }
 yamlpatch = { path = "crates/yamlpatch", version = "1.28.0" }
 zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.28.0" }
-pre-commit-models = { path = "crates/pre-commit-models", version = "0.0.1" }
+pre-commit-models = { path = "crates/pre-commit-models", version = "1.27.0" }
 
 anyhow = "1.0.102"
 itertools = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tree-sitter-iter = { path = "crates/tree-sitter-iter", version = "1.28.0" }
 yamlpath = { path = "crates/yamlpath", version = "1.28.0" }
 yamlpatch = { path = "crates/yamlpatch", version = "1.28.0" }
 zizmor-sarif = { path = "crates/zizmor-sarif", version = "1.28.0" }
+pre-commit-models = { path = "crates/pre-commit-models", version = "0.0.1" }
 
 anyhow = "1.0.102"
 itertools = "0.15.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 `zizmor` is a static analysis tool for CI/CD systems.
 
-It can find many common security issues in typical CI/CD setups, including:
+It can find and fix security issues in common CI/CD setups, including GitHub Actions,
+Dependabot, and pre-commit. Some of the things `zizmor` finds:
 
 * Template injection vulnerabilities, leading to attacker-controlled code execution
 * Accidental credential persistence and leakage

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/woodruffw?style=flat&logo=githubsponsors&labelColor=white&color=white)](https://github.com/sponsors/woodruffw)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/PGU3zGZuGG)
 
-`zizmor` is a static analysis tool for GitHub Actions.
+`zizmor` is a static analysis tool for CI/CD systems.
 
-It can find many common security issues in typical GitHub Actions CI/CD setups,
-including:
+It can find many common security issues in typical CI/CD setups, including:
 
 * Template injection vulnerabilities, leading to attacker-controlled code execution
 * Accidental credential persistence and leakage

--- a/crates/README.md
+++ b/crates/README.md
@@ -13,6 +13,7 @@ See the table and each subdirectory for more details on each crate.
 | [`github-actions-expressions`][github-actions-expressions-dir] | [![Crates.io](https://img.shields.io/crates/v/github-actions-expressions)][github-actions-expressions-crates] | [![docs.rs](https://img.shields.io/docsrs/github-actions-expressions)][github-actions-expressions-docs] | Parser and library for GitHub Actions expressions. |
 | [`tree-sitter-iter`][tree-sitter-iter-dir] | [![Crates.io](https://img.shields.io/crates/v/tree-sitter-iter)][tree-sitter-iter-crates] | [![docs.rs](https://img.shields.io/docsrs/tree-sitter-iter)][tree-sitter-iter-docs] | A very simple pre-order iterator for tree-sitter CSTs. |
 | [`zizmor-sarif`][zizmor-sarif-dir] | [![Crates.io](https://img.shields.io/crates/v/zizmor-sarif)][zizmor-sarif-crates] | [![docs.rs](https://img.shields.io/docsrs/zizmor-sarif)][zizmor-sarif-docs] | Minimal SARIF 2.1.0 data models used by `zizmor`. |
+| [`pre-commit-models`][pre-commit-models-dir] | [![Crates.io](https://img.shields.io/crates/v/pre-commit-models)][pre-commit-models-crates] | [![docs.rs](https://img.shields.io/docsrs/pre-commit-models)][zizmor-sarif-docs] | Unofficial, high-quality data models for pre-commit. |
 
 [zizmor-dir]: ./zizmor
 [zizmor-crates]: https://crates.io/crates/zizmor
@@ -45,3 +46,7 @@ See the table and each subdirectory for more details on each crate.
 [zizmor-sarif-dir]: ./zizmor-sarif
 [zizmor-sarif-crates]: https://crates.io/crates/zizmor-sarif
 [zizmor-sarif-docs]: https://docs.rs/zizmor-sarif
+
+[pre-commit-models-dir]: ./pre-commit-models
+[pre-commit-models-crates]: https://crates.io/crates/pre-commit-models
+[pre-commit-models-docs]: https://docs.rs/pre-commit-models

--- a/crates/pre-commit-models/Cargo.toml
+++ b/crates/pre-commit-models/Cargo.toml
@@ -4,13 +4,13 @@ description = "Unofficial, high-quality data models for pre-commit configuration
 repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/pre-commit-models"
 keywords = ["pre-commit", "ci"]
 categories = ["api-bindings"]
+readme = "README.md"
 authors.workspace = true
-readme.workspace = true
 homepage.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-version = "0.0.1"
+version.workspace = true
 
 [dependencies]
 indexmap.workspace = true

--- a/crates/pre-commit-models/Cargo.toml
+++ b/crates/pre-commit-models/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "0.0.1"
 
 [dependencies]
 indexmap.workspace = true

--- a/crates/pre-commit-models/Cargo.toml
+++ b/crates/pre-commit-models/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pre-commit-models"
+description = "Unofficial, high-quality data models for pre-commit configurations and hook definitions"
+repository = "https://github.com/zizmorcore/zizmor/tree/main/crates/pre-commit-models"
+keywords = ["pre-commit", "ci"]
+categories = ["api-bindings"]
+authors.workspace = true
+readme.workspace = true
+homepage.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+indexmap.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+yaml_serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/pre-commit-models/README.md
+++ b/crates/pre-commit-models/README.md
@@ -1,0 +1,17 @@
+# pre-commit-models
+
+[![zizmor](https://img.shields.io/badge/%F0%9F%8C%88-zizmor-white?labelColor=white)](https://zizmor.sh/)
+[![CI](https://github.com/zizmorcore/zizmor/actions/workflows/ci.yml/badge.svg)](https://github.com/zizmorcore/zizmor/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/pre-commit-models)](https://crates.io/crates/pre-commit-models)
+[![docs.rs](https://img.shields.io/docsrs/pre-commit-models)](https://docs.rs/pre-commit-models)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/woodruffw?style=flat&logo=githubsponsors&labelColor=white&color=white)](https://github.com/sponsors/woodruffw)
+[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/PGU3zGZuGG)
+
+Unofficial, high-quality data models for pre-commit configurations
+and hook definitions.
+
+This crate is part of [zizmor](https://zizmor.sh).
+
+## License
+
+MIT License.

--- a/crates/pre-commit-models/src/common.rs
+++ b/crates/pre-commit-models/src/common.rs
@@ -1,5 +1,20 @@
 //! Shared models and utilities.
 
+use serde::{Deserialize, Deserializer, de::Error};
+
 pub(crate) fn default_minimum_pre_commit_version() -> String {
     "0".into()
+}
+
+pub(crate) fn non_empty_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let vec = Vec::<T>::deserialize(deserializer)?;
+    if vec.is_empty() {
+        Err(D::Error::custom("expected at least one item in list"))
+    } else {
+        Ok(vec)
+    }
 }

--- a/crates/pre-commit-models/src/common.rs
+++ b/crates/pre-commit-models/src/common.rs
@@ -1,6 +1,6 @@
 //! Shared models and utilities.
 
-use serde::{Deserialize, Deserializer, de::Error};
+use serde::{Deserialize, Deserializer, de::Error as _};
 
 pub(crate) fn default_minimum_pre_commit_version() -> String {
     "0".into()

--- a/crates/pre-commit-models/src/common.rs
+++ b/crates/pre-commit-models/src/common.rs
@@ -1,0 +1,5 @@
+//! Shared models and utilities.
+
+pub(crate) fn default_minimum_pre_commit_version() -> String {
+    "0".into()
+}

--- a/crates/pre-commit-models/src/config.rs
+++ b/crates/pre-commit-models/src/config.rs
@@ -1,0 +1,131 @@
+//! Pre-commit configuration models, i.e. for `.pre-commit-config.yml`.
+//!
+//! See: <https://pre-commit.com/#plugins>
+
+use crate::common;
+use indexmap::IndexMap;
+
+/// A single pre-commit configuration, containing one or more repositories,
+/// each of which may reference one or more hooks.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Config {
+    /// A list of repository mappings.
+    pub repos: Vec<Repo>,
+    /// An optional list of `--hook-types`.
+    ///
+    /// If not supplied, this defaults to `[pre-commit]`.
+    ///
+    // TODO: Model that?
+    pub default_install_hook_types: Option<Vec<String>>,
+
+    /// A mapping from language to the default language version that
+    /// should be used for that language, if a hook does not supply its
+    /// own `language_version`.
+    #[serde(default)]
+    pub default_language_version: IndexMap<String, String>,
+
+    /// The `stages` property for a hook, if a hook does not supply its
+    /// own `stages`.
+    pub default_stages: Option<Vec<String>>,
+
+    /// The global file include pattern.
+    #[serde(default)]
+    pub files: String,
+
+    /// The global file exclude pattern.
+    #[serde(default)]
+    pub exclude: String,
+
+    /// Whether to have pre-commit stop running hooks after the first
+    /// failure.
+    #[serde(default)]
+    pub fail_fast: bool,
+
+    /// The minimum version of pre-commit required.
+    #[serde(default = "common::default_minimum_pre_commit_version")]
+    pub minimum_pre_commit_version: String,
+}
+
+/// A repository, i.e. where to get one or more hooks from.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Repo {
+    /// The repository URL to clone, or one of the special forms.
+    pub repo: RepoReference,
+    /// The Git revision to check out from.
+    pub rev: String,
+    /// One or more hooks to use.
+    pub hooks: Vec<Hook>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepoReference {
+    /// The hooks' repository is the local one.
+    ///
+    /// See: <https://pre-commit.com/#repository-local-hooks>
+    Local,
+    /// The referenced hooks are "meta" hooks.
+    ///
+    /// See: <https://pre-commit.com/#meta-hooks>
+    Meta,
+    /// A URL to `git clone`.
+    #[serde(untagged)]
+    Remote(String),
+}
+
+/// A single hook.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Hook {
+    /// The ID of the hook to use.
+    pub id: String,
+
+    /// An optional additional ID to use when referring to the hook.
+    pub alias: Option<String>,
+
+    /// Overrides the name of the hook, as shown during execution.
+    pub name: Option<String>,
+
+    /// Overrides the language version for the hook.
+    pub language_version: Option<String>,
+
+    /// Overrides the files pattern for the hook.
+    pub files: Option<String>,
+
+    /// Overrides the exclude pattern for the hook.
+    pub exclude: Option<String>,
+
+    /// Overrides the default file types to run on for the hook (AND).
+    pub types: Option<Vec<String>>,
+
+    /// Overrides the default file types to run on for the hook (OR).
+    pub types_or: Option<Vec<String>>,
+
+    /// Overrides the types to exclude for the hook.
+    pub exclude_types: Option<Vec<String>>,
+
+    /// Optional list of additional args to supply to the hook.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Overrides the set of stages to run the hook for.
+    pub stages: Option<Vec<String>>,
+
+    /// Additional dependencies to install into the hook's environment.
+    #[serde(default)]
+    pub additional_dependencies: Vec<String>,
+
+    /// If true, run the hook even when there are no matching files.
+    #[serde(default)]
+    pub always_run: bool,
+
+    /// If true, force the hook's output to be printed even if it passes.
+    #[serde(default)]
+    pub verbose: bool,
+
+    /// If present, additionally append the hook's log output to this file.
+    #[serde(default)]
+    pub log_file: Option<String>,
+}

--- a/crates/pre-commit-models/src/config.rs
+++ b/crates/pre-commit-models/src/config.rs
@@ -11,6 +11,7 @@ use indexmap::IndexMap;
 #[serde(rename_all = "snake_case")]
 pub struct Config {
     /// A list of repository mappings.
+    #[serde(deserialize_with = "common::non_empty_vec")]
     pub repos: Vec<Repo>,
     /// An optional list of `--hook-types`.
     ///
@@ -74,6 +75,7 @@ pub enum Repo {
     Repo {
         repo: String,
         rev: String,
+        #[serde(deserialize_with = "common::non_empty_vec")]
         hooks: Vec<Hook>,
     },
 }

--- a/crates/pre-commit-models/src/config.rs
+++ b/crates/pre-commit-models/src/config.rs
@@ -49,30 +49,22 @@ pub struct Config {
 
 /// A repository, i.e. where to get one or more hooks from.
 #[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub struct Repo {
-    /// The repository URL to clone, or one of the special forms.
-    pub repo: RepoReference,
-    /// The Git revision to check out from.
-    pub rev: String,
-    /// One or more hooks to use.
-    pub hooks: Vec<Hook>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RepoReference {
-    /// The hooks' repository is the local one.
-    ///
-    /// See: <https://pre-commit.com/#repository-local-hooks>
-    Local,
-    /// The referenced hooks are "meta" hooks.
-    ///
-    /// See: <https://pre-commit.com/#meta-hooks>
-    Meta,
-    /// A URL to `git clone`.
+#[serde(
+    rename_all = "snake_case",
+    rename_all_fields = "snake_case",
+    tag = "repo"
+)]
+pub enum Repo {
+    // TODO: Fill this in.
+    Local {},
+    // TODO: Fill this in.
+    Meta {},
     #[serde(untagged)]
-    Remote(String),
+    Repo {
+        repo: String,
+        rev: String,
+        hooks: Vec<Hook>,
+    },
 }
 
 /// A single hook.

--- a/crates/pre-commit-models/src/config.rs
+++ b/crates/pre-commit-models/src/config.rs
@@ -48,6 +48,10 @@ pub struct Config {
 }
 
 /// A repository, i.e. where to get one or more hooks from.
+///
+/// This concept is slightly overloaded in pre-commit, as there are
+/// two special sentinel "repository" types, `local`, and `meta`, which
+/// have a different shape than a normal Git repository.
 #[derive(Debug, serde::Deserialize)]
 #[serde(
     rename_all = "snake_case",
@@ -55,9 +59,16 @@ pub struct Config {
     tag = "repo"
 )]
 pub enum Repo {
-    // TODO: Fill this in.
+    /// A special 'local' repository, for hooks defined within the current Git repository.
+    ///
+    /// See: <https://pre-commit.com/#repository-local-hooks>
+    // TODO: Fill this in. It's seemingly identical to a normal hook,
+    // except without `rev`.
     Local {},
-    // TODO: Fill this in.
+    /// A special 'meta' repository, for hooks defined by pre-commit itself.
+    ///
+    /// See: <https://pre-commit.com/#meta-hooks>
+    // TODO: Fill this in, it's a fixed set of IDs for hooks.
     Meta {},
     #[serde(untagged)]
     Repo {

--- a/crates/pre-commit-models/src/hooks.rs
+++ b/crates/pre-commit-models/src/hooks.rs
@@ -6,13 +6,13 @@ use crate::common;
 
 /// One or more hook definitions.
 #[derive(Debug, serde::Deserialize)]
-pub struct Hooks(pub Vec<HookDefinition>);
+pub struct Hooks(#[serde(deserialize_with = "common::non_empty_vec")] pub Vec<HookDefinition>);
 
 /// A single hook definition within a `.pre-commit-hooks.yml` file.
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct HookDefinition {
-    /// The ID of the hook, as use in `.pre-commit-config.yml`.
+    /// The ID of the hook, as used in `.pre-commit-config.yml`.
     pub id: String,
 
     /// The name of the hook, shown during execution.

--- a/crates/pre-commit-models/src/hooks.rs
+++ b/crates/pre-commit-models/src/hooks.rs
@@ -1,0 +1,91 @@
+//! Pre-commit hook definition models, i.e. for `.pre-commit-hooks.yml`.
+//!
+//! See: <https://pre-commit.com/#new-hooks>
+
+use crate::common;
+
+/// One or more hook definitions.
+#[derive(Debug, serde::Deserialize)]
+pub struct Hooks(pub Vec<HookDefinition>);
+
+/// A single hook definition within a `.pre-commit-hooks.yml` file.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct HookDefinition {
+    /// The ID of the hook, as use in `.pre-commit-config.yml`.
+    pub id: String,
+
+    /// The name of the hook, shown during execution.
+    pub name: String,
+
+    /// The entrypoint for the hook, i.e. the executable to run.
+    ///
+    /// This can also contain arguments that aren't overridable, e.g.
+    /// `entry: autopep8 -i`.
+    pub entry: String,
+
+    /// The hook's language.
+    pub language: String,
+
+    /// The pattern of files to run the hook on.
+    pub files: Option<String>,
+
+    /// Excludes files matches by `files` from the hook.
+    pub exclude: Option<String>,
+
+    /// Default list of file times to run the hook on (AND).
+    pub types: Option<Vec<String>>,
+
+    /// Default list of file times to run the hook on (OR).
+    pub types_or: Option<Vec<String>>,
+
+    /// Default list of file times to exclude.
+    pub exclude_types: Option<Vec<String>>,
+
+    /// If `true`, run the hook even when there are no matching files.
+    #[serde(default)]
+    pub always_run: bool,
+
+    /// If `true`, pre-commit will stop running hooks if this hook fails.
+    #[serde(default)]
+    pub fail_fast: bool,
+
+    /// If `true`, force the hook's output to be printed even if it passes.
+    #[serde(default)]
+    pub verbose: bool,
+
+    /// If `false`, no filenames will be passed to the hook.
+    #[serde(default = "default_true")]
+    pub pass_filenames: bool,
+
+    /// If `true`, this hook will execute using a single process instead of in parallel.
+    #[serde(default)]
+    pub require_serial: bool,
+
+    /// A description of the hook, or `''` if not given.
+    #[serde(default)]
+    pub description: String,
+
+    /// The default version to use for [`Self::language`].
+    #[serde(default = "default_language_version")]
+    pub language_version: String,
+
+    /// The minimum version of pre-commit required.
+    #[serde(default = "common::default_minimum_pre_commit_version")]
+    pub minimum_pre_commit_version: String,
+
+    /// The default list of additional parameters to pass to the hook.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// The default set of stages to run the hook for.
+    pub stages: Option<Vec<String>>,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn default_language_version() -> String {
+    "default".into()
+}

--- a/crates/pre-commit-models/src/lib.rs
+++ b/crates/pre-commit-models/src/lib.rs
@@ -1,0 +1,9 @@
+//! High-quality data models for pre-commit configurations and hook definitions.
+
+#![deny(missing_debug_implementations)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![allow(clippy::redundant_field_names)]
+
+mod common;
+pub mod config;
+pub mod hooks;

--- a/crates/pre-commit-models/tests/sample-configs/gh-action-pypi-publish.yml
+++ b/crates/pre-commit-models/tests/sample-configs/gh-action-pypi-publish.yml
@@ -1,0 +1,233 @@
+# source: https://github.com/pypa/gh-action-pypi-publish/blob/ba38be9e461d3875417946c167d0b5f3d385a247/.pre-commit-config.yaml
+
+# Copyright © 2019, Sviatoslav Sydorenko (<wk+gh~pypa/gh-action-pypi-publish@sydorenko.org.ua>) and contributors (<https://github.com/pypa/gh-action-pypi-publish/graphs/contributors>)
+# All rights reserved.
+# * * *
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of gh-action-pypi-publish nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+ci:
+  autoupdate_schedule: quarterly
+  default_language_version: python3.11
+
+repos:
+- repo: https://github.com/asottile/add-trailing-comma.git
+  rev: v3.1.0
+  hooks:
+  - id: add-trailing-comma
+
+- repo: https://github.com/PyCQA/isort.git
+  rev: 6.0.0
+  hooks:
+  - id: isort
+    args:
+    - --honor-noqa
+
+- repo: https://github.com/Lucas-C/pre-commit-hooks.git
+  rev: v1.5.5
+  hooks:
+  - id: remove-tabs
+
+- repo: https://github.com/python-jsonschema/check-jsonschema.git
+  rev: 0.31.1
+  hooks:
+  - id: check-github-actions
+  - id: check-github-workflows
+  - id: check-jsonschema
+    name: Check GitHub Workflows set timeout-minutes
+    args:
+    - --builtin-schema
+    - github-workflows-require-timeout
+    files: ^\.github/workflows/[^/]+$
+    types:
+    - yaml
+  - id: check-readthedocs
+
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  rev: v5.0.0
+  hooks:
+  # Side-effects:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: mixed-line-ending
+  # Non-modifying checks:
+  - id: name-tests-test
+    files: >-
+      ^tests/[^_].*\.py$
+  - id: check-added-large-files
+  - id: check-byte-order-marker
+  - id: check-case-conflict
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-json
+  - id: check-symlinks
+  - id: check-yaml
+  - id: detect-private-key
+  # Heavy checks:
+  - id: check-ast
+  - id: debug-statements
+    language_version: python3
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
+  hooks:
+  - id: codespell
+
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.35.1
+  hooks:
+  - id: yamllint
+    files: \.(yaml|yml)$
+    types:
+    - file
+    - yaml
+    args:
+    - --strict
+
+- repo: https://github.com/PyCQA/flake8.git
+  rev: 7.1.1
+  hooks:
+  - id: flake8
+    args:
+    - --ignore
+    # NOTE: WPS326: Found implicit string concatenation
+    # NOTE: WPS332: Found walrus operator
+    - >-
+      D100,
+      D101,
+      D103,
+      D107,
+      E402,
+      E501,
+      WPS102,
+      WPS110,
+      WPS111,
+      WPS305,
+      WPS318,
+      WPS326,
+      WPS332,
+      WPS347,
+      WPS360,
+      WPS421,
+      WPS422,
+      WPS432,
+      WPS433,
+      WPS437,
+      WPS440,
+      WPS441,
+      WPS453,
+    - --per-file-ignores=attestations.py:WPS202 oidc-exchange.py:WPS202
+    additional_dependencies:
+    - flake8-2020 ~= 1.8.1
+    - flake8-pytest-style ~= 2.1.0
+    - wemake-python-styleguide ~= 1.0.0
+
+- repo: https://github.com/pre-commit/mirrors-mypy.git
+  rev: v1.16.1
+  hooks:
+  - id: mypy
+    alias: mypy-py313
+    name: MyPy, for Python 3.13
+    additional_dependencies:
+    - id  # used by `oidc-exchange.py`
+    - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
+    - packaging  # used by `print-pkg-names.py`
+    - pypi-attestations  # used by `attestations.py`
+    - sigstore  # used by `attestations.py`
+    - types-requests  # used by `oidc-exchange.py`
+    args:
+    - --python-version=3.13
+    - --any-exprs-report=.tox/.tmp/.test-results/mypy--py-3.13
+    - --cobertura-xml-report=.tox/.tmp/.test-results/mypy--py-3.13
+    - --html-report=.tox/.tmp/.test-results/mypy--py-3.13
+    - --linecount-report=.tox/.tmp/.test-results/mypy--py-3.13
+    - --linecoverage-report=.tox/.tmp/.test-results/mypy--py-3.13
+    - --lineprecision-report=.tox/.tmp/.test-results/mypy--py-3.13
+    - --txt-report=.tox/.tmp/.test-results/mypy--py-3.13
+    pass_filenames: false
+  - id: mypy
+    alias: mypy-py312
+    name: MyPy, for Python 3.12
+    additional_dependencies:
+    - id  # used by `oidc-exchange.py`
+    - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
+    - packaging  # used by `print-pkg-names.py`
+    - pypi-attestations  # used by `attestations.py`
+    - sigstore  # used by `attestations.py`
+    - types-requests  # used by `oidc-exchange.py`
+    args:
+    - --python-version=3.12
+    - --any-exprs-report=.tox/.tmp/.test-results/mypy--py-3.12
+    - --cobertura-xml-report=.tox/.tmp/.test-results/mypy--py-3.12
+    - --html-report=.tox/.tmp/.test-results/mypy--py-3.12
+    - --linecount-report=.tox/.tmp/.test-results/mypy--py-3.12
+    - --linecoverage-report=.tox/.tmp/.test-results/mypy--py-3.12
+    - --lineprecision-report=.tox/.tmp/.test-results/mypy--py-3.12
+    - --txt-report=.tox/.tmp/.test-results/mypy--py-3.12
+    pass_filenames: false
+  - id: mypy
+    alias: mypy-py311
+    name: MyPy, for Python 3.11
+    additional_dependencies:
+    - id  # used by `oidc-exchange.py`
+    - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
+    - packaging  # used by `print-pkg-names.py`
+    - pypi-attestations  # used by `attestations.py`
+    - sigstore  # used by `attestations.py`
+    - types-requests  # used by `oidc-exchange.py`
+    args:
+    - --python-version=3.11
+    - --any-exprs-report=.tox/.tmp/.test-results/mypy--py-3.11
+    - --cobertura-xml-report=.tox/.tmp/.test-results/mypy--py-3.11
+    - --html-report=.tox/.tmp/.test-results/mypy--py-3.11
+    - --linecount-report=.tox/.tmp/.test-results/mypy--py-3.11
+    - --linecoverage-report=.tox/.tmp/.test-results/mypy--py-3.11
+    - --lineprecision-report=.tox/.tmp/.test-results/mypy--py-3.11
+    - --txt-report=.tox/.tmp/.test-results/mypy--py-3.11
+    pass_filenames: false
+
+- repo: https://github.com/PyCQA/pylint.git
+  rev: v3.3.4
+  hooks:
+  - id: pylint
+    args:
+    - --disable
+    - >-
+      import-error,
+      invalid-name,
+      line-too-long,
+      missing-class-docstring,
+      missing-function-docstring,
+      missing-module-docstring,
+      protected-access,
+      super-init-not-called,
+      unused-argument,
+      wrong-import-position,
+    - --output-format
+    - colorized
+
+- repo: https://github.com/rhysd/actionlint.git
+  rev: v1.7.8
+  hooks:
+  - id: actionlint
+
+...

--- a/crates/pre-commit-models/tests/sample-hooks/pre-commit-hooks.yml
+++ b/crates/pre-commit-models/tests/sample-hooks/pre-commit-hooks.yml
@@ -1,0 +1,234 @@
+# source: https://github.com/pre-commit/pre-commit-hooks/blob/9377601095448be1e7141feaaaa835714b53f6a5/.pre-commit-hooks.yaml
+
+# Copyright (c) 2014 pre-commit dev team: Anthony Sottile, Ken Struys
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+-   id: check-added-large-files
+    name: check for added large files
+    description: prevents giant files from being committed.
+    entry: check-added-large-files
+    language: python
+    stages: [pre-commit, pre-push, manual]
+    minimum_pre_commit_version: 3.2.0
+-   id: check-ast
+    name: check python ast
+    description: simply checks whether the files parse as valid python.
+    entry: check-ast
+    language: python
+    types: [python]
+-   id: check-byte-order-marker
+    name: check-byte-order-marker (removed)
+    description: (removed) use fix-byte-order-marker instead.
+    entry: pre-commit-hooks-removed check-byte-order-marker fix-byte-order-marker https://github.com/pre-commit/pre-commit-hooks
+    language: python
+    types: [text]
+-   id: check-builtin-literals
+    name: check builtin type constructor use
+    description: requires literal syntax when initializing empty or zero python builtin types.
+    entry: check-builtin-literals
+    language: python
+    types: [python]
+-   id: check-case-conflict
+    name: check for case conflicts
+    description: checks for files that would conflict in case-insensitive filesystems.
+    entry: check-case-conflict
+    language: python
+-   id: check-docstring-first
+    name: check docstring is first (deprecated)
+    description: checks a common error of defining a docstring after code.
+    entry: check-docstring-first
+    language: python
+    types: [python]
+-   id: check-executables-have-shebangs
+    name: check that executables have shebangs
+    description: ensures that (non-binary) executables have a shebang.
+    entry: check-executables-have-shebangs
+    language: python
+    types: [text, executable]
+    stages: [pre-commit, pre-push, manual]
+    minimum_pre_commit_version: 3.2.0
+-   id: check-illegal-windows-names
+    name: check illegal windows names
+    entry: Illegal Windows filenames detected
+    language: fail
+    files: '(?i)((^|/)(CON|PRN|AUX|NUL|COM[\d¹²³]|LPT[\d¹²³])(\.|/|$)|[<>:\"\\|?*\x00-\x1F]|/[^/]*[\.\s]/|[^/]*[\.\s]$)'
+-   id: check-json
+    name: check json
+    description: checks json files for parseable syntax.
+    entry: check-json
+    language: python
+    types: [json]
+-   id: check-shebang-scripts-are-executable
+    name: check that scripts with shebangs are executable
+    description: ensures that (non-binary) files with a shebang are executable.
+    entry: check-shebang-scripts-are-executable
+    language: python
+    types: [text]
+    stages: [pre-commit, pre-push, manual]
+    minimum_pre_commit_version: 3.2.0
+-   id: pretty-format-json
+    name: pretty format json
+    description: sets a standard for formatting json files.
+    entry: pretty-format-json
+    language: python
+    types: [json]
+-   id: check-merge-conflict
+    name: check for merge conflicts
+    description: checks for files that contain merge conflict strings.
+    entry: check-merge-conflict
+    language: python
+    types: [text]
+-   id: check-symlinks
+    name: check for broken symlinks
+    description: checks for symlinks which do not point to anything.
+    entry: check-symlinks
+    language: python
+    types: [symlink]
+-   id: check-toml
+    name: check toml
+    description: checks toml files for parseable syntax.
+    entry: check-toml
+    language: python
+    types: [toml]
+-   id: check-vcs-permalinks
+    name: check vcs permalinks
+    description: ensures that links to vcs websites are permalinks.
+    entry: check-vcs-permalinks
+    language: python
+    types: [text]
+-   id: check-xml
+    name: check xml
+    description: checks xml files for parseable syntax.
+    entry: check-xml
+    language: python
+    types: [xml]
+-   id: check-yaml
+    name: check yaml
+    description: checks yaml files for parseable syntax.
+    entry: check-yaml
+    language: python
+    types: [yaml]
+-   id: debug-statements
+    name: debug statements (python)
+    description: checks for debugger imports and py37+ `breakpoint()` calls in python source.
+    entry: debug-statement-hook
+    language: python
+    types: [python]
+-   id: destroyed-symlinks
+    name: detect destroyed symlinks
+    description: detects symlinks which are changed to regular files with a content of a path which that symlink was pointing to.
+    entry: destroyed-symlinks
+    language: python
+    types: [file]
+    stages: [pre-commit, pre-push, manual]
+-   id: detect-aws-credentials
+    name: detect aws credentials
+    description: detects *your* aws credentials from the aws cli credentials file.
+    entry: detect-aws-credentials
+    language: python
+    types: [text]
+-   id: detect-private-key
+    name: detect private key
+    description: detects the presence of private keys.
+    entry: detect-private-key
+    language: python
+    types: [text]
+-   id: double-quote-string-fixer
+    name: fix double quoted strings
+    description: replaces double quoted strings with single quoted strings.
+    entry: double-quote-string-fixer
+    language: python
+    types: [python]
+-   id: end-of-file-fixer
+    name: fix end of files
+    description: ensures that a file is either empty, or ends with one newline.
+    entry: end-of-file-fixer
+    language: python
+    types: [text]
+    stages: [pre-commit, pre-push, manual]
+    minimum_pre_commit_version: 3.2.0
+-   id: file-contents-sorter
+    name: file contents sorter
+    description: sorts the lines in specified files (defaults to alphabetical). you must provide list of target files as input in your .pre-commit-config.yaml file.
+    entry: file-contents-sorter
+    language: python
+    files: '^$'
+-   id: fix-byte-order-marker
+    name: fix utf-8 byte order marker
+    description: removes utf-8 byte order marker.
+    entry: fix-byte-order-marker
+    language: python
+    types: [text]
+-   id: fix-encoding-pragma
+    name: fix python encoding pragma (removed)
+    description: (removed) use pyupgrade instead.
+    entry: pre-commit-hooks-removed fix-encoding-pragma pyupgrade https://github.com/asottile/pyupgrade
+    language: python
+    types: [python]
+-   id: forbid-new-submodules
+    name: forbid new submodules
+    description: prevents addition of new git submodules.
+    language: python
+    entry: forbid-new-submodules
+    types: [directory]
+-   id: forbid-submodules
+    name: forbid submodules
+    description: forbids any submodules in the repository
+    language: fail
+    entry: 'submodules are not allowed in this repository:'
+    types: [directory]
+-   id: mixed-line-ending
+    name: mixed line ending
+    description: replaces or checks mixed line ending.
+    entry: mixed-line-ending
+    language: python
+    types: [text]
+-   id: name-tests-test
+    name: python tests naming
+    description: verifies that test files are named correctly.
+    entry: name-tests-test
+    language: python
+    files: (^|/)tests/.+\.py$
+-   id: no-commit-to-branch
+    name: "don't commit to branch"
+    entry: no-commit-to-branch
+    language: python
+    pass_filenames: false
+    always_run: true
+-   id: requirements-txt-fixer
+    name: fix requirements.txt
+    description: sorts entries in requirements.txt.
+    entry: requirements-txt-fixer
+    language: python
+    files: (requirements|constraints).*\.txt$
+-   id: sort-simple-yaml
+    name: sort simple yaml files
+    description: sorts simple yaml files which consist only of top-level keys, preserving comments and blocks.
+    language: python
+    entry: sort-simple-yaml
+    files: '^$'
+-   id: trailing-whitespace
+    name: trim trailing whitespace
+    description: trims trailing whitespace.
+    entry: trailing-whitespace-fixer
+    language: python
+    types: [text]
+    stages: [pre-commit, pre-push, manual]
+    minimum_pre_commit_version: 3.2.0

--- a/crates/pre-commit-models/tests/test_config.rs
+++ b/crates/pre-commit-models/tests/test_config.rs
@@ -1,0 +1,14 @@
+use std::path::Path;
+
+use pre_commit_models::config::Config;
+
+#[test]
+fn test_load_all() {
+    let sample_configs = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/sample-configs");
+
+    for sample_config in std::fs::read_dir(sample_configs).unwrap() {
+        let sample_config = sample_config.unwrap().path();
+        let config_contents = std::fs::read_to_string(sample_config).unwrap();
+        yaml_serde::from_str::<Config>(&config_contents).unwrap();
+    }
+}

--- a/crates/pre-commit-models/tests/test_hooks.rs
+++ b/crates/pre-commit-models/tests/test_hooks.rs
@@ -1,0 +1,14 @@
+use std::path::Path;
+
+use pre_commit_models::hooks::Hooks;
+
+#[test]
+fn test_load_all() {
+    let sample_hooks = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/sample-hooks");
+
+    for sample_hook in std::fs::read_dir(sample_hooks).unwrap() {
+        let sample_hook = sample_hook.unwrap().path();
+        let hook_contents = std::fs::read_to_string(sample_hook).unwrap();
+        yaml_serde::from_str::<Hooks>(&hook_contents).unwrap();
+    }
+}

--- a/crates/zizmor/Cargo.toml
+++ b/crates/zizmor/Cargo.toml
@@ -56,6 +56,7 @@ itertools.workspace = true
 jsonschema.workspace = true
 line-index.workspace = true
 owo-colors.workspace = true
+pre-commit-models.workspace = true
 regex.workspace = true
 reqwest = { workspace = true, features = ["json", "query", "rustls"] }
 reqwest-middleware = { workspace = true, features = ["query"] }

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -14,10 +14,12 @@ use crate::{
         AsDocument,
         action::{Action, CompositeStep, DockerAction},
         dependabot::Dependabot,
+        pre_commit::{PreCommitConfig, PreCommitHooks},
         workflow::{Job, NormalJob, ReusableWorkflowCallJob, Step, Workflow},
     },
     registry::input::InputKey,
     state::AuditState,
+    utils::once::warn_once,
 };
 
 pub(crate) mod adhoc_packages;
@@ -65,6 +67,8 @@ pub(crate) enum AuditInput {
     Workflow(Workflow),
     Action(Action),
     Dependabot(Dependabot),
+    PreCommitConfig(PreCommitConfig),
+    PreCommitHooks(PreCommitHooks),
 }
 
 impl AuditInput {
@@ -73,6 +77,8 @@ impl AuditInput {
             AuditInput::Workflow(workflow) => &workflow.key,
             AuditInput::Action(action) => &action.key,
             AuditInput::Dependabot(dependabot) => &dependabot.key,
+            AuditInput::PreCommitConfig(pre_commit_config) => &pre_commit_config.key,
+            AuditInput::PreCommitHooks(pre_commit_hooks) => &pre_commit_hooks.key,
         }
     }
 
@@ -81,6 +87,8 @@ impl AuditInput {
             AuditInput::Workflow(workflow) => workflow.link.as_deref(),
             AuditInput::Action(action) => action.link.as_deref(),
             AuditInput::Dependabot(dependabot) => dependabot.link.as_deref(),
+            AuditInput::PreCommitConfig(pre_commit_config) => pre_commit_config.link.as_deref(),
+            AuditInput::PreCommitHooks(pre_commit_hooks) => pre_commit_hooks.link.as_deref(),
         }
     }
 
@@ -89,6 +97,8 @@ impl AuditInput {
             AuditInput::Workflow(workflow) => workflow.location(),
             AuditInput::Action(action) => action.location(),
             AuditInput::Dependabot(dependabot) => dependabot.location(),
+            AuditInput::PreCommitConfig(pre_commit_config) => pre_commit_config.location(),
+            AuditInput::PreCommitHooks(pre_commit_hooks) => pre_commit_hooks.location(),
         }
     }
 }
@@ -99,6 +109,8 @@ impl<'a> AsDocument<'a, 'a> for AuditInput {
             AuditInput::Workflow(workflow) => workflow.as_document(),
             AuditInput::Action(action) => action.as_document(),
             AuditInput::Dependabot(dependabot) => dependabot.as_document(),
+            AuditInput::PreCommitConfig(pre_commit_config) => pre_commit_config.as_document(),
+            AuditInput::PreCommitHooks(pre_commit_hooks) => pre_commit_hooks.as_document(),
         }
     }
 }
@@ -109,6 +121,8 @@ impl<'a> Routable<'a, 'a> for AuditInput {
             AuditInput::Workflow(workflow) => workflow.location().route,
             AuditInput::Action(action) => action.location().route,
             AuditInput::Dependabot(dependabot) => dependabot.location().route,
+            AuditInput::PreCommitConfig(pre_commit_config) => pre_commit_config.location().route,
+            AuditInput::PreCommitHooks(pre_commit_hooks) => pre_commit_hooks.location().route,
         }
     }
 }
@@ -128,6 +142,18 @@ impl From<Action> for AuditInput {
 impl From<Dependabot> for AuditInput {
     fn from(value: Dependabot) -> Self {
         Self::Dependabot(value)
+    }
+}
+
+impl From<PreCommitConfig> for AuditInput {
+    fn from(value: PreCommitConfig) -> Self {
+        Self::PreCommitConfig(value)
+    }
+}
+
+impl From<PreCommitHooks> for AuditInput {
+    fn from(value: PreCommitHooks) -> Self {
+        Self::PreCommitHooks(value)
     }
 }
 
@@ -393,6 +419,10 @@ pub(crate) trait Audit: AuditCore {
             AuditInput::Workflow(workflow) => self.audit_workflow(workflow, config).await,
             AuditInput::Action(action) => self.audit_action(action, config).await,
             AuditInput::Dependabot(dependabot) => self.audit_dependabot(dependabot, config).await,
+            AuditInput::PreCommitConfig(_) | AuditInput::PreCommitHooks(_) => {
+                warn_once!("pre-commit auditing not implemented yet");
+                Ok(vec![])
+            }
         }?;
 
         results.extend(self.audit_raw(input, config).await?);

--- a/crates/zizmor/src/cli.rs
+++ b/crates/zizmor/src/cli.rs
@@ -520,6 +520,9 @@ pub(crate) enum CliCollectionMode {
     Actions,
     /// Collect Dependabot configuration files (i.e. `dependabot.yml`).
     Dependabot,
+    /// Collect pre-commit configuration and hooks files,
+    /// i.e. `.pre-commit-config.yml` and `.pre-commit-hooks.yml`.
+    PreCommit,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -529,6 +532,7 @@ pub(crate) enum CollectionMode {
     Workflows,
     Actions,
     Dependabot,
+    PreCommit,
 }
 
 pub(crate) struct CollectionModeSet(HashSet<CollectionMode>);
@@ -573,6 +577,7 @@ impl From<&[CliCollectionMode]> for CollectionModeSet {
                     CliCollectionMode::Workflows => CollectionMode::Workflows,
                     CliCollectionMode::Actions => CollectionMode::Actions,
                     CliCollectionMode::Dependabot => CollectionMode::Dependabot,
+                    CliCollectionMode::PreCommit => CollectionMode::PreCommit,
                 })
                 .collect(),
         )
@@ -617,6 +622,16 @@ impl CollectionModeSet {
             matches!(
                 mode,
                 CollectionMode::All | CollectionMode::Default | CollectionMode::Dependabot
+            )
+        })
+    }
+
+    /// Shouldn we collect pre-commit files?
+    pub(crate) fn pre_commit(&self) -> bool {
+        self.0.iter().any(|mode| {
+            matches!(
+                mode,
+                CollectionMode::All | CollectionMode::Default | CollectionMode::PreCommit
             )
         })
     }

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -951,6 +951,24 @@ impl Client {
                 let mut contents = String::with_capacity(entry.size() as usize);
                 entry.read_to_string(&mut contents)?;
                 group.register(InputKind::Dependabot, contents, key, options.strict)?;
+            } else if options.mode_set.pre_commit() {
+                if matches!(
+                    file_path.file_name(),
+                    Some(".pre-commit-config.yml" | ".pre-commit-config.yaml")
+                ) {
+                    let key = InputKey::remote(slug, file_path.to_string());
+                    let mut contents = String::with_capacity(entry.size() as usize);
+                    entry.read_to_string(&mut contents)?;
+                    group.register(InputKind::PreCommitConfig, contents, key, options.strict)?;
+                } else if matches!(
+                    file_path.file_name(),
+                    Some(".pre-commit-hooks.yml" | ".pre-commit-hooks.yaml")
+                ) {
+                    let key = InputKey::remote(slug, file_path.to_string());
+                    let mut contents = String::with_capacity(entry.size() as usize);
+                    entry.read_to_string(&mut contents)?;
+                    group.register(InputKind::PreCommitHooks, contents, key, options.strict)?;
+                }
             }
         }
 

--- a/crates/zizmor/src/main.rs
+++ b/crates/zizmor/src/main.rs
@@ -487,7 +487,10 @@ async fn main() -> ExitCode {
                     CollectionError::NoInputs => {
                         let group = Group::with_title(Level::ERROR.primary_title(err.to_string()))
                             .element(Level::HELP.message("collection yielded no auditable inputs"))
-                            .element(Level::HELP.message("inputs must contain at least one valid workflow, action, or Dependabot config"));
+                            .element(
+                                Level::HELP
+                                    .message("at least one valid, auditable input must be given"),
+                            );
 
                         let renderer = Renderer::styled();
                         let report = renderer.render(&[group]);

--- a/crates/zizmor/src/models.rs
+++ b/crates/zizmor/src/models.rs
@@ -40,6 +40,7 @@ pub(crate) mod action;
 pub(crate) mod coordinate;
 pub(crate) mod dependabot;
 pub(crate) mod inputs;
+pub(crate) mod pre_commit;
 pub(crate) mod uses;
 pub(crate) mod version;
 pub(crate) mod workflow;

--- a/crates/zizmor/src/models/pre_commit.rs
+++ b/crates/zizmor/src/models/pre_commit.rs
@@ -1,0 +1,144 @@
+//! Pre-commit models.
+//!
+//! These models enrich the models under [`pre_commit_models`],
+//! providing higher-level APIs for zizmor to use.
+
+use terminal_link::Link;
+
+use crate::{
+    finding::location::{SymbolicFeature, SymbolicLocation},
+    models::AsDocument,
+    registry::input::{CollectionError, InputKey},
+};
+
+pub(crate) struct PreCommitConfig {
+    pub(crate) key: InputKey,
+    pub(crate) link: Option<String>,
+    document: yamlpath::Document,
+    inner: pre_commit_models::config::Config,
+}
+
+impl<'a> AsDocument<'a, 'a> for PreCommitConfig {
+    fn as_document(&'a self) -> &'a yamlpath::Document {
+        &self.document
+    }
+}
+
+impl std::ops::Deref for PreCommitConfig {
+    type Target = pre_commit_models::config::Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for PreCommitConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{key}", key = self.key)
+    }
+}
+
+impl PreCommitConfig {
+    pub(crate) fn from_string(contents: String, key: InputKey) -> Result<Self, CollectionError> {
+        // TODO: `from_str_with_validation` here.
+        let inner = yaml_serde::from_str(&contents)?;
+
+        let document = yamlpath::Document::new(&contents)?;
+
+        let link = match key {
+            InputKey::Local(_) | InputKey::Stdin(_) => None,
+            InputKey::Remote(_) => {
+                // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
+                Some(Link::new(key.presentation_path(), &key.to_string()).to_string())
+            }
+        };
+
+        Ok(Self {
+            key,
+            link,
+            document,
+            inner,
+        })
+    }
+
+    /// Returns this pre-commit config's [`SymbolicLocation`].
+    ///
+    /// See [`Workflow::location`] for an explanation of why this isn't
+    /// implemented through the [`Locatable`] trait.
+    pub(crate) fn location(&self) -> SymbolicLocation<'_> {
+        SymbolicLocation {
+            key: &self.key,
+            annotation: "this pre-commit config".into(),
+            link: None,
+            route: Default::default(),
+            feature_kind: SymbolicFeature::Normal,
+            kind: Default::default(),
+        }
+    }
+}
+
+pub(crate) struct PreCommitHooks {
+    pub(crate) key: InputKey,
+    pub(crate) link: Option<String>,
+    document: yamlpath::Document,
+    inner: pre_commit_models::hooks::Hooks,
+}
+
+impl<'a> AsDocument<'a, 'a> for PreCommitHooks {
+    fn as_document(&'a self) -> &'a yamlpath::Document {
+        &self.document
+    }
+}
+
+impl std::ops::Deref for PreCommitHooks {
+    type Target = pre_commit_models::hooks::Hooks;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for PreCommitHooks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{key}", key = self.key)
+    }
+}
+
+impl PreCommitHooks {
+    pub(crate) fn from_string(contents: String, key: InputKey) -> Result<Self, CollectionError> {
+        // TODO: `from_str_with_validation` here.
+        let inner = yaml_serde::from_str(&contents)?;
+
+        let document = yamlpath::Document::new(&contents)?;
+
+        let link = match key {
+            InputKey::Local(_) | InputKey::Stdin(_) => None,
+            InputKey::Remote(_) => {
+                // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
+                Some(Link::new(key.presentation_path(), &key.to_string()).to_string())
+            }
+        };
+
+        Ok(Self {
+            key,
+            link,
+            document,
+            inner,
+        })
+    }
+
+    /// Returns this pre-commit config's [`SymbolicLocation`].
+    ///
+    /// See [`Workflow::location`] for an explanation of why this isn't
+    /// implemented through the [`Locatable`] trait.
+    pub(crate) fn location(&self) -> SymbolicLocation<'_> {
+        SymbolicLocation {
+            key: &self.key,
+            annotation: "this pre-commit hooks definition".into(),
+            link: None,
+            route: Default::default(),
+            feature_kind: SymbolicFeature::Normal,
+            kind: Default::default(),
+        }
+    }
+}

--- a/crates/zizmor/src/registry/input.rs
+++ b/crates/zizmor/src/registry/input.rs
@@ -18,7 +18,12 @@ use crate::{
     audit::AuditInput,
     config::{Config, ConfigError},
     github::{Client, ClientError},
-    models::{action::Action, dependabot::Dependabot, workflow::Workflow},
+    models::{
+        action::Action,
+        dependabot::Dependabot,
+        pre_commit::{PreCommitConfig, PreCommitHooks},
+        workflow::Workflow,
+    },
 };
 
 /// Errors that can occur while collecting inputs.
@@ -129,6 +134,10 @@ pub(crate) enum InputKind {
     Action,
     /// A Dependabot configuration file.
     Dependabot,
+    /// A `.pre-commit-config.yml` file.
+    PreCommitConfig,
+    /// A `.pre-commit-hooks.yml` file.
+    PreCommitHooks,
 }
 
 impl std::fmt::Display for InputKind {
@@ -137,6 +146,8 @@ impl std::fmt::Display for InputKind {
             InputKind::Workflow => write!(f, "workflow"),
             InputKind::Action => write!(f, "action"),
             InputKind::Dependabot => write!(f, "dependabot config"),
+            InputKind::PreCommitConfig => write!(f, "pre-commit config"),
+            InputKind::PreCommitHooks => write!(f, "pre-commit hooks definition"),
         }
     }
 }
@@ -550,10 +561,14 @@ impl InputGroup {
         tracing::debug!("registering {kind} input as with key {key}");
 
         let input: Result<AuditInput, CollectionError> = match kind {
-            InputKind::Workflow => Workflow::from_string(contents, key.clone()).map(|wf| wf.into()),
-            InputKind::Action => Action::from_string(contents, key.clone()).map(|a| a.into()),
-            InputKind::Dependabot => {
-                Dependabot::from_string(contents, key.clone()).map(|d| d.into())
+            InputKind::Workflow => Workflow::from_string(contents, key.clone()).map(Into::into),
+            InputKind::Action => Action::from_string(contents, key.clone()).map(Into::into),
+            InputKind::Dependabot => Dependabot::from_string(contents, key.clone()).map(Into::into),
+            InputKind::PreCommitConfig => {
+                PreCommitConfig::from_string(contents, key.clone()).map(Into::into)
+            }
+            InputKind::PreCommitHooks => {
+                PreCommitHooks::from_string(contents, key.clone()).map(Into::into)
             }
         };
 
@@ -592,6 +607,17 @@ impl InputGroup {
         // When collecting individual files, we don't know which part
         // of the input path is the prefix.
         let (key, kind) = match (path.file_stem(), path.extension()) {
+            // TODO: Do we need the `is_workflow_path` disambiguation here?
+            // The only way this could be wrong is if the user does something
+            // bizarre like `.github/workflows/.pre-commit-{config,hooks}.yml`.
+            (Some(".pre-commit-config"), Some("yml" | "yaml")) if !is_workflow_path => (
+                InputKey::local(Group(path.as_str().into()), path, None, root),
+                InputKind::PreCommitConfig,
+            ),
+            (Some(".pre-commit-hooks"), Some("yml" | "yaml")) if !is_workflow_path => (
+                InputKey::local(Group(path.as_str().into()), path, None, root),
+                InputKind::PreCommitHooks,
+            ),
             (Some("dependabot"), Some("yml" | "yaml")) if !is_workflow_path => (
                 InputKey::local(Group(path.as_str().into()), path, None, root),
                 InputKind::Dependabot,
@@ -651,10 +677,13 @@ impl InputGroup {
             let entry = entry?;
             let entry = <&Utf8Path>::try_from(entry.path())
                 .map_err(|e| CollectionError::InvalidPath(e, entry.path().into()))?;
+            // Pre-compute file status so we don't call `stat()` once per mode
+            // check below.
+            let entry_is_file = entry.is_file();
             let root = root.as_deref();
 
             if options.mode_set.workflows()
-                && entry.is_file()
+                && entry_is_file
                 && matches!(entry.extension(), Some("yml" | "yaml"))
                 && camino::absolute_utf8(entry)?
                     .parent()
@@ -672,7 +701,7 @@ impl InputGroup {
             }
 
             if options.mode_set.actions()
-                && entry.is_file()
+                && entry_is_file
                 && matches!(entry.file_name(), Some("action.yml" | "action.yaml"))
             {
                 let key = InputKey::local(Group(path.as_str().into()), entry, Some(path), root);
@@ -687,7 +716,7 @@ impl InputGroup {
             }
 
             if options.mode_set.dependabot()
-                && entry.is_file()
+                && entry_is_file
                 && matches!(
                     entry.file_name(),
                     Some("dependabot.yml" | "dependabot.yaml")
@@ -702,6 +731,36 @@ impl InputGroup {
                     )
                 })?;
                 group.register(InputKind::Dependabot, contents, key, options.strict)?;
+            }
+
+            if options.mode_set.pre_commit() && entry_is_file {
+                if matches!(
+                    entry.file_name(),
+                    Some(".pre-commit-config.yml" | ".pre-commit-config.yaml")
+                ) {
+                    let key = InputKey::local(Group(path.as_str().into()), entry, Some(path), root);
+                    let contents = std::fs::read_to_string(entry).map_err(|e| {
+                        CollectionError::Inner(
+                            CollectionError::Io(e).into(),
+                            key.to_string(),
+                            InputKind::PreCommitConfig,
+                        )
+                    })?;
+                    group.register(InputKind::PreCommitConfig, contents, key, options.strict)?;
+                } else if matches!(
+                    entry.file_name(),
+                    Some(".pre-commit-hooks.yml" | ".pre-commit-hooks.yaml")
+                ) {
+                    let key = InputKey::local(Group(path.as_str().into()), entry, Some(path), root);
+                    let contents = std::fs::read_to_string(entry).map_err(|e| {
+                        CollectionError::Inner(
+                            CollectionError::Io(e).into(),
+                            key.to_string(),
+                            InputKind::PreCommitHooks,
+                        )
+                    })?;
+                    group.register(InputKind::PreCommitHooks, contents, key, options.strict)?;
+                }
             }
         }
 
@@ -764,7 +823,20 @@ impl InputGroup {
             return Ok(group);
         }
 
-        if let Ok(()) = group.register(InputKind::Dependabot, contents, key, true) {
+        if let Ok(()) = group.register(InputKind::Dependabot, contents.clone(), key.clone(), true) {
+            return Ok(group);
+        }
+
+        if let Ok(()) = group.register(
+            InputKind::PreCommitConfig,
+            contents.clone(),
+            key.clone(),
+            true,
+        ) {
+            return Ok(group);
+        }
+
+        if let Ok(()) = group.register(InputKind::PreCommitHooks, contents, key, true) {
             return Ok(group);
         }
 

--- a/crates/zizmor/src/utils.rs
+++ b/crates/zizmor/src/utils.rs
@@ -369,6 +369,10 @@ where
             // See: https://github.com/dtolnay/serde-yaml/issues/170
             // See: https://github.com/dtolnay/serde-yaml/issues/395
 
+            // NOTE(ww): This is wrong for pre-commit hooks files, since they have a top
+            // level YAML list instead of a mapping. We either need to make this
+            // generic over a "skeleton" type (`yaml_serde::Mapping`/`yaml_serde::Sequence`)
+            // or loosen the check above.
             match yaml_serde::from_str::<yaml_serde::Mapping>(contents) {
                 // We know we have valid YAML, so one of two things happened here:
                 // 1. The input is semantically valid, but we have a bug in

--- a/crates/zizmor/tests/integration/cli.rs
+++ b/crates/zizmor/tests/integration/cli.rs
@@ -238,7 +238,7 @@ fn test_stdin_empty() -> anyhow::Result<()> {
     error: no inputs collected
       |
       = help: collection yielded no auditable inputs
-      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+      = help: at least one valid, auditable input must be given
 
     Caused by:
         no inputs collected
@@ -796,7 +796,7 @@ fn test_stdin_valid_yaml_unknown_schema() -> anyhow::Result<()> {
     error: no inputs collected
       |
       = help: collection yielded no auditable inputs
-      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+      = help: at least one valid, auditable input must be given
 
     Caused by:
         no inputs collected
@@ -824,7 +824,7 @@ fn test_stdin_valid_yaml_unknown_schema_strict() -> anyhow::Result<()> {
     error: no inputs collected
       |
       = help: collection yielded no auditable inputs
-      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+      = help: at least one valid, auditable input must be given
 
     Caused by:
         no inputs collected

--- a/crates/zizmor/tests/integration/e2e.rs
+++ b/crates/zizmor/tests/integration/e2e.rs
@@ -309,7 +309,7 @@ fn invalid_inputs() -> Result<()> {
     error: no inputs collected
       |
       = help: collection yielded no auditable inputs
-      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+      = help: at least one valid, auditable input must be given
 
     Caused by:
         no inputs collected
@@ -359,7 +359,7 @@ fn test_issue_1394() -> Result<()> {
     error: no inputs collected
       |
       = help: collection yielded no auditable inputs
-      = help: inputs must contain at least one valid workflow, action, or Dependabot config
+      = help: at least one valid, auditable input must be given
 
     Caused by:
         no inputs collected

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__astral_sh_uv.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__astral_sh_uv.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/zizmor/tests/integration/e2e/crater.rs
-expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"astral-sh/uv@8ed803e507f41937d55865ae88c8c806573b3b9e\").run()?"
+expression: "zizmor().offline(NetworkMode::AssertOnline).output(OutputMode::Both).args([\"--persona=pedantic\"]).input(\"astral-sh/uv@8ed803e507f41937d55865ae88c8c806573b3b9e\").run()?"
 ---
  INFO zizmor: 🌈 zizmor v@@VERSION@@
- INFO collect_inputs: zizmor::registry::input: collected 25 inputs from astral-sh/uv
+ INFO collect_inputs: zizmor::registry::input: collected 26 inputs from astral-sh/uv
  INFO audit: zizmor: 🌈 completed .github/workflows/bench.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/build-dev-binaries.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/build-docker.yml
@@ -29,6 +29,8 @@ expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--persona=
  INFO audit: zizmor: 🌈 completed .github/workflows/test-system.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/test-windows-trampolines.yml
  INFO audit: zizmor: 🌈 completed .github/workflows/test.yml
+ WARN audit:audit{input=PreCommitConfig(https://github.com/astral-sh/uv/blob/8ed803e507f41937d55865ae88c8c806573b3b9e/.pre-commit-config.yaml)}: zizmor::audit: pre-commit auditing not implemented yet
+ INFO audit: zizmor: 🌈 completed .pre-commit-config.yaml
 help[anonymous-definition]: workflow or action definition without a name
    --> .github/workflows/bench.yml:1:1
     |

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_input_not_strict-2.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_input_not_strict-2.snap
@@ -8,7 +8,7 @@ fatal: no audit was performed
 error: no inputs collected
   |
   = help: collection yielded no auditable inputs
-  = help: inputs must contain at least one valid workflow, action, or Dependabot config
+  = help: at least one valid, auditable input must be given
 
 Caused by:
     no inputs collected

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_input_not_strict.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__invalid_input_not_strict.snap
@@ -8,7 +8,7 @@ fatal: no audit was performed
 error: no inputs collected
   |
   = help: collection yielded no auditable inputs
-  = help: inputs must contain at least one valid workflow, action, or Dependabot config
+  = help: at least one valid, auditable input must be given
 
 Caused by:
     no inputs collected

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,10 @@
 
 Hello, and welcome to `zizmor`'s documentation.
 
-`zizmor` is a static analysis tool for your CI/CD. It can find and fix
-many common security issues in typical CI/CD setups.
+`zizmor` is a static analysis tool for your CI/CD.
+
+It can find and fix security issues in common CI/CD setups,
+including GitHub Actions, Dependabot, and pre-commit.
 
 <div class="grid cards" markdown>
 -   :material-download:{.lg .middle} Install `zizmor`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@
 
 Hello, and welcome to `zizmor`'s documentation.
 
-`zizmor` is a static analysis tool for GitHub Actions. It can find and fix
-many common security issues in typical GitHub Actions CI/CD setups.
+`zizmor` is a static analysis tool for your CI/CD. It can find and fix
+many common security issues in typical CI/CD setups.
 
 <div class="grid cards" markdown>
 -   :material-download:{.lg .middle} Install `zizmor`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,10 +16,9 @@ You should see something like this:
 
 Here are some different ways you can run `zizmor` locally:
 
-=== "On one or more workflows"
+=== "On one or more individual files"
 
-    You can run `zizmor` on one or more workflows or composite actions as
-    explicit inputs:
+    You can run `zizmor` on one or more individual files:
 
     ```bash
     zizmor ci.yml tests.yml lint.yml action.yml
@@ -35,19 +34,11 @@ Here are some different ways you can run `zizmor` locally:
 
     !!! tip
 
-        Composite action support was added in v1.0.0.
-
-    !!! tip
-
         Pass `--collect=workflows` to avoid collecting anything except
         workflow definitions.
 
     When given one or more local directories, `zizmor` will treat each as a
-    GitHub repository and attempt to discover workflows defined under the
-    `.github/workflows` subdirectory for each. `zizmor` will also walk each
-    directory to find composite action definitions (`action.yml` in any
-    subdirectory) and Dependabot configuration files
-    (`.github/dependabot.yml`).
+    repository and attempt to workflows and other auditable inputs within it.
 
     ```bash
     # repo-a/ contains .github/workflows/{ci,tests}.yml
@@ -57,7 +48,7 @@ Here are some different ways you can run `zizmor` locally:
     # or with multiple directories
     zizmor repo-a/ ../../repo-b/
 
-    # collect only workflows, not composite actions or Dependabot configs
+    # collect only workflows
     zizmor --collect=workflows repo-a/
     ```
 
@@ -86,6 +77,13 @@ Here are some different ways you can run `zizmor` locally:
 
     ```bash
     zizmor --gh-token=$(gh auth token) zizmorcore/zizmor zizmorcore/gha-hazmat
+    ```
+
+    As will the `@<ref>` syntax for auditing a specific tag, branch,
+    or commit:
+
+    ```bash
+    zizmor --gh-token=$(gh auth token) actions/checkout@v7
     ```
 
 See [Usage](./usage.md) for more examples, including examples of configuration.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### New Features 🌈
+
+* zizmor now has **experimental** support for auditing pre-commit inputs,
+  meaning both pre-commit configuration and hook definitions (#2209)
+
 ## 1.28.0
 
 ### Security 🔒

--- a/docs/snippets/abbreviations.md
+++ b/docs/snippets/abbreviations.md
@@ -7,3 +7,4 @@
 *[PATs]: Personal Access Tokens
 *[SARIF]: Static Analysis Results Interchange Format
 *[YAML]: YAML Ain't Markup Language
+*[GHA]: GitHub Actions

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -4,7 +4,7 @@ Usage: zizmor [OPTIONS] <INPUT>...
 
 Input Options:
   <INPUT>...               The inputs to audit
-      --collect <KIND>...  Control which kinds of inputs are collected for auditing [default: default] [possible values: all, default, workflows, actions, dependabot]
+      --collect <KIND>...  Control which kinds of inputs are collected for auditing [default: default] [possible values: all, default, workflows, actions, dependabot, pre-commit]
       --strict-collection  Fail instead of warning on syntax and schema errors in collected inputs
 
 Audit Options:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,10 +10,10 @@ Before auditing, `zizmor` performs an input collection phase.
 
 There are four input sources that `zizmor` knows about:
 
-1. Individual workflow and action files, e.g. `foo.yml` and
-   `my-action/action.yml`;
-2. "Local" GitHub repositories in the form of a directory, e.g. `my-repo/`;
-3. "Remote" GitHub repositories in the form of a "slug", e.g.
+1. Individual input files, e.g. `foo.yml`, `my-action/action.yml`,
+   and `.pre-commit-config.yaml`;
+2. "Local" repositories in the form of a directory, e.g. `my-repo/`;
+3. "Remote" (GitHub) repositories in the form of a "slug", e.g.
    `pypa/sampleproject`;
 
     !!! tip
@@ -63,7 +63,7 @@ There are four input sources that `zizmor` knows about:
     ```
 
     When reading from stdin, `zizmor` automatically infers the input type
-    (workflow, action, or Dependabot config).
+    (workflow, action, Dependabot config, or pre-commit config/hook definition).
 
     !!! note
 
@@ -1008,8 +1008,8 @@ GH_HOST=custom.ghe.com zizmor ...
 
 ## Limitations
 
-`zizmor` can help you write more secure GitHub workflow and action definitions,
-as well as help you find exploitable bugs in existing definitions.
+`zizmor` can help you secure your CI/CD setup by finding common,
+well-understood flaws.
 
 However, like all tools, `zizmor` is **not a panacea**, and has
 fundamental limitations that must be kept in mind. This page
@@ -1020,9 +1020,8 @@ documents some of those limitations.
 `zizmor` is a _static_ analysis tool. It never executes any code, nor does it
 have access to any runtime state.
 
-In contrast, GitHub Actions workflow and action definitions are highly
-dynamic, and can be influenced by inputs that can only be inspected at
-runtime.
+In contrast, many CI/CD systems (like GitHub Actions) are extremely dynamic,
+and can be influenced by inputs that can only be inspected at runtime.
 
 For example, here is a workflow where a job's matrix is generated
 at runtime by a previous job, making the matrix impossible to
@@ -1104,10 +1103,9 @@ outside of any repository-tracked state.
 results.
 
 To do this, `zizmor` needs to know a lot of about the inner workings
-of the YAML serialization format that GitHub Actions workflows, action
-definitions, and Dependabot files are expressed in.
+of the YAML serialization format that its inputs are expressed in.
 
-YAML is a complicated serialization format, but GitHub *mostly* uses
+YAML is a complicated serialization format, but typical inputs *mostly* use
 a tractable subset of it. One conspicuous exception to this is
 [YAML anchors](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases),
 which GitHub has
@@ -1133,8 +1131,8 @@ If you're having issues with inputs containing anchors, see
 !!! warning "Experimental"
 
     `zizmor`'s support for parallel steps is currently **experimental**.
-    You will probably encounter bugs if you run `zizmor` on a workflow
-    that uses parallel steps; please
+    You will probably encounter bugs if you run `zizmor` on a GitHub Actions
+    workflow that uses parallel steps; please
     [report any issues you have](https://github.com/zizmorcore/zizmor/issues/new)!
 
 As of June 2026, GitHub Actions [supports parallel steps]. This support adds

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,7 +99,10 @@ zizmor --collect=actions example/example
 # collect only Dependabot configs
 zizmor --collect=dependabot example/example
 
-# collect only workflows and actions (not Dependabot configs)
+# collect only pre-commit inputs
+zizmor --collect=pre-commit example/example
+
+# collect both workflows and actions, but nothing else
 zizmor --collect=workflows,actions example/example
 ```
 


### PR DESCRIPTION
See #1799 for context.

This does not add any audits yet; this is just to ensure we can model and inject pre-commit inputs into zizmor's machinery.