### PR TITLE
fix(yamlpatch): reject Op::Replace on multi-key flow mappings

### DIFF
--- a/crates/yamlpatch/src/lib.rs
+++ b/crates/yamlpatch/src/lib.rs
@@ -362,7 +362,8 @@ fn apply_single_patch(
             let feature = route_to_feature_pretty(&patch.route, document)?;
 
             // Get the replacement content
-            let replacement = apply_value_replacement(&feature, document, value, true)?;
+            let replacement =
+                apply_value_replacement(&feature, document, value, true, &patch.route)?;
 
             // Extract the current content to calculate spans
             let current_content = document.extract(&feature);
@@ -1010,6 +1011,7 @@ fn apply_value_replacement(
     doc: &yamlpath::Document,
     value: &yaml_serde::Value,
     support_multiline_literals: bool,
+    route: &yamlpath::Route<'_>,
 ) -> Result<String, Error> {
     // Extract the current content to see what we're replacing
     let current_content_with_ws = doc.extract_with_leading_whitespace(feature);
@@ -1033,6 +1035,7 @@ fn apply_value_replacement(
             end_byte,
             current_content_with_ws,
             value,
+            route,
         );
     }
 
@@ -1126,12 +1129,29 @@ fn handle_flow_mapping_value_replacement(
     _end_byte: usize,
     current_content: &str,
     value: &yaml_serde::Value,
+    route: &yamlpath::Route<'_>,
 ) -> Result<String, Error> {
     let val_str = serialize_yaml_value(value)?;
     let val_str = val_str.trim();
 
     // Parse the flow mapping content to understand the structure
     let trimmed = current_content.trim();
+
+    // TODO: Remove this limitation.
+    // Everything below rebuilds the mapping around a single member, so it's
+    // only correct when the mapping has exactly one. Against a larger mapping
+    // it drops every other member, so reject rather than emit an incorrect
+    // patch. A failure to parse is also a rejection: we can't confirm the
+    // member count, and guessing is what produced the bad patch in the first
+    // place.
+    match yaml_serde::from_str::<yaml_serde::Mapping>(trimmed) {
+        Ok(mapping) if mapping.len() <= 1 => (),
+        _ => {
+            return Err(Error::InvalidOperation(format!(
+                "replace operation is not permitted against multi-key flow mapping route: {route:?}"
+            )));
+        }
+    }
 
     // Case 1: { key: } - has colon, empty value
     if let Some(colon_pos) = trimmed.find(':') {

--- a/crates/yamlpatch/tests/unit_tests.rs
+++ b/crates/yamlpatch/tests/unit_tests.rs
@@ -4322,3 +4322,74 @@ outer:
     --- END PATCH ---
     ");
 }
+
+/// `Op::Replace` rebuilds a flow mapping around a single member, so against a
+/// larger mapping it would drop the others.
+///
+/// This is a backstop test; at some point this should be supported.
+#[test]
+#[should_panic = "replace operation is not permitted against multi-key flow mapping"]
+fn test_replace_rejects_multi_key_flow_mapping() {
+    let document = yamlpath::Document::new("foo: { a: 1, b: 2 }\n").unwrap();
+
+    let operations = vec![Patch {
+        route: route!("foo", "b"),
+        operation: Op::Replace(yaml_serde::Value::String("newvalue".to_string())),
+    }];
+
+    let _result = apply_yaml_patches(&document, &operations).unwrap();
+}
+
+/// A flow mapping that doesn't parse on its own — here because the alias has
+/// no anchor once the fragment is detached from its document — can't have its
+/// members counted, so it's rejected too rather than guessed at.
+///
+/// This is a backstop test; at some point this should be supported.
+#[test]
+#[should_panic = "replace operation is not permitted against multi-key flow mapping"]
+fn test_replace_rejects_unparsable_flow_mapping() {
+    let original = r#"
+anchors:
+  base: &x 1
+foo: { a: *x, b: 2 }
+"#;
+
+    let operations = vec![Patch {
+        route: route!("foo", "b"),
+        operation: Op::Replace(yaml_serde::Value::String("newvalue".to_string())),
+    }];
+
+    let _result =
+        apply_yaml_patches(&yamlpath::Document::new(original).unwrap(), &operations).unwrap();
+}
+
+/// `Op::MergeInto` lowers to `Op::Replace` for keys that are already present,
+/// so it reaches the same rejection. Before it did, this silently produced
+/// `with: { fetch-depth: false }`.
+///
+/// This is a backstop test; at some point this should be supported.
+#[test]
+#[should_panic = "replace operation is not permitted against multi-key flow mapping"]
+fn test_merge_into_rejects_multi_key_flow_mapping() {
+    let original = r#"
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, persist-credentials: true }
+"#;
+
+    let operations = vec![Patch {
+        route: route!("jobs", "test", "steps", 0),
+        operation: Op::MergeInto {
+            key: "with".to_string(),
+            updates: indexmap::IndexMap::from_iter([(
+                "persist-credentials".to_string(),
+                yaml_serde::Value::Bool(false),
+            )]),
+        },
+    }];
+
+    let _result =
+        apply_yaml_patches(&yamlpath::Document::new(original).unwrap(), &operations).unwrap();
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -46,6 +46,10 @@ of `zizmor`.
 
     Many thanks to @dmbuil for proposing and implementing this improvement!
 
+* Fixed a bug where `zizmor` would silently drop the other members of an
+  inline (flow) mapping when a fix replaced one of its values. These fixes are
+  now reported as failed and the input is left unchanged (#1579)
+
 ## 1.29.0
 
 ### New Features 🌈


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Closes #1579.

`handle_flow_mapping_value_replacement` rebuilds the whole flow mapping around
one member: it finds the first colon and emits `{ key: newvalue }`. That's
fine when there's exactly one member, but with more than one it just drops
the rest, so replacing `foo/b` in `foo: { a: 1, b: 2, c: 3 }` produced
`foo: { a: newvalue }` instead of `foo: { a: 1, b: newvalue, c: 3 }`.

Same code path also runs under `Op::MergeInto` whenever the merge target
already exists in a flow mapping, so merging into an inline `with:` with more
than one key hit this too (e.g. it silently rewrote
`with: { fetch-depth: 0, persist-credentials: true }` down to
`with: { fetch-depth: false }`).

You said in the issue the fix could be "handle it correctly" or "reject it as
unsupported," and reject was fine — that's what I did. Before rebuilding
the mapping, it now re-parses the fragment as a `Mapping` and bails with an
error if it has more than one key, or if it doesn't parse at all (which
happens for a flow mapping containing an alias whose anchor lives elsewhere
in the document — you can't tell how many members it has without resolving
that first).

I did look at actually fixing the replacement instead of rejecting it — there's
a `query_exact` call nearby that resolves the exact span of a single member,
which would let you splice in the new value without touching the rest. But
that's a bigger, riskier change than what the issue asked for, so I left it as
a TODO next to the guard and kept this PR to the reject path.

## Test Plan

Added three tests: replacing in a two-key flow mapping, replacing in the
unparsable-alias case above, and the `MergeInto`-into-`with:` case, since that
one goes through a different lowering path than a plain `Op::Replace` and
wasn't otherwise covered.

`cargo test` and `cargo fmt --check` are both clean on the workspace.

Disclosure per the AI policy: I used Claude for the implementation and the
tests, and to help me dig into the `query_exact` alternative above.
