### PR TITLE
docs: add note to 'concurrency-limit' about pedantic persona

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -406,8 +406,7 @@ by workflow and job identifiers, rather than run IDs.
 
 !!! note
 
-    This is a `--pedantic` only audit because it is pretty noisy for the average user.
-    In the future, this rule might apply to persona `regular` as well.
+    This is a `--pedantic` only audit, as it is pretty noisy for the average user.
 
 Other resources:
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -404,6 +404,11 @@ resource waste vector for attackers, particularly on billed runners. Separately,
 it can be a source of subtle race conditions when attempting to locate artifacts
 by workflow and job identifiers, rather than run IDs.
 
+!!! note
+
+    This is a `--pedantic` only audit because it is pretty noisy for the average user.
+    In the future, this rule might apply to persona `regular` as well.
+
 Other resources:
 
 * [Guidelines on green software practices for GitHub Actions CI workflows]


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

I noticed that the [`concurrency-limit` section](https://docs.zizmor.sh/audits/#concurrency-limits) does not mention that it is a persona `pedantic`-only rule currently. The reason for this being that

> "[...] they'll be pretty noisy for the average user" - [William](https://github.com/zizmorcore/zizmor/pull/1227#discussion_r2427753229)

While it might change in the future, I still think it is best to document it in the meantime.

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
