### PR TITLE
Add shell completion examples

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -354,14 +354,11 @@ shells. It supports all of the shells supported by
 [`clap_complete`](https://crates.io/crates/clap_complete),
 which includes popular shells like `bash`, `zsh`, and `fish`.
 
-To enable tab completion, you can use the `--completions=<shell>` flag
-to emit a completion script for the specified shell.
-
 !!! tip
 
     You can run `echo $SHELL` to help you determine your shell.
 
-Run one of the following:
+To enable shell autocompletion for zizmor, run one of the following:
 
 === "Bash"
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -355,13 +355,52 @@ shells. It supports all of the shells supported by
 which includes popular shells like `bash`, `zsh`, and `fish`.
 
 To enable tab completion, you can use the `--completions=<shell>` flag
-to emit a completion script for the specified shell. For example,
-to enable tab completion for `bash`, you can run:
+to emit a completion script for the specified shell.
 
-```bash
-zizmor --completions=bash > ~/.bash_completion.d/zizmor # (1)!
-```
+!!! tip
 
-1. The correct location of your completion script will depend on your
-   shell and its configuration. Consult your shell's documentation
-   for more information.
+    You can run `echo $SHELL` to help you determine your shell.
+
+Run one of the following:
+
+=== "Bash"
+
+    ```bash
+    echo 'eval "$(zizmor --completions bash)"' >> ~/.bashrc
+    ```
+
+=== "Zsh"
+
+    ```bash
+    echo 'eval "$(zizmor --completions zsh)"' >> ~/.zshrc
+    ```
+
+=== "fish"
+
+    ```bash
+    echo 'zizmor --completions fish | source' > ~/.config/fish/completions/zizmor.fish
+    ```
+
+=== "Elvish"
+
+    ```bash
+    echo 'eval (zizmor --completions elvish | slurp)' >> ~/.elvish/rc.elv
+    ```
+
+=== "PowerShell / pwsh"
+
+    ```powershell
+    if (!(Test-Path -Path $PROFILE)) {
+      New-Item -ItemType File -Path $PROFILE -Force
+    }
+    Add-Content -Path $PROFILE -Value '(& zizmor --completions powershell) | Out-String | Invoke-Expression'
+    ```
+
+=== "Nushell"
+
+    ```nu
+    mkdir ($nu.user-autoload-dirs | first)
+    zizmor --completions nushell | save --force ($nu.user-autoload-dirs | first | path join zizmor.nu)
+    ```
+
+Then restart your shell or source your shell configuration file.


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Like in [ty](https://docs.astral.sh/ty/installation/#shell-autocompletion), [uv](https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion) and [ruff](https://docs.astral.sh/ruff/configuration/#shell-autocompletion), I find it very useful to see examples of how to actually install the completions for other shells.

Codex made the code changes here, after prompting it to copy from ruff and adapt to zizmor.

I have not created an issue for this since it is just a small documentation change.

## Test Plan

Ran `make site-live`, and here is the updated documentation.

<img width="2267" height="1034" alt="image" src="https://github.com/user-attachments/assets/acface93-65fa-4415-bc69-b97b0de219d1" />


<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
