### PR TITLE
Suggest tags belonging to the action being used

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -51,7 +51,12 @@ impl Artipacked {
             match self.client {
                 Some(ref client) => {
                     let tag = client
-                        .longest_tag_for_commit(uses.owner(), uses.repo(), uses.git_ref())
+                        .longest_tag_for_commit(
+                            uses.owner(),
+                            uses.repo(),
+                            uses.subpath(),
+                            uses.git_ref(),
+                        )
                         .await?;
 
                     match tag {

--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -65,7 +65,7 @@ impl KnownVulnerableActions {
 
                 match self
                     .client
-                    .longest_tag_for_commit(uses.owner(), uses.repo(), &commit_ref)
+                    .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), &commit_ref)
                     .await
                     .map_err(Self::err)?
                 {
@@ -84,7 +84,7 @@ impl KnownVulnerableActions {
             commit_ref => {
                 match self
                     .client
-                    .longest_tag_for_commit(uses.owner(), uses.repo(), commit_ref)
+                    .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_ref)
                     .await
                     .map_err(Self::err)?
                 {

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -131,7 +131,7 @@ impl RefVersionMismatch {
                 // SHA-pinned action without a recognized version comment.
                 let Some(tag) = self
                     .client
-                    .longest_tag_for_commit(uses.owner(), uses.repo(), commit_sha)
+                    .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_sha)
                     .await
                     .map_err(Self::err)?
                 else {
@@ -208,7 +208,7 @@ impl RefVersionMismatch {
 
         if let Some(suggestion) = self
             .client
-            .longest_tag_for_commit(uses.owner(), uses.repo(), commit_sha)
+            .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_sha)
             .await
             .map_err(Self::err)?
         {

--- a/crates/zizmor/src/audit/stale_action_refs.rs
+++ b/crates/zizmor/src/audit/stale_action_refs.rs
@@ -30,7 +30,7 @@ impl StaleActionRefs {
         let tag = match &uses.commit_ref() {
             Some(commit_ref) => self
                 .client
-                .longest_tag_for_commit(uses.owner(), uses.repo(), commit_ref)
+                .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_ref)
                 .await
                 .map_err(Self::err)?,
             None => return Ok(false),

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -76,7 +76,7 @@ impl UnpinnedUses {
         // version avoids any later `ref-version-mismatch` findings when the
         // major tag is mutated by the upstream.
         let longest_tag = match client
-            .longest_tag_for_commit(uses.owner(), uses.repo(), &commit)
+            .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), &commit)
             .await
         {
             Ok(Some(tag)) => Cow::Owned(tag.name),

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -646,6 +646,7 @@ impl Client {
         &self,
         owner: &str,
         repo: &str,
+        subpath: Option<&str>,
         commit: &str,
     ) -> Result<Option<Tag>, ClientError> {
         // Annoying: GitHub doesn't provide a rev-parse or similar API to
@@ -655,13 +656,7 @@ impl Client {
         // is not pulling every tag eagerly before scanning them.
         let tags = self.list_tags(owner, repo).await?;
 
-        // Heuristic: there can be multiple tags for a commit, so we pick
-        // the longest one. This isn't super sound, but it gets us from
-        // `sha -> v1.2.3` instead of `sha -> v1`.
-        Ok(tags
-            .into_iter()
-            .filter(|t| t.commit.sha == commit)
-            .max_by_key(|t| t.name.len()))
+        Ok(best_tag_for_commit(tags, subpath, commit))
     }
 
     #[instrument(skip(self))]
@@ -996,6 +991,40 @@ pub(crate) struct Tag {
     pub(crate) commit: Commit,
 }
 
+/// Pick the tag that best describes `commit` for the action at `subpath`.
+///
+/// Repositories that publish several actions from subdirectories tag each one under its own
+/// prefix, so a single commit can carry `save/v1.0.0`, `restore/v1.0.0` and
+/// `allowlist-check/v1.0.0` at once. Picking purely by length would hand every action in such a
+/// repository whichever sibling has the longest name, so tags naming the action being used are
+/// preferred, and tags naming *some other* action are only used when nothing better exists.
+fn best_tag_for_commit(tags: Vec<Tag>, subpath: Option<&str>, commit: &str) -> Option<Tag> {
+    let candidates = tags.into_iter().filter(|t| t.commit.sha == commit);
+
+    // Heuristic: there can be multiple tags for a commit, so we pick
+    // the longest one. This isn't super sound, but it gets us from
+    // `sha -> v1.2.3` instead of `sha -> v1`.
+    let longest = |tags: Vec<Tag>| tags.into_iter().max_by_key(|t| t.name.len());
+
+    let (preferred, rest): (Vec<_>, Vec<_>) = match subpath {
+        // `owner/repo/stash/save` is released as `save/vX.Y.Z` or `stash/save/vX.Y.Z`.
+        Some(subpath) => {
+            let prefixes = [
+                format!("{subpath}/"),
+                format!(
+                    "{leaf}/",
+                    leaf = subpath.rsplit('/').next().unwrap_or(subpath)
+                ),
+            ];
+            candidates.partition(|t| prefixes.iter().any(|p| t.name.starts_with(p.as_str())))
+        }
+        // An action at the repository root is described by an unprefixed tag.
+        None => candidates.partition(|t| !t.name.contains('/')),
+    };
+
+    longest(preferred).or_else(|| longest(rest))
+}
+
 /// A single commit, as returned by GitHub's commits endpoints.
 ///
 /// This model is intentionally incomplete.
@@ -1069,7 +1098,80 @@ pub(crate) struct File {
 
 #[cfg(test)]
 mod tests {
-    use crate::github::{Client, GitHubHost, GitHubToken};
+    use crate::github::{Client, Commit, GitHubHost, GitHubToken, Tag, best_tag_for_commit};
+
+    fn tags(names: &[(&str, &str)]) -> Vec<Tag> {
+        names
+            .iter()
+            .map(|(name, sha)| Tag {
+                name: (*name).into(),
+                commit: Commit { sha: (*sha).into() },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_best_tag_for_commit() {
+        // A monorepo of actions, where every action is tagged under its own prefix
+        // and all of them happen to share a commit.
+        let monorepo = [
+            ("allowlist-check/v1", "abcd"),
+            ("allowlist-check/v1.0.0", "abcd"),
+            ("restore/v1", "abcd"),
+            ("restore/v1.0.0", "abcd"),
+            ("save/v1", "abcd"),
+            ("save/v1.0.0", "abcd"),
+        ];
+
+        for (subpath, expected) in [
+            // The action's own tag wins over a longer-named sibling's.
+            (Some("stash/save"), "save/v1.0.0"),
+            (Some("stash/restore"), "restore/v1.0.0"),
+            (Some("allowlist-check"), "allowlist-check/v1.0.0"),
+        ] {
+            assert_eq!(
+                best_tag_for_commit(tags(&monorepo), subpath, "abcd")
+                    .unwrap()
+                    .name,
+                expected
+            );
+        }
+
+        // Nothing names this action, so a sibling is better than no suggestion at all.
+        assert_eq!(
+            best_tag_for_commit(tags(&monorepo), Some("pelican"), "abcd")
+                .unwrap()
+                .name,
+            "allowlist-check/v1.0.0"
+        );
+
+        // Ordinary repositories are unaffected: longest tag at the commit still wins.
+        let plain = [("v1", "abcd"), ("v1.2.3", "abcd"), ("v2.0.0", "beef")];
+        assert_eq!(
+            best_tag_for_commit(tags(&plain), None, "abcd")
+                .unwrap()
+                .name,
+            "v1.2.3"
+        );
+        assert_eq!(
+            best_tag_for_commit(tags(&plain), Some("sub"), "abcd")
+                .unwrap()
+                .name,
+            "v1.2.3"
+        );
+
+        // A root action prefers an unprefixed tag over a subdirectory action's.
+        let mixed = [("v1.0.0", "abcd"), ("some-action/v1.0.0", "abcd")];
+        assert_eq!(
+            best_tag_for_commit(tags(&mixed), None, "abcd")
+                .unwrap()
+                .name,
+            "v1.0.0"
+        );
+
+        // Tags on other commits are never considered.
+        assert!(best_tag_for_commit(tags(&plain), None, "dead").is_none());
+    }
 
     #[test]
     fn test_github_host() {


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes https://github.com/zizmorcore/zizmor/issues/2243

In a repository that ships several actions from subdirectories and tags each under its own prefix, when Zizmor suggests auto-fix for actions, the longest_tag_for_commit picked the longest tag name among every tag at a commit, without knowing which action inside the repository was being used. , one commit carries several tags, so every action there was told about whichever sibling had the longest name — and that was offered as an auto-fix.

Concretely, for apache/infrastructure-actions/stash/save@61dcea11…, whose commit also carries restore/* and allowlist-check/* tags:

is pointed to by tag allowlist-check/v1.0.0
where the answer should be save/v1.0.0.

With this fix - the choice prefers a tag that names the action being used:

with a subpath, tags prefixed by the full subpath (stash/save/) or its leaf (save/);
without one, tags containing no /, so a root action does not use subdirectory action's tag;
otherwise the previous longest-tag-at-this-commit behaviour, unchanged, so repositories that do not use prefixed tags behave exactly as before — including the fallback where nothing names the action and a sibling is still better than no suggestion.
Validation was already correct and is untouched: commit_for_ref matches tag names exactly and peels annotated tags, so a correct # save/v1.0.0 comment resolves to the pinned commit and produces no finding. Only the suggestion side was wrong.

Note for review: 7 tests in known_vulnerable_actions fail on my machine both with and without this change (108 passed / 7 failed on a clean tree, 109 / 7 with it — the extra pass being the new test), so I have assumed they are environmental rather than related.


## Test Plan

`github::tests::test_best_tag_for_commit` unit tests the selection over a synthetic tag set modelled on the real `apache/infrastructure-actions` tags, covering:

* each of `stash/save`, `stash/restore` and `allowlist-check` getting its own tag rather than the longest sibling;
* an action with no tag of its own still falling back to a sibling;
* repositories without prefixed tags keeping the previous longest-tag behaviour, with and without a subpath;
* a root action preferring an unprefixed tag over a subdirectory action's;
* tags on other commits never being considered.

Note for review: 7 tests in `known_vulnerable_actions` fail on my machine both with and without this change (108 passed / 7 failed on a clean tree, 109 / 7 with it — the extra pass being the new test), so I have assumed they are environmental rather than related.

