### PR TITLE
feat: add support for ratchet ref pin comments

### DIFF
--- a/crates/zizmor/src/models/version.rs
+++ b/crates/zizmor/src/models/version.rs
@@ -23,6 +23,24 @@ static_regex!(
     "#
 );
 
+// Ratchet pins actions with comments like `# ratchet:actions/checkout@v4.2.2`.
+// See https://github.com/sethvargo/ratchet for details.
+static_regex!(
+    RATCHET_COMMENT_PATTERN,
+    r#"(?x)                             # verbose mode
+    ^                                   # start of string
+    \#                                  # start of comment
+    \s*                                 # optional whitespace
+    ratchet:                            # ratchet prefix
+    [^@]+                               # action name, anything up to @
+    @                                   # separator
+    (                                   # start capturing group for version
+      \S+                               # one or more non-whitespace characters
+    )                                   # end capturing group for version
+    $                                   # end of string
+    "#
+);
+
 /// A "raw" version.
 ///
 /// This represents an arbitrary string that we *think* is a version
@@ -42,7 +60,11 @@ impl<'a> From<&'a str> for RawVersion<'a> {
 impl<'a> RawVersion<'a> {
     pub(crate) fn from_comment(comment: &Comment<'a>) -> Option<Self> {
         let comment = comment.as_raw();
-        if let Some(captures) = VERSION_COMMENT_PATTERN.captures(comment)
+        if let Some(captures) = RATCHET_COMMENT_PATTERN.captures(comment)
+            && let Some(version_match) = captures.get(1)
+        {
+            Some(version_match.as_str().into())
+        } else if let Some(captures) = VERSION_COMMENT_PATTERN.captures(comment)
             && let Some(version_match) = captures.get(1)
         {
             Some(version_match.as_str().into())
@@ -161,7 +183,7 @@ impl PartialEq for Version<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::version::VERSION_COMMENT_PATTERN;
+    use crate::models::version::{RATCHET_COMMENT_PATTERN, VERSION_COMMENT_PATTERN};
 
     use super::Version;
 
@@ -205,6 +227,34 @@ mod tests {
                 }
                 (Some(caps), None) => {
                     assert!(false, "Got unexpected match: {caps:?}")
+                }
+                (Some(_), Some(_)) => (),
+            }
+        }
+    }
+
+    #[test]
+    fn test_ratchet_comment_pattern() {
+        let test_cases = vec![
+            ("# ratchet:actions/checkout@v4", Some("v4")),
+            ("# ratchet:actions/checkout@v4.2.2", Some("v4.2.2")),
+            ("# ratchet:actions/setup-node@v3.8.2", Some("v3.8.2")),
+            ("# ratchet:owner/repo/path@v1.0.0", Some("v1.0.0")),
+            ("# ratchet:actions/checkout@4.2.2", Some("4.2.2")),
+            // These should NOT match the ratchet pattern
+            ("# v4.2.2", None),
+            ("# actions/checkout@v4.2.2", None),
+            ("# some other comment", None),
+        ];
+
+        for (comment, expected) in test_cases {
+            match (RATCHET_COMMENT_PATTERN.captures(comment), expected) {
+                (None, None) => (),
+                (None, Some(expected)) => {
+                    panic!("Got no match in '{comment}', but expected {expected}")
+                }
+                (Some(caps), None) => {
+                    panic!("Got unexpected match: {caps:?}")
                 }
                 (Some(_), Some(_)) => (),
             }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -34,6 +34,10 @@ of `zizmor`.
 
 * The [cache-poisoning] audit now handles and exposes auto-fixes in a more general manner (#2332)
 
+* zizmor now recognizes @sethvargo/ratchet version comments when evaluating ref pinning (#2319)
+
+    Many thanks to @njgudman for proposing and implementing this enhancement!
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`


### PR DESCRIPTION
adds a regex that accepts ratchet git ref comments used to pin and unpin github actions

Generated with copilot

Refs: #2316

<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Add a regular expression to process github actions references pinned to git shas with [ratchet](https://github.com/sethvargo/ratchet) so that the ref-version-mismatch check passes.

## Test Plan

Includes unit test that use ratchet's pin comment format

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
