### PR TITLE
Add a hidden parent span for unpinned-uses

### DIFF
--- a/crates/zizmor/src/audit/unpinned_uses.rs
+++ b/crates/zizmor/src/audit/unpinned_uses.rs
@@ -183,6 +183,7 @@ impl UnpinnedUses {
             .confidence(Confidence::High)
             .severity(severity)
             .persona(persona)
+            .add_location(parent.location().hidden())
             .add_location(
                 parent
                     .location()

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__json_v1__json_v1.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__json_v1__json_v1.snap
@@ -244,6 +244,52 @@ expression: output
               "verbatim_path": "@@INPUT@@"
             }
           },
+          "annotation": "this step",
+          "route": {
+            "route": [
+              {
+                "Key": "jobs"
+              },
+              {
+                "Key": "unpinned-0"
+              },
+              {
+                "Key": "steps"
+              },
+              {
+                "Index": 0
+              }
+            ]
+          },
+          "feature_kind": "Normal",
+          "kind": "Hidden"
+        },
+        "concrete": {
+          "location": {
+            "start_point": {
+              "row": 15,
+              "column": 8
+            },
+            "end_point": {
+              "row": 18,
+              "column": 0
+            },
+            "offset_span": {
+              "start": 295,
+              "end": 372
+            }
+          },
+          "feature": "uses: actions/checkout@v3\n        with:\n          persist-credentials: false\n",
+          "comments": []
+        }
+      },
+      {
+        "symbolic": {
+          "key": {
+            "Local": {
+              "verbatim_path": "@@INPUT@@"
+            }
+          },
           "annotation": "action is not pinned to a hash (required by blanket policy)",
           "route": {
             "route": [

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -35,6 +35,9 @@ of `zizmor`.
 * Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`
   input containing a `prek`-specific `builtin` section (#2259)
 
+* Fixed a bug where the [unpinned-uses] audit would fail to honor
+  ignore comments within the same step scope (#2289)
+
 ## 1.29.0
 
 ### New Features 🌈
@@ -126,7 +129,7 @@ of `zizmor`.
 ### Bug Fixes 🐛
 
 * Fixed a bug where the [secrets-outside-env] audit would not honor
-  ignore comments within the same job scope (#2157)
+  ignore comments within the same job scope (#2158)
 
 * Fixed a bug where the [ref-version-mismatch] audit would not honor
   ignore comments within the same steps scope (#2177)


### PR DESCRIPTION
This is in the general class of "zizmor ignores should work anywhere in the step, not just on the `uses:` line."

See #2157, #2177 for similar cases.