### PR TITLE
Add `sbt` to known Dependabot ecosystems

### DIFF
--- a/crates/github-actions-models/src/dependabot/v2.rs
+++ b/crates/github-actions-models/src/dependabot/v2.rs
@@ -410,6 +410,8 @@ pub enum PackageEcosystem {
     Pub,
     /// `rust-toolchain`
     RustToolchain,
+    /// `sbt`
+    Sbt,
     /// `swift`
     Swift,
     /// `terraform`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,8 @@ of `zizmor`.
 * The [dependabot-cooldown] audit is now aware of GitHub's new three-day default
   cooldown (#2193)
 
+* `sbt` is now recognized as a `package-ecosystem` in `dependabot.yml` (#2211)
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where the [template-injection] audit would incorrectly flag


### PR DESCRIPTION
See #2208, plus https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/