### PR TITLE
feat(ref-confusion): add audit for pre-commit-config

### DIFF
--- a/crates/zizmor/src/audit/ref_confusion.rs
+++ b/crates/zizmor/src/audit/ref_confusion.rs
@@ -13,6 +13,7 @@ use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::audit::AuditError;
 use crate::finding::Finding;
 use crate::finding::location::Locatable as _;
+use crate::models::pre_commit::PreCommitConfig;
 use crate::models::repo_ref::RepoRef;
 use crate::models::{StepCommon as _, action::CompositeStep};
 use crate::{
@@ -167,6 +168,42 @@ impl Audit for RefConfusion {
                     .build(step)
                     .map_err(Self::err)?,
             );
+        }
+
+        Ok(findings)
+    }
+
+    async fn audit_pre_commit_config<'doc>(
+        &self,
+        pre_commit: &'doc PreCommitConfig,
+        _config: &crate::config::Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let mut findings = vec![];
+
+        for repo in pre_commit.repos() {
+            let Some(remote) = repo.repo() else {
+                continue;
+            };
+
+            if self.confusable(remote).await? {
+                findings.push(
+                    Self::finding()
+                        .severity(Severity::Medium)
+                        .confidence(Confidence::High)
+                        .add_location(
+                            repo.location()
+                                .with_keys(["repo".into()])
+                                .annotated("this repo"),
+                        )
+                        .add_location(
+                            repo.location()
+                                .primary()
+                                .with_keys(["rev".into()])
+                                .annotated(REF_CONFUSION_ANNOTATION),
+                        )
+                        .build(pre_commit)?,
+                )
+            }
         }
 
         Ok(findings)

--- a/crates/zizmor/src/audit/ref_confusion.rs
+++ b/crates/zizmor/src/audit/ref_confusion.rs
@@ -8,6 +8,7 @@
 
 use anyhow::anyhow;
 use github_actions_models::common::Uses;
+use subfeature::Subfeature;
 
 use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::audit::AuditError;
@@ -193,12 +194,14 @@ impl Audit for RefConfusion {
                         .add_location(
                             repo.location()
                                 .with_keys(["repo".into()])
+                                .subfeature(Subfeature::new(0, remote.repo.as_str()))
                                 .annotated("this repo"),
                         )
                         .add_location(
                             repo.location()
                                 .primary()
                                 .with_keys(["rev".into()])
+                                .subfeature(Subfeature::new(0, remote.rev.as_str()))
                                 .annotated(REF_CONFUSION_ANNOTATION),
                         )
                         .build(pre_commit)?,

--- a/crates/zizmor/tests/integration/audit/ref_confusion.rs
+++ b/crates/zizmor/tests/integration/audit/ref_confusion.rs
@@ -35,12 +35,12 @@ fn test_ref_confusion_pre_commit() -> Result<()> {
             .run()?,
         @"
     warning[ref-confusion]: git ref for action with ambiguous ref type
-     --> @@INPUT@@:3:5
+     --> @@INPUT@@:3:10
       |
     2 |   - repo: https://github.com/woodruffw/gha-hazmat
-      |     --------------------------------------------- this repo
+      |           --------------------------------------- this repo
     3 |     rev: confusable
-      |     ^^^^^^^^^^^^^^^ uses a ref that's provided by both the branch and tag namespaces
+      |          ^^^^^^^^^^ uses a ref that's provided by both the branch and tag namespaces
       |
       = note: audit confidence → High
 

--- a/crates/zizmor/tests/integration/audit/ref_confusion.rs
+++ b/crates/zizmor/tests/integration/audit/ref_confusion.rs
@@ -27,6 +27,32 @@ fn test_ref_confusion() -> Result<()> {
 
 #[cfg_attr(not(feature = "gh-token-tests"), ignore)]
 #[test]
+fn test_ref_confusion_pre_commit() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("ref-confusion/pre-commit/.pre-commit-config.yaml"))
+            .offline(NetworkMode::AssertOnline)
+            .run()?,
+        @"
+    warning[ref-confusion]: git ref for action with ambiguous ref type
+     --> @@INPUT@@:3:5
+      |
+    2 |   - repo: https://github.com/woodruffw/gha-hazmat
+      |     --------------------------------------------- this repo
+    3 |     rev: confusable
+      |     ^^^^^^^^^^^^^^^ uses a ref that's provided by both the branch and tag namespaces
+      |
+      = note: audit confidence → High
+
+    1 finding: 0 informational, 0 low, 1 medium, 0 high
+    "
+    );
+
+    Ok(())
+}
+
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
 fn test_issue_518_repro() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()

--- a/crates/zizmor/tests/integration/test-data/ref-confusion/pre-commit/.pre-commit-config.yaml
+++ b/crates/zizmor/tests/integration/test-data/ref-confusion/pre-commit/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/woodruffw/gha-hazmat
+    rev: confusable
+    hooks:
+      - id: some-hook

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,8 @@ of `zizmor`.
 
 * The `archived-uses` audit now supports pre-commit config inputs (#2272)
 
+* The `ref-confusion` audit now supports pre-commit config inputs (#2274)
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR is part of #2256 .

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Extends the `ref-confusion` audit to `.pre-commit-config.yaml` files.

## Test Plan

Snapshot test was added. This reuses the example in the [hazmat repo](https://github.com/woodruffw/gha-hazmat/).

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
