### PR TITLE
fix(yamlpatch): preserve nesting in Add and Replace

### DIFF
--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -1084,16 +1084,17 @@ fn apply_value_replacement(
         // Regular block style - use standard formatting
         let val_str = serialize_yaml_value(value)?;
 
-        // A multi-line block collection can't share the key's line: splicing it
-        // after `key:` puts the collection's first entry on that line and leaves
-        // the remaining lines at the key's own depth, e.g. `target: outer:`,
-        // which is not valid YAML. Emit it as a nested block instead.
-        if val_str.contains('\n')
-            && matches!(
-                value,
-                yaml_serde::Value::Mapping(_) | yaml_serde::Value::Sequence(_)
-            )
-        {
+        // A non-empty block collection can't share the key's line: splicing it
+        // after `key:` produces invalid YAML even when its serialized form is a
+        // single line, e.g. `target: outer: value` or `target: - value`. Emit it
+        // as a nested block instead, while keeping empty collections inline.
+        let is_nonempty_block_collection = match value {
+            yaml_serde::Value::Mapping(mapping) => !mapping.is_empty(),
+            yaml_serde::Value::Sequence(sequence) => !sequence.is_empty(),
+            _ => false,
+        };
+
+        if is_nonempty_block_collection {
             let key_indent = &key_part[..key_part.len() - key_part.trim_start().len()];
             let mut result = key_part.to_string();
             for line in val_str.lines() {

--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -842,7 +842,11 @@ fn handle_block_mapping_addition(
                     result.push('\n');
                     result.push_str(&indent);
                     result.push_str("  "); // 2 spaces for nested content
-                    result.push_str(line.trim_start());
+                    // `serialize_yaml_value` anchors its output at column 0, so
+                    // each line's own leading whitespace *is* its depth relative
+                    // to the value's root. Trimming it here would flatten every
+                    // nested level into a sibling of the top-level key.
+                    result.push_str(line);
                 }
             }
             result
@@ -1079,7 +1083,32 @@ fn apply_value_replacement(
 
         // Regular block style - use standard formatting
         let val_str = serialize_yaml_value(value)?;
-        format!("{} {}", key_part, val_str.trim())
+
+        // A multi-line block collection can't share the key's line: splicing it
+        // after `key:` puts the collection's first entry on that line and leaves
+        // the remaining lines at the key's own depth, e.g. `target: outer:`,
+        // which is not valid YAML. Emit it as a nested block instead.
+        if val_str.contains('\n')
+            && matches!(
+                value,
+                yaml_serde::Value::Mapping(_) | yaml_serde::Value::Sequence(_)
+            )
+        {
+            let key_indent = &key_part[..key_part.len() - key_part.trim_start().len()];
+            let mut result = key_part.to_string();
+            for line in val_str.lines() {
+                if !line.trim().is_empty() {
+                    result.push('\n');
+                    result.push_str(key_indent);
+                    result.push_str("  "); // 2 spaces for nested content
+                    // As above: preserve each line's own relative depth.
+                    result.push_str(line);
+                }
+            }
+            result
+        } else {
+            format!("{} {}", key_part, val_str.trim())
+        }
     } else {
         // This is just a value, replace it directly
 

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -4086,6 +4086,83 @@ top:
 }
 
 #[test]
+fn test_replace_single_entry_block_mapping() {
+    let original = r#"
+top:
+  target:
+    old: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let value: yaml_serde::Value = yaml_serde::from_str("new: value\n").unwrap();
+    let operations = vec![Patch {
+        route: route!("top", "target"),
+        operation: Op::Replace(value),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    top:
+      target:
+        new: value
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_replace_single_entry_block_sequence() {
+    let original = r#"
+top:
+  target:
+    old: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let value: yaml_serde::Value = yaml_serde::from_str("- value\n").unwrap();
+    let operations = vec![Patch {
+        route: route!("top", "target"),
+        operation: Op::Replace(value),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    top:
+      target:
+        - value
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_replace_empty_collections_inline() {
+    let original = r#"
+top:
+  target:
+    old: 1
+"#;
+
+    for (serialized, expected) in [("{}", "{}"), ("[]", "[]")] {
+        let document = yamlpath::Document::new(original).unwrap();
+        let value: yaml_serde::Value = yaml_serde::from_str(serialized).unwrap();
+        let operations = vec![Patch {
+            route: route!("top", "target"),
+            operation: Op::Replace(value),
+        }];
+
+        let result = apply_yaml_patches(&document, &operations).unwrap();
+        assert_eq!(result.source(), format!("\ntop:\n  target: {expected}\n"));
+    }
+}
+
+#[test]
 fn test_replace_deeply_nested_block_mapping() {
     let original = r#"
 top:

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -3975,3 +3975,232 @@ foo:
       - [def, ghi]
     ");
 }
+
+#[test]
+fn test_add_nested_block_mapping() {
+    let original = r#"
+top:
+  existing: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+
+    // A value nested two levels deep.
+    let value: yaml_serde::Value = yaml_serde::from_str("outer:\n  inner: value\n").unwrap();
+
+    let operations = vec![Patch {
+        route: route!("top"),
+        operation: Op::Add {
+            key: "added".to_string(),
+            value,
+        },
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    top:
+      existing: 1
+      added:
+        outer:
+          inner: value
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_replace_nested_block_mapping() {
+    let original = r#"
+top:
+  target:
+    old: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+
+    // Control: replacing the same route with a *scalar* works, confirming
+    // the route itself is correct.
+    let scalar_ops = vec![Patch {
+        route: route!("top", "target"),
+        operation: Op::Replace(yaml_serde::Value::String("replaced".to_string())),
+    }];
+    let scalar_result = apply_yaml_patches(&document, &scalar_ops);
+    assert!(
+        scalar_result.is_ok(),
+        "control case should succeed: {:?}",
+        scalar_result.err()
+    );
+
+    let value: yaml_serde::Value = yaml_serde::from_str("outer:\n  inner: value\n").unwrap();
+    let operations = vec![Patch {
+        route: route!("top", "target"),
+        operation: Op::Replace(value),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations)
+        .expect("Op::Replace with a block mapping value should succeed");
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    top:
+      target:
+        outer:
+          inner: value
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_replace_block_sequence() {
+    let original = r#"
+top:
+  target:
+    old: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let value: yaml_serde::Value = yaml_serde::from_str("- a\n- b\n").unwrap();
+
+    let operations = vec![Patch {
+        route: route!("top", "target"),
+        operation: Op::Replace(value),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    top:
+      target:
+        - a
+        - b
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_replace_deeply_nested_block_mapping() {
+    let original = r#"
+top:
+  target:
+    old: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let value: yaml_serde::Value =
+        yaml_serde::from_str("a:\n  b:\n    c:\n      d: deep\n").unwrap();
+
+    let operations = vec![Patch {
+        route: route!("top", "target"),
+        operation: Op::Replace(value),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    // Every level keeps its own relative depth.
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    top:
+      target:
+        a:
+          b:
+            c:
+              d: deep
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_add_nested_block_mapping_preserves_comments() {
+    // Comment preservation is the reason to reach for yamlpatch over a
+    // serialize/deserialize round-trip, so pin it together with the nesting.
+    let original = r#"# Top-of-file comment.
+outer:
+  # Comment attached to the existing entry.
+  existing:
+    nested:
+      key: 1  # trailing comment
+# Final comment.
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let value: yaml_serde::Value =
+        yaml_serde::from_str("first:\n  second: value\nsibling: other\n").unwrap();
+
+    let operations = vec![Patch {
+        route: route!("outer"),
+        operation: Op::Add {
+            key: "added".to_string(),
+            value,
+        },
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+    # Top-of-file comment.
+    outer:
+      # Comment attached to the existing entry.
+      existing:
+        nested:
+          key: 1  # trailing comment
+      added:
+        first:
+          second: value
+        sibling: other
+    # Final comment.
+
+    --- END PATCH ---
+    ");
+}
+
+#[test]
+fn test_merge_into_nested_block_mapping() {
+    // `Op::MergeInto` lowers to `Op::Add` when the key is absent, so it is
+    // subject to the same flattening bug.
+    let original = r#"
+outer:
+  target:
+    existing: 1
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let mut updates: indexmap::IndexMap<String, yaml_serde::Value> = indexmap::IndexMap::new();
+    updates.insert(
+        "first".to_string(),
+        yaml_serde::from_str("second: value\n").unwrap(),
+    );
+
+    let operations = vec![Patch {
+        route: route!("outer", "target"),
+        operation: Op::MergeInto {
+            key: "added".to_string(),
+            updates,
+        },
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+
+    insta::assert_snapshot!(format_patch(result.source()), @r"
+    --- PATCH ---
+
+    outer:
+      target:
+        existing: 1
+        added:
+          first:
+            second: value
+
+    --- END PATCH ---
+    ");
+}

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -4162,6 +4162,47 @@ top:
     }
 }
 
+/// This is a backstop test; `Replace` currently mistakes any colon in a
+/// sequence scalar for a mapping key separator.
+#[test]
+#[should_panic]
+fn test_replace_sequence_scalar_containing_colon() {
+    let original = r#"
+top:
+  - https://example.com
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let operations = vec![Patch {
+        route: route!("top", 0),
+        operation: Op::Replace(yaml_serde::Value::String("new".to_string())),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+    assert_eq!(result.source(), "\ntop:\n  - new\n");
+}
+
+/// This is a backstop test; `Replace` does not yet indent block collections
+/// relative to a block sequence marker.
+#[test]
+#[should_panic]
+fn test_replace_block_sequence_scalar_with_mapping() {
+    let original = r#"
+top:
+  - old
+"#;
+
+    let document = yamlpath::Document::new(original).unwrap();
+    let value: yaml_serde::Value = yaml_serde::from_str("new:\n  child: value\n").unwrap();
+    let operations = vec![Patch {
+        route: route!("top", 0),
+        operation: Op::Replace(value),
+    }];
+
+    let result = apply_yaml_patches(&document, &operations).unwrap();
+    assert_eq!(result.source(), "\ntop:\n  - new:\n      child: value\n");
+}
+
 #[test]
 fn test_replace_deeply_nested_block_mapping() {
     let original = r#"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -41,6 +41,11 @@ of `zizmor`.
 * Fixed a bug where `zizmor` would reject a `dependabot.yml` containing
   a `goproxy-server` registry definition (#2300)
 
+* Fixed a handful of unsound patch bugs when performing YAML add and/or
+  replace operations (#2295)
+
+    Many thanks to @dmbuil for proposing and implementing this improvement!
+
 ## 1.29.0
 
 ### New Features 🌈


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

Both operations assumed a serialized value is a single-line scalar, so mapping values nested more than one level deep did not round-trip.

`serialize_yaml_value` anchors its output at column 0, which means each line's leading whitespace is its depth relative to the value's root.

In `handle_block_mapping_addition`, `trim_start()` discarded that depth, flattening every nested level into a sibling of the top-level key. The result was well-formed YAML that parsed to a different document than the one requested, silently.

In `apply_value_replacement`, the value was unconditionally formatted as `key: value` on one line. A block collection was therefore spliced onto the key's own line, leaving the remaining lines at the key's depth and producing invalid YAML such as `target: outer: `, which failed to re-parse.

Sequences are covered alongside mappings, since a multi-line block sequence hits the same splice in the replacement path.

Closes  #2270 

Claude was used to help me review the tests added.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

- `test_add_nested_block_mapping`: `Op::Add` with a value nested two levels deep. Previously produced well-formed YAML that parsed to a *different* document (`inner` emitted as a sibling of `outer` instead of its child).
- `test_replace_nested_block_mapping`: `Op::Replace` with a block-mapping value. Previously emitted `target: outer:` and failed to re-parse. Includes a scalar-replacement control case on the same route, so a failure can't be mistaken for a bad route.
- `test_replace_block_sequence`: the `Value::Sequence` arm of the replacement fix; a multi-line block sequence hits the same splice as a mapping.
- `test_replace_deeply_nested_block_mapping`: four levels deep, confirming each level keeps its own relative depth rather than only the first.
- `test_merge_into_nested_block_mapping`: `Op::MergeInto` lowers to `Op::Add`, so it was subject to the same flattening; nothing covered that path.
- `test_add_nested_block_mapping_preserves_comments`: asserts the fix doesn't regress comment preservation, pinning top-of-file, entry-attached, trailing-inline and end-of-file comments alongside the corrected nesting.

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
