### PR TITLE
Support audit ID aliasing

### DIFF
--- a/crates/zizmor/src/audit/hardcoded_credentials.rs
+++ b/crates/zizmor/src/audit/hardcoded_credentials.rs
@@ -10,16 +10,17 @@ use crate::{
     state::AuditState,
 };
 
-pub(crate) struct HardcodedContainerCredentials;
+pub(crate) struct HardcodedCredentials;
 
 audit_meta!(
-    HardcodedContainerCredentials,
-    "hardcoded-container-credentials",
-    "hardcoded credential in GitHub Actions container configurations"
+    HardcodedCredentials,
+    "hardcoded-credentials",
+    "hardcoded credential is present",
+    &["hardcoded-container-credentials"]
 );
 
 #[async_trait::async_trait]
-impl Audit for HardcodedContainerCredentials {
+impl Audit for HardcodedCredentials {
     fn new(_state: &AuditState) -> Result<Self, AuditLoadError>
     where
         Self: Sized,

--- a/crates/zizmor/src/audit/mod.rs
+++ b/crates/zizmor/src/audit/mod.rs
@@ -35,7 +35,7 @@ pub(crate) mod excessive_permissions;
 pub(crate) mod forbidden_uses;
 pub(crate) mod github_app;
 pub(crate) mod github_env;
-pub(crate) mod hardcoded_container_credentials;
+pub(crate) mod hardcoded_credentials;
 pub(crate) mod impostor_commit;
 pub(crate) mod insecure_commands;
 pub(crate) mod insecure_url_scheme;
@@ -179,6 +179,13 @@ pub(crate) trait AuditCore {
     where
         Self: Sized;
 
+    fn aliases() -> &'static [&'static str]
+    where
+        Self: Sized,
+    {
+        &[]
+    }
+
     fn desc() -> &'static str
     where
         Self: Sized;
@@ -215,13 +222,19 @@ pub(crate) trait AuditCore {
 /// audit_meta!(SomeAudit, "some-audit", "brief description");
 /// ```
 macro_rules! audit_meta {
-    ($t:ty, $id:literal, $desc:expr_2021) => {
+    ($t:ty, $id:literal, $desc:expr_2021 $(, $aliases:expr_2021)?) => {
         use crate::audit::AuditCore;
 
         impl AuditCore for $t {
             fn ident() -> &'static str {
                 $id
             }
+
+            $(
+                fn aliases() -> &'static [&'static str] {
+                    $aliases
+                }
+            )?
 
             fn desc() -> &'static str
             where

--- a/crates/zizmor/src/config/mod.rs
+++ b/crates/zizmor/src/config/mod.rs
@@ -21,7 +21,7 @@ pub mod schema;
 use crate::{
     App, CollectionOptions,
     audit::{
-        AuditCore as _, dependabot_cooldown::DependabotCooldown, forbidden_uses::ForbiddenUses,
+        AuditCore, dependabot_cooldown::DependabotCooldown, forbidden_uses::ForbiddenUses,
         known_vulnerable_actions::KnownVulnerableActions,
         secrets_outside_env::SecretsOutsideEnvironment, unpinned_uses::UnpinnedUses,
     },
@@ -202,16 +202,21 @@ impl RawConfig {
         yaml_serde::from_str(contents).map_err(ConfigErrorInner::Syntax)
     }
 
-    fn rule_config<T>(&self, ident: &'static str) -> Result<Option<T>, ConfigErrorInner>
+    fn rule_config<A: AuditCore, T>(&self) -> Result<Option<T>, ConfigErrorInner>
     where
         T: DeserializeOwned,
     {
-        self.rules
-            .get(ident)
+        // Try the rule's primary identifier first, then each alias in order of appearance.
+        let mut candidates = std::iter::once(A::ident()).chain(A::aliases().iter().map(|a| *a));
+
+        // TODO: Should we be more aggressive here and require exclusivity, i.e. reject
+        // a config that has rule objects that match more than one candidate?
+        candidates
+            .find_map(|ident| self.rules.get(ident))
             .and_then(|rule_config| rule_config.config.as_ref())
             .map(|policy| yaml_serde::from_value::<T>(yaml_serde::Value::Mapping(policy.clone())))
             .transpose()
-            .map_err(|e| ConfigErrorInner::AuditSyntax(e, ident))
+            .map_err(|e| ConfigErrorInner::AuditSyntax(e, A::ident()))
     }
 }
 
@@ -500,20 +505,20 @@ impl Config {
         let raw = RawConfig::load(contents)?;
 
         let dependabot_cooldown_config = raw
-            .rule_config(DependabotCooldown::ident())?
+            .rule_config::<DependabotCooldown, DependabotCooldownConfig>()?
             .unwrap_or_default();
 
-        let forbidden_uses_config = raw.rule_config(ForbiddenUses::ident())?;
+        let forbidden_uses_config = raw.rule_config::<ForbiddenUses, ForbiddenUsesConfig>()?;
 
         let secrets_outside_env_config =
-            raw.rule_config::<SecretsOutsideEnvConfig>(SecretsOutsideEnvironment::ident())?;
+            raw.rule_config::<SecretsOutsideEnvironment, SecretsOutsideEnvConfig>()?;
         let secrets_outside_env_policy = secrets_outside_env_config
             .map(Into::into)
             .unwrap_or_default();
 
         let unpinned_uses_policies = {
             if let Some(unpinned_uses_config) =
-                raw.rule_config::<UnpinnedUsesConfig>(UnpinnedUses::ident())?
+                raw.rule_config::<UnpinnedUses, UnpinnedUsesConfig>()?
             {
                 UnpinnedUsesPolicies::try_from(unpinned_uses_config)?
             } else {
@@ -522,7 +527,7 @@ impl Config {
         };
 
         let known_vulnerable_actions_config = raw
-            .rule_config::<KnownVulnerableActionsConfig>(KnownVulnerableActions::ident())?
+            .rule_config::<KnownVulnerableActions, KnownVulnerableActionsConfig>()?
             .unwrap_or_default();
 
         Ok(Self {

--- a/crates/zizmor/src/registry.rs
+++ b/crates/zizmor/src/registry.rs
@@ -54,7 +54,7 @@ impl AuditRegistry {
         register_audit!(audit::ref_confusion::RefConfusion);
         register_audit!(audit::use_trusted_publishing::UseTrustedPublishing);
         register_audit!(audit::template_injection::TemplateInjection);
-        register_audit!(audit::hardcoded_container_credentials::HardcodedContainerCredentials);
+        register_audit!(audit::hardcoded_credentials::HardcodedCredentials);
         register_audit!(audit::self_hosted_runner::SelfHostedRunner);
         register_audit!(audit::known_vulnerable_actions::KnownVulnerableActions);
         register_audit!(audit::unpinned_uses::UnpinnedUses);


### PR DESCRIPTION
I don't think this approach is good. A better approach is probably to remap/rewrite the config at load time.

See #2232 