### PR TITLE
fix: repair broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ through one of the following:
 
 ## Star History
 
-<a href="https://star-history.com/#zizmorcore/zizmor&Date">
+<a href="https://star-history.dera.page/#zizmorcore/zizmor&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zizmorcore/zizmor&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zizmorcore/zizmor&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=zizmorcore/zizmor&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=zizmorcore/zizmor&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=zizmorcore/zizmor&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=zizmorcore/zizmor&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart at the top of the README is broken: it fails to render because the current endpoint depends on the GitHub stargazer REST API, which no longer serves unauthenticated requests. Project visitors see a blank/broken image.

This MR switches the chart to star-history.dera.page, an alternative data source that requires no API token and serves the SVG and the page front-end from the same origin, so the chart renders reliably again.

Verified both the <picture>/<source> entries and the surrounding link are updated.