### PR TITLE
Ensure that GitHub token is always redacted

### DIFF
--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -97,7 +97,7 @@ impl FromStr for GitHubHost {
 }
 
 /// A sanitized GitHub access token.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct GitHubToken(String);
 
 impl GitHubToken {
@@ -110,7 +110,16 @@ impl GitHubToken {
     }
 
     fn to_header_value(&self) -> Result<HeaderValue, InvalidHeaderValue> {
-        HeaderValue::from_str(&format!("Bearer {}", self.0))
+        let mut hv = HeaderValue::from_str(&format!("Bearer {}", self.0))?;
+        hv.set_sensitive(true);
+
+        Ok(hv)
+    }
+}
+
+impl std::fmt::Debug for GitHubToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("GitHubToken").field(&"***").finish()
     }
 }
 
@@ -1068,6 +1077,9 @@ mod tests {
         ] {
             assert_eq!(GitHubToken::new(token).unwrap().0, expected);
         }
+
+        // Ensure our Debug impl redacts.
+        insta::assert_compact_debug_snapshot!(&GitHubToken::new("hackme"), @r#"Ok(GitHubToken("***"))"#);
     }
 
     #[test]

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -1079,7 +1079,16 @@ mod tests {
         }
 
         // Ensure our Debug impl redacts.
-        insta::assert_compact_debug_snapshot!(&GitHubToken::new("hackme"), @r#"Ok(GitHubToken("***"))"#);
+        insta::assert_compact_debug_snapshot!(
+            GitHubToken::new("hackme").unwrap(),
+            @r#"GitHubToken("***")"#
+        );
+
+        // Ensure the header value also redacts.
+        insta::assert_compact_debug_snapshot!(
+            GitHubToken::new("hackme").unwrap().to_header_value().unwrap(),
+            @"Sensitive"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This follows #2213.

I'm going to do a full RCA, but the TL;DR is that I naively added a `Debug` impl to `GitHubToken` at some point, without thinking about redacting the sensitive state within it. #2180 then made it possible for a user to log that debug representation.

The fix is to ensure that `GitHubToken` can never be debug-printed without redaction. We do that here by adding a custom `Debug` impl, although a potentially better solution would be to use something like `secrecy::SecretString`.

Separately, we also mark the `HeaderValue` returned by `to_header_value` as sensitive to tell anything that logs it to also perform appropriate redaction.