### PR TITLE
fix(yamlpatch): reject Op::Replace on multi-key flow mappings

### DIFF
--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -362,7 +362,8 @@ fn apply_single_patch(
             let feature = route_to_feature_pretty(&patch.route, document)?;
 
             // Get the replacement content
-            let replacement = apply_value_replacement(&feature, document, value, true)?;
+            let replacement =
+                apply_value_replacement(&feature, document, value, true, &patch.route)?;
 
             // Extract the current content to calculate spans
             let current_content = document.extract(&feature);
@@ -1010,6 +1011,7 @@ fn apply_value_replacement(
     doc: &yamlpath::Document,
     value: &yaml_serde::Value,
     support_multiline_literals: bool,
+    route: &yamlpath::Route<'_>,
 ) -> Result<String, Error> {
     // Extract the current content to see what we're replacing
     let current_content_with_ws = doc.extract_with_leading_whitespace(feature);
@@ -1033,6 +1035,7 @@ fn apply_value_replacement(
             end_byte,
             current_content_with_ws,
             value,
+            route,
         );
     }
 
@@ -1126,12 +1129,29 @@ fn handle_flow_mapping_value_replacement(
     _end_byte: usize,
     current_content: &str,
     value: &yaml_serde::Value,
+    route: &yamlpath::Route<'_>,
 ) -> Result<String, Error> {
     let val_str = serialize_yaml_value(value)?;
     let val_str = val_str.trim();
 
     // Parse the flow mapping content to understand the structure
     let trimmed = current_content.trim();
+
+    // TODO: Remove this limitation.
+    // Everything below rebuilds the mapping around a single member, so it's
+    // only correct when the mapping has exactly one. Against a larger mapping
+    // it drops every other member, so reject rather than emit an incorrect
+    // patch. A failure to parse is also a rejection: we can't confirm the
+    // member count, and guessing is what produced the bad patch in the first
+    // place.
+    match yaml_serde::from_str::<yaml_serde::Mapping>(trimmed) {
+        Ok(mapping) if mapping.len() <= 1 => (),
+        _ => {
+            return Err(Error::InvalidOperation(format!(
+                "replace operation is not permitted against multi-key flow mapping route: {route:?}"
+            )));
+        }
+    }
 
     // Case 1: { key: } - has colon, empty value
     if let Some(colon_pos) = trimmed.find(':') {

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -4322,3 +4322,74 @@ outer:
     --- END PATCH ---
     ");
 }
+
+/// `Op::Replace` rebuilds a flow mapping around a single member, so against a
+/// larger mapping it would drop the others.
+///
+/// This is a backstop test; at some point this should be supported.
+#[test]
+#[should_panic = "replace operation is not permitted against multi-key flow mapping"]
+fn test_replace_rejects_multi_key_flow_mapping() {
+    let document = yamlpath::Document::new("foo: { a: 1, b: 2 }\n").unwrap();
+
+    let operations = vec![Patch {
+        route: route!("foo", "b"),
+        operation: Op::Replace(yaml_serde::Value::String("newvalue".to_string())),
+    }];
+
+    let _result = apply_yaml_patches(&document, &operations).unwrap();
+}
+
+/// A flow mapping that doesn't parse on its own — here because the alias has
+/// no anchor once the fragment is detached from its document — can't have its
+/// members counted, so it's rejected too rather than guessed at.
+///
+/// This is a backstop test; at some point this should be supported.
+#[test]
+#[should_panic = "replace operation is not permitted against multi-key flow mapping"]
+fn test_replace_rejects_unparsable_flow_mapping() {
+    let original = r#"
+anchors:
+  base: &x 1
+foo: { a: *x, b: 2 }
+"#;
+
+    let operations = vec![Patch {
+        route: route!("foo", "b"),
+        operation: Op::Replace(yaml_serde::Value::String("newvalue".to_string())),
+    }];
+
+    let _result =
+        apply_yaml_patches(&yamlpath::Document::new(original).unwrap(), &operations).unwrap();
+}
+
+/// `Op::MergeInto` lowers to `Op::Replace` for keys that are already present,
+/// so it reaches the same rejection. Before it did, this silently produced
+/// `with: { fetch-depth: false }`.
+///
+/// This is a backstop test; at some point this should be supported.
+#[test]
+#[should_panic = "replace operation is not permitted against multi-key flow mapping"]
+fn test_merge_into_rejects_multi_key_flow_mapping() {
+    let original = r#"
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, persist-credentials: true }
+"#;
+
+    let operations = vec![Patch {
+        route: route!("jobs", "test", "steps", 0),
+        operation: Op::MergeInto {
+            key: "with".to_string(),
+            updates: indexmap::IndexMap::from_iter([(
+                "persist-credentials".to_string(),
+                yaml_serde::Value::Bool(false),
+            )]),
+        },
+    }];
+
+    let _result =
+        apply_yaml_patches(&yamlpath::Document::new(original).unwrap(), &operations).unwrap();
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -46,6 +46,10 @@ of `zizmor`.
 
     Many thanks to @dmbuil for proposing and implementing this improvement!
 
+* Fixed a bug where `zizmor` would silently drop the other members of an
+  inline (flow) mapping when a fix replaced one of its values. These fixes are
+  now reported as failed and the input is left unchanged (#1579)
+
 ## 1.29.0
 
 ### New Features 🌈


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes #1579.

`handle_flow_mapping_value_replacement` rebuilds a flow mapping around a single
member: it finds the first colon in the whole fragment and emits
`{ <first key>: <newvalue> }`. That's correct for one member and wrong for any
more, so replacing `foo/b` in `foo: { a: 1, b: 2, c: 3 }` gave
`foo: { a: newvalue }`.

I took the reject option from your comment on the issue. The guard sits in the
helper, next to the assumption it protects, and mirrors the
`Style::MultilineFlowMapping` arm in `Op::Add`, `// TODO: Remove this
limitation.` included.

Not just a unit-test curiosity: `Op::MergeInto` lowers to `Op::Replace` for keys
that already exist, so anything merging into an inline `with:` hit it. Before:

```yaml
# MergeInto { key: "with", updates: { persist-credentials: false } }
- uses: actions/checkout@v4
  with: { fetch-depth: 0, persist-credentials: true }
```

produced

```yaml
- uses: actions/checkout@v4
  with: { fetch-depth: false }
```

`persist-credentials` gone, `false` on the wrong key. That now errors instead.

A fragment that fails to parse standalone is rejected too, not passed through.
Otherwise the original corruption survives the fix wherever the fragment isn't
valid YAML on its own, e.g. an alias whose anchor is elsewhere in the document:

```yaml
anchors:
  base: &x 1
foo: { a: *x, b: 2 }   # route foo/b -> foo: { a: newvalue }, pre-fix
```

Aliases are illegal in workflows but fine in `dependabot.yml` and pre-commit
configs, both of which reach `Op::Replace`. The `MergeInto` arm already
hard-errors on the same parse, so this follows it. The cost is refusing a fix on
a *single*-member flow mapping that contains an alias, which is a safe failure.

Three things I'd rather flag than quietly leave for you to find:

- **A correct fix looks tractable, if you'd prefer it over rejecting.** I
  assumed at first that the member was unrecoverable here, because
  `query_pretty` resolves both `route!("foo","b")` and `route!("foo", 0)` to the
  same feature. That's wrong: `query_exact` distinguishes them (`Scalar "2"` at
  `(16,17)` vs. the whole mapping at `(9,23)`), so splicing its span handles
  members, quoted keys containing `,` and `:`, and the list-item case. The two
  shapes that keep the current fallbacks are `{ key: }`, where `query_exact`
  returns `None`, and `{ key }`, where it returns the *key* and splicing would
  give `{ newvalue }` instead of `{ key: newvalue }`. Both are pinned by
  `test_replace_empty_flow_value` and `test_replace_empty_flow_value_no_colon`.
  Happy to do that instead, but it's a bigger change and you said rejecting was
  fine.
- **Same-class cases this deliberately leaves wrong**, since `len() == 1` is
  load-bearing for the two tests above: `foo:\n  - { a: 1 }` with `route!("foo",0)`
  gives `- { a: newvalue }` rather than `- newvalue`, and `- {}` gives
  `- { : newvalue }`. Both need the `query_exact` approach.
- **The user-facing message is misleading, but that's pre-existing.**
  `output/fix.rs:100` wraps every fix error as `conflict after applying previous
  fixes: {e}`, so this rejection surfaces as a conflict. Left alone here.

Also happy to drop the unused `_content` / `_start_byte` / `_end_byte`
parameters on the helper as a separate PR. I left them because the `TODO` above
implies whoever implements the real fix will want the span back.

## Test Plan

Three backstop tests, in the `#[should_panic]` style already used for
`test_emplace_comment_on_multiline_string`:

- `test_replace_rejects_multi_key_flow_mapping` — two members, the boundary.
- `test_replace_rejects_unparsable_flow_mapping` — the alias case above.
- `test_merge_into_rejects_multi_key_flow_mapping` — the real `with:` shape,
  guarding the `MergeInto` lowering.

I mutated the guard to check each test earns its place: widening it to
`len() <= 2` fails the first and third, dropping the parse-failure rejection
fails the second, and rejecting single-member mappings fails
`test_replace_empty_flow_value`, `test_replace_empty_flow_value_no_colon`,
`test_replace_value_in_flow_mapping_within_block_context` and
`test_merge_into_flow_mapping` — which is the single-member success path, so I
didn't add a fourth test duplicating it.

Also checked as non-regressions: `MergeInto` with only new keys still appends
into a multi-member flow mapping, flow *sequences* are unaffected
(`foo: [1,2,3]` at `foo/1` already patches correctly), and rejection is atomic,
since `apply_yaml_patches` rebuilds from the input document.

`cargo test` is green across the workspace and `cargo fmt --check` is clean.

Disclosure per the AI policy: I used Claude for the implementation, the tests
and the `query_exact` investigation written up above.

---
Used AI assistance on this; I reviewed and tested the change myself.