### PR TITLE
Suggest tags belonging to the action being used

### DIFF
--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -50,7 +50,7 @@ impl Artipacked {
             match self.client {
                 Some(ref client) => {
                     let tag = client
-                        .longest_tag_for_commit(&uses.into(), uses.git_ref())
+                        .longest_tag_for_commit(&uses.into(), uses.subpath(), uses.git_ref())
                         .await?;
 
                     match tag {

--- a/crates/zizmor/src/audit/artipacked.rs
+++ b/crates/zizmor/src/audit/artipacked.rs
@@ -51,7 +51,12 @@ impl Artipacked {
             match self.client {
                 Some(ref client) => {
                     let tag = client
-                        .longest_tag_for_commit(uses.owner(), uses.repo(), uses.git_ref())
+                        .longest_tag_for_commit(
+                            uses.owner(),
+                            uses.repo(),
+                            uses.subpath(),
+                            uses.git_ref(),
+                        )
                         .await?;
 
                     match tag {

--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -65,7 +65,7 @@ impl KnownVulnerableActions {
 
                 match self
                     .client
-                    .longest_tag_for_commit(uses.owner(), uses.repo(), &commit_ref)
+                    .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), &commit_ref)
                     .await
                     .map_err(Self::err)?
                 {
@@ -84,7 +84,7 @@ impl KnownVulnerableActions {
             commit_ref => {
                 match self
                     .client
-                    .longest_tag_for_commit(uses.owner(), uses.repo(), commit_ref)
+                    .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_ref)
                     .await
                     .map_err(Self::err)?
                 {

--- a/crates/zizmor/src/audit/known_vulnerable_actions.rs
+++ b/crates/zizmor/src/audit/known_vulnerable_actions.rs
@@ -73,7 +73,7 @@ impl KnownVulnerableActions {
 
                 match self
                     .client
-                    .longest_tag_for_commit(&slug, commit_ref.commit())
+                    .longest_tag_for_commit(&slug, repo_ref.subpath(), commit_ref.commit())
                     .await
                     .map_err(Self::err)?
                 {
@@ -92,7 +92,7 @@ impl KnownVulnerableActions {
             commit_ref => {
                 match self
                     .client
-                    .longest_tag_for_commit(&slug, commit_ref)
+                    .longest_tag_for_commit(&slug, repo_ref.subpath(), commit_ref)
                     .await
                     .map_err(Self::err)?
                 {

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -131,7 +131,7 @@ impl RefVersionMismatch {
                 // SHA-pinned action without a recognized version comment.
                 let Some(tag) = self
                     .client
-                    .longest_tag_for_commit(uses.owner(), uses.repo(), commit_sha)
+                    .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_sha)
                     .await
                     .map_err(Self::err)?
                 else {
@@ -208,7 +208,7 @@ impl RefVersionMismatch {
 
         if let Some(suggestion) = self
             .client
-            .longest_tag_for_commit(uses.owner(), uses.repo(), commit_sha)
+            .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_sha)
             .await
             .map_err(Self::err)?
         {

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -115,7 +115,7 @@ impl RefVersionMismatch {
                 // SHA-pinned action without a recognized version comment.
                 let Some(tag) = self
                     .client
-                    .longest_tag_for_commit(&uses.into(), commit_sha)
+                    .longest_tag_for_commit(&uses.into(), uses.subpath(), commit_sha)
                     .await
                     .map_err(Self::err)?
                 else {
@@ -193,7 +193,7 @@ impl RefVersionMismatch {
 
         if let Some(suggestion) = self
             .client
-            .longest_tag_for_commit(&uses.into(), commit_sha)
+            .longest_tag_for_commit(&uses.into(), uses.subpath(), commit_sha)
             .await
             .map_err(Self::err)?
         {

--- a/crates/zizmor/src/audit/stale_action_refs.rs
+++ b/crates/zizmor/src/audit/stale_action_refs.rs
@@ -30,7 +30,7 @@ impl StaleActionRefs {
         let tag = match &uses.commit_ref() {
             Some(commit_ref) => self
                 .client
-                .longest_tag_for_commit(uses.owner(), uses.repo(), commit_ref)
+                .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), commit_ref)
                 .await
                 .map_err(Self::err)?,
             None => return Ok(false),

--- a/crates/zizmor/src/audit/stale_action_refs.rs
+++ b/crates/zizmor/src/audit/stale_action_refs.rs
@@ -30,7 +30,7 @@ impl StaleActionRefs {
         let tag = match uses.commit_ref() {
             Some(commit_ref) => self
                 .client
-                .longest_tag_for_commit(&uses.into(), commit_ref)
+                .longest_tag_for_commit(&uses.into(), uses.subpath(), commit_ref)
                 .await
                 .map_err(Self::err)?,
             None => return Ok(false),

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -76,7 +76,7 @@ impl UnpinnedUses {
         // version avoids any later `ref-version-mismatch` findings when the
         // major tag is mutated by the upstream.
         let longest_tag = match client
-            .longest_tag_for_commit(uses.owner(), uses.repo(), &commit)
+            .longest_tag_for_commit(uses.owner(), uses.repo(), uses.subpath(), &commit)
             .await
         {
             Ok(Some(tag)) => Cow::Owned(tag.name),

--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -73,7 +73,7 @@ impl UnpinnedUses {
         // version avoids any later `ref-version-mismatch` findings when the
         // major tag is mutated by the upstream.
         let longest_tag = match client
-            .longest_tag_for_commit(&uses.into(), git_ref.commit())
+            .longest_tag_for_commit(&uses.into(), uses.subpath(), git_ref.commit())
             .await
         {
             Ok(Some(tag)) => Cow::Owned(tag.name),

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -667,11 +667,8 @@ impl Client {
         subpath: Option<&str>,
         commit: &str,
     ) -> Result<Option<Tag>, ClientError> {
-        // Annoying: GitHub doesn't provide a rev-parse or similar API to
-        // perform the commit -> tag lookup, so we download every tag and
-        // do it for them.
-        // This could be optimized in various ways, not least of which
-        // is not pulling every tag eagerly before scanning them.
+        // This was once slow, but is now fast (enough) since we use
+        // a raw Git `ls-refs` under the hood.
         let tags = self.list_tags(slug).await?;
 
         Ok(best_tag_for_commit(tags, subpath, commit))
@@ -1008,36 +1005,55 @@ pub(crate) struct Tag {
 
 /// Pick the tag that best describes `commit` for the action at `subpath`.
 ///
-/// Repositories that publish several actions from subdirectories tag each one under its own
-/// prefix, so a single commit can carry `save/v1.0.0`, `restore/v1.0.0` and
-/// `allowlist-check/v1.0.0` at once. Picking purely by length would hand every action in such a
-/// repository whichever sibling has the longest name, so tags naming the action being used are
-/// preferred, and tags naming *some other* action are only used when nothing better exists.
+/// This involves two heuristics:
+///
+/// 1. The tag that most closely matches the "intent" of the action reference.
+///    This is complicated because GitHub allows a single repository to host multiple
+///    actions, and some repositories choose to version their actions fully independently
+///    while *also* allowing them to overlap (in the sense that a single commit may
+///    be pointed to by several tags, e.g. `foo/v1` and `bar/v1` might both point to
+///    `abcd...`).
+///
+///    We handle this with a *very* naive prefix match: we look for a tag that
+///    matches `{subpath}/...` or `{leaf}/...`, where `{leaf}` is the last
+///    directory in the subpath.
+///
+/// 2. The longest tag. Many repositories (inadvisedly) attempt to imitate SemVer
+///    by publishing several tags, which then get moved around to imitate version bumps.
+///    For example, `v4` and `v4.0.0` might both point to `abcd...`, but `v4` will eventually
+///    be moved whereas `v4.0.0` will (hopefully) remain fixed. This kind of mutable reference
+///    is bad, but people do it, and we don't want to resolve to a likely mutable reference
+///    if we can avoid it
+///
+///    We handle this by selecting the longest tag for a commit.
+///
+/// Put together, we prefer the longest tag that has a matching prefix,
+/// followed by a tag that has a matching prefix, followed by any longest tag.
 fn best_tag_for_commit(tags: Vec<Tag>, subpath: Option<&str>, commit: &str) -> Option<Tag> {
-    let candidates = tags.into_iter().filter(|t| t.commit.sha == commit);
+    // Heuristic: `owner/repo/stash/save` might be released as either `save/vX.Y.Z`
+    // or `stash/save/vX.Y.Z`.
+    let preferred_prefixes = subpath.map(|subpath| {
+        let leaf = subpath.rsplit_once('/').map_or(subpath, |(_, leaf)| leaf);
+        [subpath, leaf]
+    });
 
-    // Heuristic: there can be multiple tags for a commit, so we pick
-    // the longest one. This isn't super sound, but it gets us from
-    // `sha -> v1.2.3` instead of `sha -> v1`.
-    let longest = |tags: Vec<Tag>| tags.into_iter().max_by_key(|t| t.name.len());
+    tags.into_iter()
+        .filter(|tag| tag.commit.sha == commit)
+        .max_by_key(|tag| {
+            let is_preferred = match preferred_prefixes.as_ref() {
+                Some(prefixes) => prefixes.iter().any(|prefix| {
+                    tag.name
+                        .strip_prefix(prefix)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+                }),
+                // An action at the repository root is described by an unprefixed tag.
+                None => !tag.name.contains('/'),
+            };
 
-    let (preferred, rest): (Vec<_>, Vec<_>) = match subpath {
-        // `owner/repo/stash/save` is released as `save/vX.Y.Z` or `stash/save/vX.Y.Z`.
-        Some(subpath) => {
-            let prefixes = [
-                format!("{subpath}/"),
-                format!(
-                    "{leaf}/",
-                    leaf = subpath.rsplit('/').next().unwrap_or(subpath)
-                ),
-            ];
-            candidates.partition(|t| prefixes.iter().any(|p| t.name.starts_with(p.as_str())))
-        }
-        // An action at the repository root is described by an unprefixed tag.
-        None => candidates.partition(|t| !t.name.contains('/')),
-    };
-
-    longest(preferred).or_else(|| longest(rest))
+            // Prefer a tag for this action, then use length to choose its most
+            // specific version (`v1.2.3` rather than `v1`).
+            (is_preferred, tag.name.len())
+        })
 }
 
 /// A single commit, as returned by GitHub's commits endpoints.
@@ -1144,7 +1160,9 @@ mod tests {
         for (subpath, expected) in [
             // The action's own tag wins over a longer-named sibling's.
             (Some("stash/save"), "save/v1.0.0"),
+            (Some("save"), "save/v1.0.0"),
             (Some("stash/restore"), "restore/v1.0.0"),
+            (Some("restore"), "restore/v1.0.0"),
             (Some("allowlist-check"), "allowlist-check/v1.0.0"),
         ] {
             assert_eq!(

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -664,6 +664,7 @@ impl Client {
     pub(crate) async fn longest_tag_for_commit(
         &self,
         slug: &Slug<'_>,
+        subpath: Option<&str>,
         commit: &str,
     ) -> Result<Option<Tag>, ClientError> {
         // Annoying: GitHub doesn't provide a rev-parse or similar API to
@@ -673,13 +674,7 @@ impl Client {
         // is not pulling every tag eagerly before scanning them.
         let tags = self.list_tags(slug).await?;
 
-        // Heuristic: there can be multiple tags for a commit, so we pick
-        // the longest one. This isn't super sound, but it gets us from
-        // `sha -> v1.2.3` instead of `sha -> v1`.
-        Ok(tags
-            .into_iter()
-            .filter(|t| t.commit.sha == commit)
-            .max_by_key(|t| t.name.len()))
+        Ok(best_tag_for_commit(tags, subpath, commit))
     }
 
     #[instrument(skip(self))]
@@ -1011,6 +1006,40 @@ pub(crate) struct Tag {
     pub(crate) commit: Commit,
 }
 
+/// Pick the tag that best describes `commit` for the action at `subpath`.
+///
+/// Repositories that publish several actions from subdirectories tag each one under its own
+/// prefix, so a single commit can carry `save/v1.0.0`, `restore/v1.0.0` and
+/// `allowlist-check/v1.0.0` at once. Picking purely by length would hand every action in such a
+/// repository whichever sibling has the longest name, so tags naming the action being used are
+/// preferred, and tags naming *some other* action are only used when nothing better exists.
+fn best_tag_for_commit(tags: Vec<Tag>, subpath: Option<&str>, commit: &str) -> Option<Tag> {
+    let candidates = tags.into_iter().filter(|t| t.commit.sha == commit);
+
+    // Heuristic: there can be multiple tags for a commit, so we pick
+    // the longest one. This isn't super sound, but it gets us from
+    // `sha -> v1.2.3` instead of `sha -> v1`.
+    let longest = |tags: Vec<Tag>| tags.into_iter().max_by_key(|t| t.name.len());
+
+    let (preferred, rest): (Vec<_>, Vec<_>) = match subpath {
+        // `owner/repo/stash/save` is released as `save/vX.Y.Z` or `stash/save/vX.Y.Z`.
+        Some(subpath) => {
+            let prefixes = [
+                format!("{subpath}/"),
+                format!(
+                    "{leaf}/",
+                    leaf = subpath.rsplit('/').next().unwrap_or(subpath)
+                ),
+            ];
+            candidates.partition(|t| prefixes.iter().any(|p| t.name.starts_with(p.as_str())))
+        }
+        // An action at the repository root is described by an unprefixed tag.
+        None => candidates.partition(|t| !t.name.contains('/')),
+    };
+
+    longest(preferred).or_else(|| longest(rest))
+}
+
 /// A single commit, as returned by GitHub's commits endpoints.
 ///
 /// This model is intentionally incomplete.
@@ -1085,9 +1114,82 @@ pub(crate) struct File {
 #[cfg(test)]
 mod tests {
     use crate::{
-        github::{Client, GitHubHost, GitHubToken},
+        github::{Client, Commit, GitHubHost, GitHubToken, Tag, best_tag_for_commit},
         models::repo_ref::Slug,
     };
+
+    fn tags(names: &[(&str, &str)]) -> Vec<Tag> {
+        names
+            .iter()
+            .map(|(name, sha)| Tag {
+                name: (*name).into(),
+                commit: Commit { sha: (*sha).into() },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_best_tag_for_commit() {
+        // A monorepo of actions, where every action is tagged under its own prefix
+        // and all of them happen to share a commit.
+        let monorepo = [
+            ("allowlist-check/v1", "abcd"),
+            ("allowlist-check/v1.0.0", "abcd"),
+            ("restore/v1", "abcd"),
+            ("restore/v1.0.0", "abcd"),
+            ("save/v1", "abcd"),
+            ("save/v1.0.0", "abcd"),
+        ];
+
+        for (subpath, expected) in [
+            // The action's own tag wins over a longer-named sibling's.
+            (Some("stash/save"), "save/v1.0.0"),
+            (Some("stash/restore"), "restore/v1.0.0"),
+            (Some("allowlist-check"), "allowlist-check/v1.0.0"),
+        ] {
+            assert_eq!(
+                best_tag_for_commit(tags(&monorepo), subpath, "abcd")
+                    .unwrap()
+                    .name,
+                expected
+            );
+        }
+
+        // Nothing names this action, so a sibling is better than no suggestion at all.
+        assert_eq!(
+            best_tag_for_commit(tags(&monorepo), Some("pelican"), "abcd")
+                .unwrap()
+                .name,
+            "allowlist-check/v1.0.0"
+        );
+
+        // Ordinary repositories are unaffected: longest tag at the commit still wins.
+        let plain = [("v1", "abcd"), ("v1.2.3", "abcd"), ("v2.0.0", "beef")];
+        assert_eq!(
+            best_tag_for_commit(tags(&plain), None, "abcd")
+                .unwrap()
+                .name,
+            "v1.2.3"
+        );
+        assert_eq!(
+            best_tag_for_commit(tags(&plain), Some("sub"), "abcd")
+                .unwrap()
+                .name,
+            "v1.2.3"
+        );
+
+        // A root action prefers an unprefixed tag over a subdirectory action's.
+        let mixed = [("v1.0.0", "abcd"), ("some-action/v1.0.0", "abcd")];
+        assert_eq!(
+            best_tag_for_commit(tags(&mixed), None, "abcd")
+                .unwrap()
+                .name,
+            "v1.0.0"
+        );
+
+        // Tags on other commits are never considered.
+        assert!(best_tag_for_commit(tags(&plain), None, "dead").is_none());
+    }
 
     #[test]
     fn test_github_host() {

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -646,6 +646,7 @@ impl Client {
         &self,
         owner: &str,
         repo: &str,
+        subpath: Option<&str>,
         commit: &str,
     ) -> Result<Option<Tag>, ClientError> {
         // Annoying: GitHub doesn't provide a rev-parse or similar API to
@@ -655,13 +656,7 @@ impl Client {
         // is not pulling every tag eagerly before scanning them.
         let tags = self.list_tags(owner, repo).await?;
 
-        // Heuristic: there can be multiple tags for a commit, so we pick
-        // the longest one. This isn't super sound, but it gets us from
-        // `sha -> v1.2.3` instead of `sha -> v1`.
-        Ok(tags
-            .into_iter()
-            .filter(|t| t.commit.sha == commit)
-            .max_by_key(|t| t.name.len()))
+        Ok(best_tag_for_commit(tags, subpath, commit))
     }
 
     #[instrument(skip(self))]
@@ -996,6 +991,40 @@ pub(crate) struct Tag {
     pub(crate) commit: Commit,
 }
 
+/// Pick the tag that best describes `commit` for the action at `subpath`.
+///
+/// Repositories that publish several actions from subdirectories tag each one under its own
+/// prefix, so a single commit can carry `save/v1.0.0`, `restore/v1.0.0` and
+/// `allowlist-check/v1.0.0` at once. Picking purely by length would hand every action in such a
+/// repository whichever sibling has the longest name, so tags naming the action being used are
+/// preferred, and tags naming *some other* action are only used when nothing better exists.
+fn best_tag_for_commit(tags: Vec<Tag>, subpath: Option<&str>, commit: &str) -> Option<Tag> {
+    let candidates = tags.into_iter().filter(|t| t.commit.sha == commit);
+
+    // Heuristic: there can be multiple tags for a commit, so we pick
+    // the longest one. This isn't super sound, but it gets us from
+    // `sha -> v1.2.3` instead of `sha -> v1`.
+    let longest = |tags: Vec<Tag>| tags.into_iter().max_by_key(|t| t.name.len());
+
+    let (preferred, rest): (Vec<_>, Vec<_>) = match subpath {
+        // `owner/repo/stash/save` is released as `save/vX.Y.Z` or `stash/save/vX.Y.Z`.
+        Some(subpath) => {
+            let prefixes = [
+                format!("{subpath}/"),
+                format!(
+                    "{leaf}/",
+                    leaf = subpath.rsplit('/').next().unwrap_or(subpath)
+                ),
+            ];
+            candidates.partition(|t| prefixes.iter().any(|p| t.name.starts_with(p.as_str())))
+        }
+        // An action at the repository root is described by an unprefixed tag.
+        None => candidates.partition(|t| !t.name.contains('/')),
+    };
+
+    longest(preferred).or_else(|| longest(rest))
+}
+
 /// A single commit, as returned by GitHub's commits endpoints.
 ///
 /// This model is intentionally incomplete.
@@ -1069,7 +1098,80 @@ pub(crate) struct File {
 
 #[cfg(test)]
 mod tests {
-    use crate::github::{Client, GitHubHost, GitHubToken};
+    use crate::github::{Client, Commit, GitHubHost, GitHubToken, Tag, best_tag_for_commit};
+
+    fn tags(names: &[(&str, &str)]) -> Vec<Tag> {
+        names
+            .iter()
+            .map(|(name, sha)| Tag {
+                name: (*name).into(),
+                commit: Commit { sha: (*sha).into() },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_best_tag_for_commit() {
+        // A monorepo of actions, where every action is tagged under its own prefix
+        // and all of them happen to share a commit.
+        let monorepo = [
+            ("allowlist-check/v1", "abcd"),
+            ("allowlist-check/v1.0.0", "abcd"),
+            ("restore/v1", "abcd"),
+            ("restore/v1.0.0", "abcd"),
+            ("save/v1", "abcd"),
+            ("save/v1.0.0", "abcd"),
+        ];
+
+        for (subpath, expected) in [
+            // The action's own tag wins over a longer-named sibling's.
+            (Some("stash/save"), "save/v1.0.0"),
+            (Some("stash/restore"), "restore/v1.0.0"),
+            (Some("allowlist-check"), "allowlist-check/v1.0.0"),
+        ] {
+            assert_eq!(
+                best_tag_for_commit(tags(&monorepo), subpath, "abcd")
+                    .unwrap()
+                    .name,
+                expected
+            );
+        }
+
+        // Nothing names this action, so a sibling is better than no suggestion at all.
+        assert_eq!(
+            best_tag_for_commit(tags(&monorepo), Some("pelican"), "abcd")
+                .unwrap()
+                .name,
+            "allowlist-check/v1.0.0"
+        );
+
+        // Ordinary repositories are unaffected: longest tag at the commit still wins.
+        let plain = [("v1", "abcd"), ("v1.2.3", "abcd"), ("v2.0.0", "beef")];
+        assert_eq!(
+            best_tag_for_commit(tags(&plain), None, "abcd")
+                .unwrap()
+                .name,
+            "v1.2.3"
+        );
+        assert_eq!(
+            best_tag_for_commit(tags(&plain), Some("sub"), "abcd")
+                .unwrap()
+                .name,
+            "v1.2.3"
+        );
+
+        // A root action prefers an unprefixed tag over a subdirectory action's.
+        let mixed = [("v1.0.0", "abcd"), ("some-action/v1.0.0", "abcd")];
+        assert_eq!(
+            best_tag_for_commit(tags(&mixed), None, "abcd")
+                .unwrap()
+                .name,
+            "v1.0.0"
+        );
+
+        // Tags on other commits are never considered.
+        assert!(best_tag_for_commit(tags(&plain), None, "dead").is_none());
+    }
 
     #[test]
     fn test_github_host() {

--- a/crates/zizmor/src/github.rs
+++ b/crates/zizmor/src/github.rs
@@ -1134,18 +1134,17 @@ mod tests {
         models::repo_ref::Slug,
     };
 
-    fn tags(names: &[(&str, &str)]) -> Vec<Tag> {
-        names
-            .iter()
-            .map(|(name, sha)| Tag {
-                name: (*name).into(),
-                commit: Commit { sha: (*sha).into() },
-            })
-            .collect()
-    }
-
     #[test]
     fn test_best_tag_for_commit() {
+        fn tags(names: &[(&str, &str)]) -> Vec<Tag> {
+            names
+                .iter()
+                .map(|(name, sha)| Tag {
+                    name: (*name).into(),
+                    commit: Commit { sha: (*sha).into() },
+                })
+                .collect()
+        }
         // A monorepo of actions, where every action is tagged under its own prefix
         // and all of them happen to share a commit.
         let monorepo = [

--- a/crates/zizmor/src/models/repo_ref.rs
+++ b/crates/zizmor/src/models/repo_ref.rs
@@ -123,6 +123,18 @@ impl<'doc> RepoRef<'doc> {
         }
     }
 
+    /// Returns the subpath to the action within this repository, if it has one.
+    ///
+    /// Only a `uses:` clause can carry a subpath, as in
+    /// `owner/repo/subpath@ref`. A Git URL reference has no notion of one,
+    /// since the URL names the repository and nothing within it.
+    pub(crate) fn subpath(&self) -> Option<&'doc str> {
+        match self {
+            RepoRef::Uses(uses) => uses.subpath(),
+            RepoRef::Url { .. } => None,
+        }
+    }
+
     /// Return this repository reference's Git reference, if it has one.
     pub(crate) fn git_ref(&self) -> &'doc str {
         match self {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -74,6 +74,11 @@ of `zizmor`.
 * Fixed a bug where the [artipacked] audit would incorrectly flag the `#!yaml with:`
   clauses of unrelated actions (#2339)
 
+* Fixed a class of bugs where zizmor would incorrectly match an action's commit to a sibling
+  action's tag (#2247)
+
+    Many thanks to @potiuk for proposing and implementing this improvement!
+
 ## 1.29.0
 
 ### New Features 🌈


### PR DESCRIPTION
A repository that ships several actions from subdirectories tags each one under its own prefix, so a single commit can carry save/v1.0.0, restore/v1.0.0 and allowlist-check/v1.0.0 at once. Choosing purely by length hands every action in such a repository whichever sibling happens to have the longest name, and offers that as an auto-fix, so accepting it writes another action's version into the workflow.

Prefer a tag that names the action being used, keep the previous choice for everything else, and fall back to it when nothing names the action.

<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

Disclosure: Generated with help of LLM.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes https://github.com/zizmorcore/zizmor/issues/2243

In a repository that ships several actions from subdirectories and tags each under its own prefix, when Zizmor suggests auto-fix for actions, the longest_tag_for_commit picked the longest tag name among every tag at a commit, without knowing which action inside the repository was being used. , one commit carries several tags, so every action there was told about whichever sibling had the longest name — and that was offered as an auto-fix.

Concretely, for https://github.com/apache/infrastructure-actions/commit/61dcea11…, whose commit also carries restore/* and allowlist-check/* tags:

is pointed to by tag allowlist-check/v1.0.0
where the answer should be save/v1.0.0.

With this fix - the choice prefers a tag that names the action being used:

with a subpath, tags prefixed by the full subpath (stash/save/) or its leaf (save/);
without one, tags containing no /, so a root action does not use subdirectory action's tag;
otherwise the previous longest-tag-at-this-commit behaviour, unchanged, so repositories that do not use prefixed tags behave exactly as before — including the fallback where nothing names the action and a sibling is still better than no suggestion.
Validation was already correct and is untouched: commit_for_ref matches tag names exactly and peels annotated tags, so a correct # save/v1.0.0 comment resolves to the pinned commit and produces no finding. Only the suggestion side was **wrong.**

## Test Plan

Added unit tests covering the pure function that resolves best match.

Note for review: 7 tests in known_vulnerable_actions fail on my machine both with and without this change (108 passed / 7 failed on a clean tree, 109 / 7 with it — the extra pass being the new test), so I have assumed they are environmental rather than related.


<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
