### PR TITLE
Don't flag org-only app token requests as missing repos

### DIFF
--- a/crates/zizmor/src/audit/github_app.rs
+++ b/crates/zizmor/src/audit/github_app.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashSet, sync::LazyLock};
+
 use github_actions_models::common::{EnvValue, RepositoryUses, Uses, expr::LoE};
 use indexmap::IndexMap;
 use subfeature::Subfeature;
@@ -14,6 +16,41 @@ use crate::{
     utils::ExtractedExpr,
 };
 
+/// Permissions that only affect organization access, not access within repositories.
+///
+/// When these (and only these) are present, we skip our presence requirement for
+/// the `repositories` key, since it's superfluous when the app only works on
+/// org-level resources.
+///
+/// See #2219 for more context.
+static ORG_ONLY_PERMISSIONS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
+    // See: https://github.com/actions/create-github-app-token/blob/main/action.yml
+    // TODO: More permissions to add here?
+    [
+        "permission-custom-properties-for-organizations",
+        "permission-enterprise-custom-properties-for-organizations",
+        "permission-members",
+        "permission-organization-administration",
+        "permission-organization-announcement-banners",
+        "permission-organization-copilot-seat-management",
+        "permission-organization-custom-org-roles",
+        "permission-organization-custom-properties",
+        "permission-organization-custom-roles",
+        "permission-organization-events",
+        "permission-organization-hooks",
+        "permission-organization-packages",
+        "permission-organization-personal-access-token-requests",
+        "permission-organization-personal-access-tokens",
+        "permission-organization-plan",
+        "permission-organization-projects",
+        "permission-organization-secrets",
+        "permission-organization-self-hosted-runners",
+        "permission-organization-user-blocking",
+    ]
+    .into_iter()
+    .collect()
+});
+
 pub(crate) struct GitHubApp;
 
 audit_meta!(
@@ -23,6 +60,17 @@ audit_meta!(
 );
 
 impl GitHubApp {
+    /// Test whether the given `permissions` are a subset of [`ORG_ONLY_PERMISSIONS`].
+    fn permissions_are_org_only(permissions: &HashSet<&str>) -> bool {
+        // No explicit permissions means the app's default permissions, which
+        // we have to assume are broader than org-only.
+        if permissions.is_empty() {
+            return false;
+        }
+
+        permissions.is_subset(&ORG_ONLY_PERMISSIONS)
+    }
+
     fn process_step<'doc>(
         &self,
         step: &impl StepCommon<'doc>,
@@ -117,10 +165,25 @@ impl GitHubApp {
             }
         }
 
+        let permissions: HashSet<&str> = with
+            .keys()
+            .map(|k| k.as_str())
+            .filter(|k| k.starts_with("permission-"))
+            .collect();
+
+        tracing::trace!("permissions: {permissions:?}");
+
         // `owner: ...` without `repositories: ...` grants the app token access to all
         // repositories in the owner's account, which is likely more access than the
         // user intended.
-        if with.contains_key("owner") && !with.contains_key("repositories") {
+        //
+        // We only flag this if the user doesn't specify permissions explicitly or does
+        // specify them explicitly to include permissions outside of managing organiztion
+        // resources.
+        if with.contains_key("owner")
+            && !with.contains_key("repositories")
+            && !Self::permissions_are_org_only(&permissions)
+        {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::High)

--- a/crates/zizmor/tests/integration/audit/github_app.rs
+++ b/crates/zizmor/tests/integration/audit/github_app.rs
@@ -62,7 +62,19 @@ fn test_regular_persona() -> anyhow::Result<()> {
        = note: audit confidence → High
        = tip: specify at least one `permission-<name>` input to limit the token's permissions
 
-    5 findings: 0 informational, 0 low, 0 medium, 5 high
+    error[github-app]: dangerous use of GitHub App tokens
+      --> @@INPUT@@:83:11
+       |
+    81 |         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+       |               ------------------------------------------------------------------------ app token requested here
+    82 |         with:
+    83 |           owner: github
+       |           ^^^^^^^^^^^^^ token granted access to all repositories for this owner's app installation
+       |
+       = note: audit confidence → High
+       = tip: use `repositories: 'repo1,repo2'` to scope the token to specific repositories
+
+    6 findings: 0 informational, 0 low, 0 medium, 6 high
     ");
     Ok(())
 }

--- a/crates/zizmor/tests/integration/audit/github_app.rs
+++ b/crates/zizmor/tests/integration/audit/github_app.rs
@@ -66,3 +66,19 @@ fn test_regular_persona() -> anyhow::Result<()> {
     ");
     Ok(())
 }
+
+/// Repro case for #2219.
+///
+/// We should produce no `github-app` findings here despite the lack of a `repositories`
+/// key, since the app's token request is scoped to just org-level permissions.
+#[test]
+fn test_issue_2219() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+    zizmor()
+        .input(input_under_test("github-app/issue-2219-repro.yml"))
+        .run()?,
+    @"No findings to report. Good job!"
+    );
+
+    Ok(())
+}

--- a/crates/zizmor/tests/integration/test-data/github-app.yml
+++ b/crates/zizmor/tests/integration/test-data/github-app.yml
@@ -55,3 +55,33 @@ jobs:
           client-id: ${{ vars.GHES_APP_CLIENT_ID }}
           private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
           permission-issues: write
+
+      # OK: repositories is not explicitly provided, but the permissions
+      # are limited to non-repository resources.
+      - name: github-app-owner-with-repositories
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          owner: github
+          client-id: ${{ vars.GHES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
+          permission-members: write
+
+      # OK: repositories is not explicitly provided, but the permissions
+      # are limited to non-repository resources.
+      - name: github-app-owner-with-repositories
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          owner: github
+          client-id: ${{ vars.GHES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
+          permission-members: write
+
+      # NOT OK: permissions are a superset of org permissions but no explicit repositories
+      - name: github-app-owner-with-repositories
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          owner: github
+          client-id: ${{ vars.GHES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
+          permission-members: write
+          permission-issues: write

--- a/crates/zizmor/tests/integration/test-data/github-app/issue-2219-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/github-app/issue-2219-repro.yml
@@ -1,0 +1,31 @@
+# Reproduction case for #2219.
+#
+# See: https://github.com/zizmorcore/zizmor/issues/2219
+
+name: ISSUE-2219-REPRO
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  github-app:
+    name: github-app
+    runs-on: ubuntu-latest
+    environment:
+      name: test
+    steps:
+      - name: github-app-skips-token-revoke
+        # We should NOT flag this with the `github-app` rule despite lacking a `repositories`
+        # key, since it only requests org-level permissions and therefore has no reasonable
+        # repository scope.
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-members: read

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,10 @@ of `zizmor`.
 * Fixed a bug where `zizmor` would reject a valid workflow definition for
   containing a literal `jobs.<job>.outputs.<name>` value for being a non-string (#2220)
 
+* Fixed a bug where the [github-app] audit would incorrectly flag some usages
+  as needing a `#!yaml repositories:` key, despite requesting organization-level-only
+  permissions (#2227)
+
 ## 1.28.0
 
 ### Security 🔒


### PR DESCRIPTION
This avoids a false positive: we should only flag `repositories` for being missing if the app's installation's token request actually has repo-scoped permissions.

Fixes #2219.