### PR TITLE
Handle `jobs.*.outputs` literals gracefully

### DIFF
--- a/crates/github-actions-models/src/workflow/job.rs
+++ b/crates/github-actions-models/src/workflow/job.rs
@@ -24,7 +24,7 @@ pub struct NormalJob {
     pub environment: Option<DeploymentEnvironment>,
     pub concurrency: Option<Concurrency>,
     #[serde(default)]
-    pub outputs: IndexMap<String, String>,
+    pub outputs: Env,
     #[serde(default)]
     pub env: LoE<Env>,
     pub defaults: Option<Defaults>,

--- a/crates/github-actions-models/tests/sample-workflows/zizmor-issue-2218.yml
+++ b/crates/github-actions-models/tests/sample-workflows/zizmor-issue-2218.yml
@@ -1,0 +1,28 @@
+# https://github.com/zizmorcore/zizmor/issues/2218
+#
+# minimized from https://github.com/AOMediaCodec/avm/blob/636fcda8/.github/workflows/nightly.yaml
+
+name: Nightly
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"  # 4am UTC / 8pm PST
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vars:
+    name: Set common variables
+    runs-on: ubuntu-latest
+    outputs:
+      timeout-minutes: 660
+    steps:
+      - name: Do nothing
+        run: |
+          echo noop

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,11 @@ of `zizmor`.
 * zizmor now has **experimental** support for auditing pre-commit inputs,
   meaning both pre-commit configuration and hook definitions (#2209)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where `zizmor` would reject a valid workflow definition for
+  containing a literal `jobs.<job>.outputs.<name>` value for being a non-string (#2220)
+
 ## 1.28.0
 
 ### Security 🔒


### PR DESCRIPTION
This fixes the first part of #2218, but reveals a much more surprising bug:

```
 INFO zizmor: 🌈 zizmor v1.28.0
fatal: no audit was performed
error: failed to load https://github.com/AOMediaCodec/avm/blob/HEAD/.github/workflows/pull_request.yaml as workflow
  |
  = help: this typically indicates a bug in zizmor; please report it
  = help: https://github.com/zizmorcore/zizmor/issues/new?template=bug-report.yml

Caused by:
    0: failed to load https://github.com/AOMediaCodec/avm/blob/HEAD/.github/workflows/pull_request.yaml as workflow
    1: failed to load internal pathing document
    2: input is not valid YAML
```

That suggests a `yamlpath` or `tree-sitter-yaml` bug, probably the latter.