### PR TITLE
Handle prek's `builtin` repo type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ tree-sitter-powershell = "=0.26.4"
 tree-sitter-yaml = "0.7.2"
 tikv-jemallocator = "0.7"
 typomania = { version = "0.2.0", default-features = false }
-url = "2.5.8"
+url = { version = "2.5.8", features = ["serde"] }
 walkdir = "2.5.0"
 
 [workspace.lints.rust]

--- a/crates/pre-commit-models/src/config.rs
+++ b/crates/pre-commit-models/src/config.rs
@@ -71,6 +71,12 @@ pub enum Repo {
     /// See: <https://pre-commit.com/#meta-hooks>
     // TODO: Fill this in, it's a fixed set of IDs for hooks.
     Meta {},
+    /// A special 'builtin` repository, for hooks defined by prek itself.
+    ///
+    /// This is a prek-specific extension.
+    ///
+    /// See: <https://prek.j178.dev/builtin/#2-explicit-builtin-repository>
+    Builtin {},
     #[serde(untagged)]
     Remote(RemoteRepo),
 }

--- a/crates/pre-commit-models/tests/sample-configs/builtin.yml
+++ b/crates/pre-commit-models/tests/sample-configs/builtin.yml
@@ -1,0 +1,12 @@
+---
+fail_fast: false
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+repos:
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^dist/
+      - id: check-yaml
+        args: [--allow-multiple-documents]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ of `zizmor`.
 
 * The [impostor-commit] audit now supports pre-commit config inputs (#2256)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`
+  input containing a `prek`-specific `builtin` section (#2259)
+
 ## 1.29.0
 
 ### New Features 🌈


### PR DESCRIPTION
This is a prek extension to pre-commit, but it's easy enough for us to handle (since it doesn't require any additional analysis, at least for now).

Fixes #2258.