### PR TITLE
Express version bounds in action coordinates

### DIFF
--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -14,7 +14,8 @@ use crate::config::Config;
 use crate::finding::location::{Locatable as _, Routable as _};
 use crate::finding::{Confidence, Finding, Fix, FixDisposition, Severity};
 use crate::models::coordinate::{
-    ActionCoordinate, ControlExpr, ControlFieldType, Toggle, Usage, VersionBound,
+    ActionCoordinate, ControlExpr, ControlFieldType, ControlOrigin, Toggle, Usage, UsageState,
+    VersionBound,
 };
 use crate::models::version::Version;
 use crate::models::workflow::{JobCommon as _, NormalJob, Step, Steps};
@@ -583,7 +584,7 @@ impl CachePoisoning {
 
             if cache_enabled {
                 // Caching is enabled; upgrade the confidence.
-                Some(Usage::DirectOptIn)
+                Some(cache_usage.into_enabled())
             } else {
                 // Caching is disabled; rule out this usage.
                 None
@@ -603,7 +604,7 @@ impl CachePoisoning {
             return Ok(None);
         };
 
-        let cache_usage = if matches!(cache_usage, Usage::ConditionalOptIn) {
+        let cache_usage = if matches!(cache_usage.state(), UsageState::Conditional) {
             self.conditional_cache_usage_heuristics(coord, step, scenario, cache_usage)
         } else {
             Some(cache_usage)
@@ -613,26 +614,71 @@ impl CachePoisoning {
             return Ok(None);
         };
 
-        let locations = match cache_usage {
-            Usage::ConditionalOptIn => vec![
-                step.location().primary().with_keys(["uses".into()]),
-                step.location()
-                    .with_keys(["with".into()])
-                    .annotated("may enable caching here"),
-            ],
-            Usage::DirectOptIn => vec![
-                step.location().primary().with_keys(["uses".into()]),
-                step.location()
-                    .with_keys(["with".into()])
-                    .annotated("enables caching explicitly here"),
-            ],
-            Usage::DefaultActionBehaviour => vec![
-                step.location()
-                    .primary()
-                    .with_keys(["uses".into()])
-                    .annotated("enables caching by default"),
-            ],
-            Usage::Always => vec![
+        let locations = match cache_usage.state() {
+            UsageState::Conditional => {
+                let version_is_conditional =
+                    cache_usage.origins().contains(&ControlOrigin::UsesRef);
+                let mut uses_location = step.location().primary().with_keys(["uses".into()]);
+                if version_is_conditional {
+                    uses_location = uses_location.annotated("action version may enable caching");
+                }
+
+                let mut locations = vec![uses_location];
+                for origin in cache_usage.origins() {
+                    match origin {
+                        ControlOrigin::Input { field } => locations.push(
+                            step.location()
+                                .with_keys(["with".into(), (*field).into()])
+                                .annotated("may enable caching here"),
+                        ),
+                        ControlOrigin::WithExpression => locations.push(
+                            step.location()
+                                .with_keys(["with".into()])
+                                .annotated("may enable caching here"),
+                        ),
+                        ControlOrigin::Default { .. } | ControlOrigin::UsesRef => {}
+                    }
+                }
+
+                locations
+            }
+            UsageState::Enabled => {
+                let has_explicit_origin = cache_usage.origins().iter().any(|origin| {
+                    matches!(
+                        origin,
+                        ControlOrigin::Input { .. } | ControlOrigin::WithExpression
+                    )
+                });
+
+                if !has_explicit_origin {
+                    vec![
+                        step.location()
+                            .primary()
+                            .with_keys(["uses".into()])
+                            .annotated("enables caching by default"),
+                    ]
+                } else {
+                    let mut locations = vec![step.location().primary().with_keys(["uses".into()])];
+                    for origin in cache_usage.origins() {
+                        match origin {
+                            ControlOrigin::Input { field } => locations.push(
+                                step.location()
+                                    .with_keys(["with".into(), (*field).into()])
+                                    .annotated("enables caching explicitly here"),
+                            ),
+                            ControlOrigin::WithExpression => locations.push(
+                                step.location()
+                                    .with_keys(["with".into()])
+                                    .annotated("enables caching explicitly here"),
+                            ),
+                            ControlOrigin::Default { .. } | ControlOrigin::UsesRef => {}
+                        }
+                    }
+
+                    locations
+                }
+            }
+            UsageState::Always => vec![
                 step.location()
                     .primary()
                     .with_keys(["uses".into()])

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -14,8 +14,7 @@ use crate::config::Config;
 use crate::finding::location::{Locatable as _, Routable as _};
 use crate::finding::{Confidence, Finding, Fix, FixDisposition, Severity};
 use crate::models::coordinate::{
-    ActionCoordinate, ControlExpr, ControlFieldType, ControlOrigin, Toggle, Usage, UsageState,
-    VersionBound,
+    ActionCoordinate, ControlExpr, ControlFieldType, ControlOrigin, Toggle, Usage, VersionBound,
 };
 use crate::models::version::Version;
 use crate::models::workflow::{JobCommon as _, NormalJob, Step, Steps};
@@ -552,7 +551,7 @@ impl CachePoisoning {
         }
     }
 
-    /// Apply heuristics to a `Usage::ConditionalOptIn` to attempt to refine it into
+    /// Apply heuristics to a [`Usage::Conditional`] to attempt to refine it into
     /// a more precise usage.
     ///
     /// Returns `None` if the heuristics determine that caching is effectively disabled.
@@ -584,7 +583,10 @@ impl CachePoisoning {
 
             if cache_enabled {
                 // Caching is enabled; upgrade the confidence.
-                Some(cache_usage.into_enabled())
+                Some(match cache_usage {
+                    Usage::Conditional(origins) => Usage::Enabled(origins),
+                    usage => usage,
+                })
             } else {
                 // Caching is disabled; rule out this usage.
                 None
@@ -604,7 +606,7 @@ impl CachePoisoning {
             return Ok(None);
         };
 
-        let cache_usage = if matches!(cache_usage.state(), UsageState::Conditional) {
+        let cache_usage = if matches!(&cache_usage, Usage::Conditional(_)) {
             self.conditional_cache_usage_heuristics(coord, step, scenario, cache_usage)
         } else {
             Some(cache_usage)
@@ -614,17 +616,16 @@ impl CachePoisoning {
             return Ok(None);
         };
 
-        let locations = match cache_usage.state() {
-            UsageState::Conditional => {
-                let version_is_conditional =
-                    cache_usage.origins().contains(&ControlOrigin::UsesRef);
+        let locations = match &cache_usage {
+            Usage::Conditional(origins) => {
+                let version_is_conditional = origins.contains(&ControlOrigin::UsesRef);
                 let mut uses_location = step.location().primary().with_keys(["uses".into()]);
                 if version_is_conditional {
                     uses_location = uses_location.annotated("action version may enable caching");
                 }
 
                 let mut locations = vec![uses_location];
-                for origin in cache_usage.origins() {
+                for origin in origins {
                     match origin {
                         ControlOrigin::Input { field } => locations.push(
                             step.location()
@@ -642,8 +643,8 @@ impl CachePoisoning {
 
                 locations
             }
-            UsageState::Enabled => {
-                let has_explicit_origin = cache_usage.origins().iter().any(|origin| {
+            Usage::Enabled(origins) => {
+                let has_explicit_origin = origins.iter().any(|origin| {
                     matches!(
                         origin,
                         ControlOrigin::Input { .. } | ControlOrigin::WithExpression
@@ -659,7 +660,7 @@ impl CachePoisoning {
                     ]
                 } else {
                     let mut locations = vec![step.location().primary().with_keys(["uses".into()])];
-                    for origin in cache_usage.origins() {
+                    for origin in origins {
                         match origin {
                             ControlOrigin::Input { field } => locations.push(
                                 step.location()
@@ -678,7 +679,7 @@ impl CachePoisoning {
                     locations
                 }
             }
-            UsageState::Always => vec![
+            Usage::Always => vec![
                 step.location()
                     .primary()
                     .with_keys(["uses".into()])

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -42,7 +42,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/cache/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/cache".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptOut,
                 "lookup-only",
                 ControlFieldType::Boolean,
@@ -52,7 +52,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/setup-java/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-java".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "cache",
                 ControlFieldType::FreeString,
@@ -62,13 +62,13 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/setup-go/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-go".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
+            control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
         },
         // https://github.com/actions/setup-node/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-node".parse().unwrap(),
             control: ControlExpr::any([
-                ControlExpr::single(
+                ControlExpr::field(
                     Toggle::OptIn,
                     "cache",
                     // https://github.com/actions/setup-node/blob/65d868f8d4/src/cache-utils.ts#L101-L111
@@ -76,7 +76,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                     false,
                 ),
                 // NOTE: Added with `setup-node@v5`.
-                ControlExpr::single(
+                ControlExpr::field(
                     Toggle::OptIn,
                     "package-manager-cache",
                     ControlFieldType::Boolean,
@@ -87,7 +87,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/setup-python/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-python".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "cache",
                 ControlFieldType::FreeString,
@@ -97,12 +97,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/setup-dotnet/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-dotnet".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, false),
+            control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, false),
         },
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "astral-sh/setup-uv".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "enable-cache",
                 ControlFieldType::Boolean,
@@ -112,7 +112,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/Swatinem/rust-cache/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "Swatinem/rust-cache".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptOut,
                 "lookup-only",
                 ControlFieldType::Boolean,
@@ -122,7 +122,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/ruby/setup-ruby/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "ruby/setup-ruby".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "bundler-cache",
                 ControlFieldType::Boolean,
@@ -132,17 +132,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/PyO3/maturin-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "PyO3/maturin-action".parse().unwrap(),
-            control: ControlExpr::single(
-                Toggle::OptIn,
-                "sccache",
-                ControlFieldType::Boolean,
-                false,
-            ),
+            control: ControlExpr::field(Toggle::OptIn, "sccache", ControlFieldType::Boolean, false),
         },
         // https://github.com/mlugg/setup-zig/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "mlugg/setup-zig".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "use-cache",
                 ControlFieldType::Boolean,
@@ -152,7 +147,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/oven-sh/setup-bun/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "oven-sh/setup-bun".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptOut,
                 "no-cache",
                 ControlFieldType::Boolean,
@@ -162,7 +157,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/DeterminateSystems/magic-nix-cache-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "DeterminateSystems/magic-nix-cache-action".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "use-gha-cache",
                 ControlFieldType::Boolean,
@@ -172,7 +167,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/graalvm/setup-graalvm/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "graalvm/setup-graalvm".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptIn,
                 "cache",
                 ControlFieldType::FreeString,
@@ -182,7 +177,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/gradle/actions/blob/main/setup-gradle/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "gradle/actions/setup-gradle".parse().unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptOut,
                 "cache-disabled",
                 ControlFieldType::Boolean,
@@ -193,13 +188,13 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         ActionCoordinate::Configurable {
             uses_pattern: "docker/setup-buildx-action".parse().unwrap(),
             control: ControlExpr::all([
-                ControlExpr::single(
+                ControlExpr::field(
                     Toggle::OptIn,
                     "cache-binary",
                     ControlFieldType::Boolean,
                     true,
                 ),
-                ControlExpr::single(
+                ControlExpr::field(
                     Toggle::OptIn,
                     "version",
                     ControlFieldType::FreeString,
@@ -210,7 +205,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions-rust-lang/setup-rust-toolchain".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
+            control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
         },
         // https://github.com/Mozilla-Actions/sccache-action/blob/main/action.yml
         ActionCoordinate::NotConfigurable("Mozilla-Actions/sccache-action".parse().unwrap()),
@@ -219,12 +214,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/jdx/mise-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "jdx/mise-action".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
+            control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
         },
         // https://github.com/ramsey/composer-install/blob/v3/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "ramsey/composer-install".parse().unwrap(),
-            control: ControlExpr::Single {
+            control: ControlExpr::Field {
                 toggle: Toggle::OptOut,
                 field_name: "ignore-cache",
                 field_type: ControlFieldType::Exact(&["yes", "true", "1"]),
@@ -253,7 +248,7 @@ static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::new(
         // Container registries
         ActionCoordinate::Configurable {
             uses_pattern: "docker/build-push-action".parse().unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "push", ControlFieldType::Boolean, true),
+            control: ControlExpr::field(Toggle::OptIn, "push", ControlFieldType::Boolean, true),
         },
         ActionCoordinate::NotConfigurable("redhat-actions/push-to-registry".parse().unwrap()),
         // Cloud + Edge providers
@@ -377,7 +372,7 @@ struct CacheControlField<'a> {
 impl<'a> CacheControlField<'a> {
     fn extract(coord: &'a ActionCoordinate, step: &'a impl StepCommon<'a>) -> Option<Self> {
         if let ActionCoordinate::Configurable { control, .. } = coord
-            && let ControlExpr::Single {
+            && let ControlExpr::Field {
                 toggle,
                 field_name,
                 field_type: ControlFieldType::Boolean,
@@ -500,7 +495,7 @@ impl CachePoisoning {
         step: &Step<'doc>,
     ) -> Option<Fix<'doc>> {
         match control {
-            ControlExpr::Single {
+            ControlExpr::Field {
                 toggle,
                 field_name,
                 field_type,
@@ -541,8 +536,11 @@ impl CachePoisoning {
                     }],
                 })
             }
-            // For complex control expressions (All/Any/Not), don't provide automatic fixes for now
-            ControlExpr::All(_) | ControlExpr::Any(_) | ControlExpr::Not(_) => None,
+            // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
+            ControlExpr::VersionBound(_)
+            | ControlExpr::All(_)
+            | ControlExpr::Any(_)
+            | ControlExpr::Not(_) => None,
         }
     }
 

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -669,6 +669,8 @@ impl CachePoisoning {
 
                 if !has_explicit_origin {
                     vec![
+                        // TODO: use a subfeature here. We'll need to plumb the `&'doc Uses` here,
+                        // maybe by having `Usage` wrap it as part of `ActionCoordinate::usage`?
                         step.location()
                             .primary()
                             .with_keys(["uses".into()])

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -660,6 +660,8 @@ impl CachePoisoning {
                 locations
             }
             Usage::Enabled(origins) => {
+                // We need to check if any of the origins point at or within the `with:` clause.
+                // TODO: Rename? Maybe `usage_originates_from_with_clause`?
                 let has_explicit_origin = origins.iter().any(|origin| {
                     matches!(
                         origin,

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -13,7 +13,10 @@ use crate::audit::{Audit, AuditError, audit_meta};
 use crate::config::Config;
 use crate::finding::location::{Locatable as _, Routable as _};
 use crate::finding::{Confidence, Finding, Fix, FixDisposition, Severity};
-use crate::models::coordinate::{ActionCoordinate, ControlExpr, ControlFieldType, Toggle, Usage};
+use crate::models::coordinate::{
+    ActionCoordinate, ControlExpr, ControlFieldType, Toggle, Usage, VersionBound,
+};
+use crate::models::version::Version;
 use crate::models::workflow::{JobCommon as _, NormalJob, Step, Steps};
 use crate::models::{StepBodyCommon, StepCommon};
 use crate::state::AuditState;
@@ -102,12 +105,16 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "astral-sh/setup-uv".parse().unwrap(),
-            control: ControlExpr::field(
-                Toggle::OptIn,
-                "enable-cache",
-                ControlFieldType::Boolean,
-                true,
-            ),
+            control: ControlExpr::all([
+                // v10 and newer disable cache automatically.
+                ControlExpr::VersionBound(VersionBound::LessThan(Version::parse("v10").unwrap())),
+                ControlExpr::field(
+                    Toggle::OptIn,
+                    "enable-cache",
+                    ControlFieldType::Boolean,
+                    true,
+                ),
+            ]),
         },
         // https://github.com/Swatinem/rust-cache/blob/master/action.yml
         ActionCoordinate::Configurable {

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -105,15 +105,26 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "astral-sh/setup-uv".parse().unwrap(),
-            control: ControlExpr::all([
-                // v10 and newer disable cache automatically.
-                ControlExpr::VersionBound(VersionBound::LessThan(Version::parse("v10").unwrap())),
+            // Caching is enabled when explicitly requested at any version, or
+            // by default before v10 unless explicitly disabled.
+            control: ControlExpr::any([
                 ControlExpr::field(
                     Toggle::OptIn,
                     "enable-cache",
                     ControlFieldType::Boolean,
-                    true,
+                    false,
                 ),
+                ControlExpr::all([
+                    ControlExpr::VersionBound(VersionBound::LessThan(
+                        Version::parse("v10").unwrap(),
+                    )),
+                    ControlExpr::field(
+                        Toggle::OptIn,
+                        "enable-cache",
+                        ControlFieldType::Boolean,
+                        true,
+                    ),
+                ]),
             ]),
         },
         // https://github.com/Swatinem/rust-cache/blob/master/action.yml

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -660,44 +660,59 @@ impl CachePoisoning {
                 locations
             }
             Usage::Enabled(origins) => {
-                // We need to check if any of the origins point at or within the `with:` clause.
-                // TODO: Rename? Maybe `usage_originates_from_with_clause`?
                 let has_explicit_origin = origins.iter().any(|origin| {
                     matches!(
                         origin,
                         ControlOrigin::Input { .. } | ControlOrigin::WithExpression
                     )
                 });
+                let default_fields = origins
+                    .iter()
+                    .filter_map(|origin| match origin {
+                        ControlOrigin::Default { field } => Some(format!("`{field}`")),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
 
-                if !has_explicit_origin {
-                    vec![
-                        // TODO: use a subfeature here. We'll need to plumb the `&'doc Uses` here,
-                        // maybe by having `Usage` wrap it as part of `ActionCoordinate::usage`?
-                        step.location()
-                            .primary()
-                            .with_keys(["uses".into()])
-                            .annotated("enables caching by default"),
-                    ]
+                let default_annotation = if default_fields.is_empty() {
+                    (!has_explicit_origin).then(|| "enables caching by default".to_string())
                 } else {
-                    let mut locations = vec![step.location().primary().with_keys(["uses".into()])];
-                    for origin in origins {
-                        match origin {
-                            ControlOrigin::Input { field } => locations.push(
-                                step.location()
-                                    .with_keys(["with".into(), (*field).into()])
-                                    .annotated("enables caching explicitly here"),
-                            ),
-                            ControlOrigin::WithExpression => locations.push(
-                                step.location()
-                                    .with_keys(["with".into()])
-                                    .annotated("enables caching explicitly here"),
-                            ),
-                            ControlOrigin::Default { .. } | ControlOrigin::UsesRef => {}
-                        }
-                    }
+                    let version_qualifier = if origins.contains(&ControlOrigin::UsesRef) {
+                        " for this action version"
+                    } else {
+                        ""
+                    };
+                    Some(format!(
+                        "omitting {} enables caching{version_qualifier}",
+                        default_fields.join(" and ")
+                    ))
+                };
 
-                    locations
+                // TODO: use a subfeature here. We'll need to plumb the `&'doc Uses` here,
+                // maybe by having `Usage` wrap it as part of `ActionCoordinate::usage`?
+                let mut uses_location = step.location().primary().with_keys(["uses".into()]);
+                if let Some(annotation) = default_annotation {
+                    uses_location = uses_location.annotated(annotation);
                 }
+
+                let mut locations = vec![uses_location];
+                for origin in origins {
+                    match origin {
+                        ControlOrigin::Input { field } => locations.push(
+                            step.location()
+                                .with_keys(["with".into(), (*field).into()])
+                                .annotated("enables caching explicitly here"),
+                        ),
+                        ControlOrigin::WithExpression => locations.push(
+                            step.location()
+                                .with_keys(["with".into()])
+                                .annotated("enables caching explicitly here"),
+                        ),
+                        ControlOrigin::Default { .. } | ControlOrigin::UsesRef => {}
+                    }
+                }
+
+                locations
             }
             Usage::Always => vec![
                 step.location()

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -105,15 +105,20 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "astral-sh/setup-uv".parse().unwrap(),
-            // Caching is enabled when explicitly requested at any version, or
-            // by default before v10 unless explicitly disabled.
             control: ControlExpr::any([
+                // Regardless of the version, setting `enable-cache: true`
+                // always explicitly enables the cache.
                 ControlExpr::field(
                     Toggle::OptIn,
                     "enable-cache",
-                    ControlFieldType::Boolean,
+                    ControlFieldType::Exact(&["true"]),
                     false,
                 ),
+                // For setup-uv below v10, any boolishly true `enable-cache`
+                // (including `enable-cache: auto`) is considered to enable the cache.
+                // This is slightly imprecise since `auto` actually disables the cache
+                // on self-hosted runners, but we don't have a good static way to
+                // detect those at the moment.
                 ControlExpr::all([
                     ControlExpr::VersionBound(VersionBound::LessThan(
                         Version::parse("v10").unwrap(),

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -11,7 +11,10 @@ use crate::{
         location::{Comment, Feature, Location, Routable as _},
     },
     github,
-    models::{StepCommon, action::CompositeStep, uses::RepositoryUsesExt as _, workflow::Step},
+    models::{
+        StepCommon, action::CompositeStep, uses::RepositoryUsesExt as _, version::RawVersion,
+        workflow::Step,
+    },
     utils::once::static_regex,
 };
 
@@ -51,10 +54,8 @@ enum CommentVersionState<'doc> {
 impl RefVersionMismatch {
     fn extract_version_from_comments<'doc>(comments: &'doc [Comment<'doc>]) -> Option<&'doc str> {
         for comment in comments {
-            if let Some(captures) = VERSION_COMMENT_PATTERN.captures(comment.as_ref())
-                && let Some(version_match) = captures.get(1)
-            {
-                return Some(version_match.as_str());
+            if let Some(version) = RawVersion::from_comment(comment) {
+                return Some(version.as_raw());
             }
         }
         None

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -15,7 +15,6 @@ use crate::{
         StepCommon, action::CompositeStep, uses::RepositoryUsesExt as _, version::RawVersion,
         workflow::Step,
     },
-    utils::once::static_regex,
 };
 
 pub(crate) struct RefVersionMismatch {
@@ -26,22 +25,6 @@ audit_meta!(
     RefVersionMismatch,
     "ref-version-mismatch",
     "action's hash pin has mismatched or missing version comment"
-);
-
-static_regex!(
-    VERSION_COMMENT_PATTERN,
-    r#"(?x)                             # verbose mode
-    ^                                   # start of string
-    \#                                  # start of comment
-    \s*                                 # optional whitespace
-    (?:                                 # start non-capturing group for version prefix
-      (?:tag|version|ver)\s*[:=]\s*     # version prefix + `:` or `=`
-    )?                                  # end optional non-capturing group
-    (                                   # start capturing group for version
-      \S+                               # one or more non-whitespace characters
-    )                                   # end capturing group for version
-    $                                   # end of string
-    "#
 );
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -266,52 +249,6 @@ mod tests {
     use crate::{
         finding::location::Locatable as _, models::action::Action, registry::input::InputKey,
     };
-
-    #[test]
-    fn test_version_comment_pattern() {
-        let test_cases = vec![
-            ("# tag=v2.8.0", Some("v2.8.0")),
-            ("# tag=v6-beta", Some("v6-beta")),
-            ("# tag=v1.2.3-rc.1", Some("v1.2.3-rc.1")),
-            ("# tag=v1.2.3rc.1", Some("v1.2.3rc.1")),
-            ("# tag=v6-beta-2", Some("v6-beta-2")),
-            ("# tag=release-2024-01", Some("release-2024-01")),
-            ("# v2.8.0", Some("v2.8.0")),
-            ("# v6-beta", Some("v6-beta")),
-            ("# v1.2.3-rc.1", Some("v1.2.3-rc.1")),
-            ("# v1.2.3rc1", Some("v1.2.3rc1")),
-            ("# v6-beta-2", Some("v6-beta-2")),
-            ("# v1.0.0-rc-1", Some("v1.0.0-rc-1")),
-            ("# v2.0-preview-3", Some("v2.0-preview-3")),
-            ("# tag=2.8.0", Some("2.8.0")),
-            ("# version: 2.8.0", Some("2.8.0")),
-            ("# version: v1.2.3-rc.1", Some("v1.2.3-rc.1")),
-            ("# version: v1.2.3rc.1", Some("v1.2.3rc.1")),
-            ("# version: v6-beta-2", Some("v6-beta-2")),
-            ("# version: v1.0.0-rc-1", Some("v1.0.0-rc-1")),
-            ("# ver=1.0.0", Some("1.0.0")),
-            ("# visit the docs", None),
-            ("# some other comment", None),
-            ("# zizmor: ignore[ref-version-mismatch]", None),
-        ];
-
-        for (comment, expected) in test_cases {
-            // Test the pattern matching directly
-            match (VERSION_COMMENT_PATTERN.captures(comment), expected) {
-                (None, None) => (),
-                (None, Some(expected)) => {
-                    assert!(
-                        false,
-                        "Got no match in '{comment}', but expected {expected}"
-                    )
-                }
-                (Some(caps), None) => {
-                    assert!(false, "Got unexpected match: {caps:?}")
-                }
-                (Some(_), Some(_)) => (),
-            }
-        }
-    }
 
     #[test]
     fn test_comment_version_state_with_unrelated_comment() {

--- a/crates/zizmor/src/audit/use_trusted_publishing.rs
+++ b/crates/zizmor/src/audit/use_trusted_publishing.rs
@@ -38,7 +38,7 @@ static KNOWN_TRUSTED_PUBLISHING_ACTIONS: LazyLock<Vec<(ActionCoordinate, &[&str]
                 ActionCoordinate::Configurable {
                     uses_pattern: "pypa/gh-action-pypi-publish".parse().unwrap(),
                     control: ControlExpr::all([
-                        ControlExpr::single(
+                        ControlExpr::field(
                             Toggle::OptIn,
                             "password",
                             ControlFieldType::FreeString,
@@ -50,13 +50,13 @@ static KNOWN_TRUSTED_PUBLISHING_ACTIONS: LazyLock<Vec<(ActionCoordinate, &[&str]
                         // If we used `any` we'd end up accidentally satisfying
                         // when the user only sets one of the control fields.
                         ControlExpr::all([
-                            ControlExpr::single(
+                            ControlExpr::field(
                                 Toggle::OptIn,
                                 "repository-url",
                                 ControlFieldType::Exact(KNOWN_PYTHON_TP_INDICES),
                                 true,
                             ),
-                            ControlExpr::single(
+                            ControlExpr::field(
                                 Toggle::OptIn,
                                 "repository_url",
                                 ControlFieldType::Exact(KNOWN_PYTHON_TP_INDICES),
@@ -84,7 +84,7 @@ static KNOWN_TRUSTED_PUBLISHING_ACTIONS: LazyLock<Vec<(ActionCoordinate, &[&str]
             (
                 ActionCoordinate::Configurable {
                     uses_pattern: "rubygems/release-gem".parse().unwrap(),
-                    control: ControlExpr::not(ControlExpr::single(
+                    control: ControlExpr::not(ControlExpr::field(
                         Toggle::OptIn,
                         "setup-trusted-publisher",
                         ControlFieldType::Boolean,
@@ -97,13 +97,13 @@ static KNOWN_TRUSTED_PUBLISHING_ACTIONS: LazyLock<Vec<(ActionCoordinate, &[&str]
                 ActionCoordinate::Configurable {
                     uses_pattern: "rubygems/configure-rubygems-credentials".parse().unwrap(),
                     control: ControlExpr::all([
-                        ControlExpr::single(
+                        ControlExpr::field(
                             Toggle::OptIn,
                             "api-token",
                             ControlFieldType::FreeString,
                             false,
                         ),
-                        ControlExpr::single(
+                        ControlExpr::field(
                             Toggle::OptIn,
                             "gem-server",
                             ControlFieldType::Exact(KNOWN_RUBY_TP_INDICES),
@@ -119,14 +119,14 @@ static KNOWN_TRUSTED_PUBLISHING_ACTIONS: LazyLock<Vec<(ActionCoordinate, &[&str]
                 ActionCoordinate::Configurable {
                     uses_pattern: "actions/setup-node".parse().unwrap(),
                     control: ControlExpr::all([
-                        ControlExpr::single(
+                        ControlExpr::field(
                             Toggle::OptIn,
                             "registry-url",
                             ControlFieldType::Exact(KNOWN_NPMJS_TP_INDICES),
                             true,
                         ),
                         // Detect when always-auth is enabled (indicating manual token usage)
-                        ControlExpr::single(
+                        ControlExpr::field(
                             Toggle::OptIn,
                             "always-auth",
                             ControlFieldType::Boolean,

--- a/crates/zizmor/src/finding/location.rs
+++ b/crates/zizmor/src/finding/location.rs
@@ -3,7 +3,6 @@
 use std::borrow::Cow;
 use std::ops::Range;
 
-use crate::models::version::Version;
 use crate::registry::input::InputKey;
 use crate::{models::AsDocument, utils::once::static_regex};
 use line_index::{LineCol, TextSize};

--- a/crates/zizmor/src/finding/location.rs
+++ b/crates/zizmor/src/finding/location.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::ops::Range;
 
+use crate::models::version::Version;
 use crate::registry::input::InputKey;
 use crate::{models::AsDocument, utils::once::static_regex};
 use line_index::{LineCol, TextSize};
@@ -305,7 +306,7 @@ static_regex!(IGNORE_EXPR, r"# zizmor: ignore\[(.+)\](?:\s+.*)?$");
 #[serde(transparent)]
 pub(crate) struct Comment<'doc>(&'doc str);
 
-impl Comment<'_> {
+impl<'doc> Comment<'doc> {
     pub(crate) fn is_meaningful(&self) -> bool {
         let content = self.0.strip_prefix('#').unwrap_or(self.0).trim();
         !content.is_empty()
@@ -323,10 +324,8 @@ impl Comment<'_> {
             .split(",")
             .any(|r| r.trim() == rule_id)
     }
-}
 
-impl<'a> AsRef<str> for Comment<'a> {
-    fn as_ref(&self) -> &'a str {
+    pub(crate) fn as_raw(&self) -> &'doc str {
         self.0
     }
 }

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -53,6 +53,7 @@ impl ActionCoordinate {
     pub(crate) fn usage<'doc>(&self, step: &impl StepCommon<'doc>) -> Option<Usage> {
         let uses_pattern = self.uses_pattern();
 
+        // Only `uses:` clauses are analyzed at the moment.
         let Some(StepBodyCommon::Uses {
             uses: Uses::Repository(uses),
             with,

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -456,14 +456,22 @@ mod tests {
 
     #[test]
     fn test_version_bound_provenance() {
-        let control = ControlExpr::all([
-            ControlExpr::VersionBound(VersionBound::LessThan(Version::parse("v10").unwrap())),
+        let control = ControlExpr::any([
             ControlExpr::field(
                 Toggle::OptIn,
                 "enable-cache",
                 ControlFieldType::Boolean,
-                true,
+                false,
             ),
+            ControlExpr::all([
+                ControlExpr::VersionBound(VersionBound::LessThan(Version::parse("v10").unwrap())),
+                ControlExpr::field(
+                    Toggle::OptIn,
+                    "enable-cache",
+                    ControlFieldType::Boolean,
+                    true,
+                ),
+            ]),
         ]);
 
         let v6 = RepositoryUses::parse("foo/bar@v6.5.0").unwrap();
@@ -481,12 +489,30 @@ mod tests {
         assert_eq!(
             control.eval(&v6, &[], &explicit),
             ControlEvaluation::Satisfied(vec![
-                ControlOrigin::UsesRef,
                 ControlOrigin::Input {
                     field: "enable-cache"
                 },
+                ControlOrigin::UsesRef,
             ])
         );
+
+        let v10 = RepositoryUses::parse("foo/bar@v10.0.0").unwrap();
+        assert_eq!(
+            control.eval(&v10, &[], &explicit),
+            ControlEvaluation::Satisfied(vec![ControlOrigin::Input {
+                field: "enable-cache"
+            }])
+        );
+        assert!(matches!(
+            control.eval(&v10, &[], &IndexMap::new()),
+            ControlEvaluation::NotSatisfied(_)
+        ));
+
+        let disabled = IndexMap::from([("enable-cache".into(), EnvValue::Boolean(false))]);
+        assert!(matches!(
+            control.eval(&v6, &[], &disabled),
+            ControlEvaluation::NotSatisfied(_)
+        ));
 
         let unknown =
             RepositoryUses::parse("foo/bar@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1").unwrap();

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -15,10 +15,10 @@
 
 use std::ops::{BitAnd, BitOr, Not};
 
-use github_actions_models::common::{EnvValue, Uses, expr::LoE};
+use github_actions_models::common::{EnvValue, RepositoryUses, Uses, expr::LoE};
 use indexmap::IndexMap;
 
-use crate::utils::ExtractedExpr;
+use crate::{finding::location::Comment, models::version::Version, utils::ExtractedExpr};
 
 use super::{StepBodyCommon, StepCommon, uses::RepositoryUsesPattern};
 
@@ -27,7 +27,7 @@ pub(crate) enum ActionCoordinate {
         /// The `uses:` pattern of the coordinate
         uses_pattern: RepositoryUsesPattern,
         /// The expression of fields that controls the coordinate
-        control: ControlExpr,
+        control: ControlExpr<'static>,
     },
     NotConfigurable(RepositoryUsesPattern),
 }
@@ -63,6 +63,12 @@ impl ActionCoordinate {
             return None;
         }
 
+        let step_location = step.location();
+        let uses_location = step_location
+            .with_keys(["uses".into()])
+            .concretize(step.document())
+            .ok()?;
+
         match self {
             Self::Configurable {
                 uses_pattern: _,
@@ -71,7 +77,7 @@ impl ActionCoordinate {
                 let LoE::Literal(with) = with else {
                     return Some(Usage::ConditionalOptIn);
                 };
-                match control.eval(with) {
+                match control.eval(uses, &uses_location.concrete.comments, with) {
                     ControlEvaluation::DefaultSatisfied => Some(Usage::DefaultActionBehaviour),
                     ControlEvaluation::Satisfied => Some(Usage::DirectOptIn),
                     ControlEvaluation::NotSatisfied => None,
@@ -186,6 +192,19 @@ impl BitOr for ControlEvaluation {
     }
 }
 
+pub(crate) enum VersionBound<'a> {
+    Exact(Version<'a>),
+    LessThan(Version<'a>),
+    GreaterThan(Version<'a>),
+    // TODO: Not(Version)?
+}
+
+impl<'a> VersionBound<'a> {
+    pub(crate) fn eval(&self, uses: &RepositoryUses) -> ControlEvaluation {
+        todo!()
+    }
+}
+
 /// An "expression" of control fields.
 ///
 /// This allows us to express basic quantified logic, such as
@@ -194,9 +213,11 @@ impl BitOr for ControlEvaluation {
 /// This is made slightly more complicated by the fact that our logic is
 /// four-valued: control fields can be default-satisfied, explicitly satisfied,
 /// not satisfied, or conditionally satisfied.
-pub(crate) enum ControlExpr {
+pub(crate) enum ControlExpr<'a> {
+    /// A single bound on the action's version.
+    VersionBound(VersionBound<'a>),
     /// A single control field.
-    Single {
+    Field {
         /// What kind of toggle the input is.
         toggle: Toggle,
         /// The field that controls the action's behavior.
@@ -206,22 +227,22 @@ pub(crate) enum ControlExpr {
         /// Whether this control is satisfied by default, if not present.
         satisfied_by_default: bool,
     },
-    /// Universal quantification: all of the fields must be satisfied.
+    /// Universal quantification: all of the constraints must be satisfied.
     All(Vec<Self>),
-    /// Existential quantification: any of the fields must be satisfied.
+    /// Existential quantification: any of the constraints must be satisfied.
     Any(Vec<Self>),
     /// Negation: the "opposite" of the expression's satisfaction.
     Not(Box<Self>),
 }
 
-impl ControlExpr {
-    pub(crate) fn single(
+impl<'a> ControlExpr<'a> {
+    pub(crate) fn field(
         toggle: Toggle,
         field_name: &'static str,
         field_type: ControlFieldType,
         enabled_by_default: bool,
     ) -> Self {
-        Self::Single {
+        Self::Field {
             toggle,
             field_name,
             field_type,
@@ -241,9 +262,15 @@ impl ControlExpr {
         Self::Not(Box::new(expr))
     }
 
-    pub(crate) fn eval(&self, with: &IndexMap<String, EnvValue>) -> ControlEvaluation {
+    pub(crate) fn eval(
+        &self,
+        uses: &RepositoryUses,
+        comments: &[Comment],
+        with: &IndexMap<String, EnvValue>,
+    ) -> ControlEvaluation {
         match self {
-            Self::Single {
+            Self::VersionBound(vb) => todo!(),
+            Self::Field {
                 toggle,
                 field_name,
                 field_type,
@@ -316,13 +343,13 @@ impl ControlExpr {
             }
             Self::All(exprs) => exprs
                 .iter()
-                .map(|expr| expr.eval(with))
+                .map(|expr| expr.eval(uses, comments, with))
                 .fold(ControlEvaluation::Satisfied, |acc, expr| acc & expr),
             Self::Any(exprs) => exprs
                 .iter()
-                .map(|expr| expr.eval(with))
+                .map(|expr| expr.eval(uses, comments, with))
                 .fold(ControlEvaluation::NotSatisfied, |acc, expr| acc | expr),
-            Self::Not(expr) => !expr.eval(with),
+            Self::Not(expr) => !expr.eval(uses, comments, with),
         }
     }
 }
@@ -339,7 +366,7 @@ pub(crate) enum Usage {
 mod tests {
     use std::str::FromStr as _;
 
-    use github_actions_models::common::EnvValue;
+    use github_actions_models::common::{EnvValue, RepositoryUses};
     use indexmap::IndexMap;
 
     use super::ActionCoordinate;
@@ -357,27 +384,28 @@ mod tests {
     #[test]
     fn test_freestring_control() {
         let optin_control =
-            ControlExpr::single(Toggle::OptIn, "set-me", ControlFieldType::FreeString, false);
+            ControlExpr::field(Toggle::OptIn, "set-me", ControlFieldType::FreeString, false);
         let optout_control =
-            ControlExpr::single(Toggle::OptOut, "set-me", ControlFieldType::FreeString, true);
+            ControlExpr::field(Toggle::OptOut, "set-me", ControlFieldType::FreeString, true);
 
+        let uses = RepositoryUses::parse("foo/bar").unwrap();
         let with_enabled = IndexMap::from([("set-me".into(), EnvValue::String("anything".into()))]);
         let with_disabled = IndexMap::from([("set-me".into(), EnvValue::String("".into()))]);
 
         assert!(matches!(
-            optin_control.eval(&with_enabled),
+            optin_control.eval(&uses, &[], &with_enabled),
             ControlEvaluation::Satisfied
         ));
         assert!(matches!(
-            optin_control.eval(&with_disabled),
+            optin_control.eval(&uses, &[], &with_disabled),
             ControlEvaluation::NotSatisfied
         ));
         assert!(matches!(
-            optout_control.eval(&with_enabled),
+            optout_control.eval(&uses, &[], &with_enabled),
             ControlEvaluation::NotSatisfied
         ));
         assert!(matches!(
-            optout_control.eval(&with_disabled),
+            optout_control.eval(&uses, &[], &with_disabled),
             ControlEvaluation::Satisfied
         ));
     }
@@ -449,7 +477,7 @@ mod tests {
         // missing the needed control.
         let coord = ActionCoordinate::Configurable {
             uses_pattern: RepositoryUsesPattern::from_str("foo/bar").unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "set-me", ControlFieldType::Boolean, false),
+            control: ControlExpr::field(Toggle::OptIn, "set-me", ControlFieldType::Boolean, false),
         };
         let step = &steps[0];
         assert_eq!(coord.usage(step), None);
@@ -465,7 +493,7 @@ mod tests {
         // Coordinate `uses:` matches and is enabled by default.
         let coord = ActionCoordinate::Configurable {
             uses_pattern: RepositoryUsesPattern::from_str("foo/bar").unwrap(),
-            control: ControlExpr::single(Toggle::OptIn, "set-me", ControlFieldType::Boolean, true),
+            control: ControlExpr::field(Toggle::OptIn, "set-me", ControlFieldType::Boolean, true),
         };
         let step = &steps[0];
         assert_eq!(coord.usage(step), Some(Usage::DefaultActionBehaviour));
@@ -482,7 +510,7 @@ mod tests {
         // the default.
         let coord = ActionCoordinate::Configurable {
             uses_pattern: RepositoryUsesPattern::from_str("foo/bar").unwrap(),
-            control: ControlExpr::single(
+            control: ControlExpr::field(
                 Toggle::OptOut,
                 "disable-cache",
                 ControlFieldType::Boolean,

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -359,7 +359,14 @@ impl<'a> ControlExpr<'a> {
                         ControlFieldType::FreeString => Some(!field_value.is_empty()),
                         // We expect a "fixed" string control, i.e. one of a set of values.
                         ControlFieldType::Exact(items) => {
-                            Some(items.contains(&field_value.to_string().as_str()))
+                            let value = field_value.to_string();
+                            if ExtractedExpr::from_fenced(&value).is_some() {
+                                // Like `ControlFieldType::Boolean`, this could
+                                // evaluate any way.
+                                None
+                            } else {
+                                Some(items.contains(&value.as_str()))
+                            }
                         }
                     };
 
@@ -455,12 +462,41 @@ mod tests {
     }
 
     #[test]
+    fn test_exact_control() {
+        let control = ControlExpr::field(
+            Toggle::OptIn,
+            "set-me",
+            ControlFieldType::Exact(&["yes"]),
+            false,
+        );
+        let uses = RepositoryUses::parse("foo/bar@doesnotmatter").unwrap();
+
+        for (value, expected) in [
+            (
+                EnvValue::String("yes".into()),
+                ControlEvaluation::Satisfied(vec![ControlOrigin::Input { field: "set-me" }]),
+            ),
+            (
+                EnvValue::String("no".into()),
+                ControlEvaluation::NotSatisfied(vec![ControlOrigin::Input { field: "set-me" }]),
+            ),
+            (
+                EnvValue::String("${{ expression }}".into()),
+                ControlEvaluation::Conditional(vec![ControlOrigin::Input { field: "set-me" }]),
+            ),
+        ] {
+            let with = IndexMap::from([("set-me".into(), value)]);
+            assert_eq!(control.eval(&uses, &[], &with), expected);
+        }
+    }
+
+    #[test]
     fn test_version_bound_provenance() {
         let control = ControlExpr::any([
             ControlExpr::field(
                 Toggle::OptIn,
                 "enable-cache",
-                ControlFieldType::Boolean,
+                ControlFieldType::Exact(&["true"]),
                 false,
             ),
             ControlExpr::all([
@@ -507,6 +543,21 @@ mod tests {
             control.eval(&v10, &[], &IndexMap::new()),
             ControlEvaluation::NotSatisfied(_)
         ));
+
+        let automatic = IndexMap::from([("enable-cache".into(), EnvValue::String("auto".into()))]);
+        assert!(matches!(
+            control.eval(&v10, &[], &automatic),
+            ControlEvaluation::NotSatisfied(_)
+        ));
+        assert_eq!(
+            control.eval(&v6, &[], &automatic),
+            ControlEvaluation::Satisfied(vec![
+                ControlOrigin::UsesRef,
+                ControlOrigin::Input {
+                    field: "enable-cache"
+                },
+            ])
+        );
 
         let disabled = IndexMap::from([("enable-cache".into(), EnvValue::Boolean(false))]);
         assert!(matches!(

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -16,7 +16,7 @@
 use std::ops::{BitAnd, BitOr, Not};
 
 use github_actions_models::common::{EnvValue, RepositoryUses, Uses, expr::LoE};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet, indexset};
 
 use crate::{
     finding::location::Comment,
@@ -80,7 +80,9 @@ impl ActionCoordinate {
                 control,
             } => {
                 let LoE::Literal(with) = with else {
-                    return Some(Usage::Conditional(vec![ControlOrigin::WithExpression]));
+                    return Some(Usage::Conditional(indexset! {
+                        ControlOrigin::WithExpression
+                    }));
                 };
                 match control.eval(uses, &uses_location.concrete.comments, with) {
                     ControlEvaluation::Satisfied(origins) => Some(Usage::Enabled(origins)),
@@ -118,7 +120,7 @@ pub(crate) enum ControlFieldType {
 }
 
 /// The part of a step that determined a control expression's result.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum ControlOrigin {
     /// A missing input whose action-defined default determined the result.
     ///
@@ -146,24 +148,12 @@ pub(crate) enum ControlOrigin {
 #[derive(Clone, Debug, PartialEq)]
 enum ControlEvaluation {
     /// The control expression is satisfied.
-    Satisfied(Vec<ControlOrigin>),
+    Satisfied(IndexSet<ControlOrigin>),
     /// The control expression is not satisfied.
-    NotSatisfied(Vec<ControlOrigin>),
+    NotSatisfied(IndexSet<ControlOrigin>),
     /// The result depends on an Actions expression or another value that can't
     /// be determined statically.
-    Conditional(Vec<ControlOrigin>),
-}
-
-impl ControlEvaluation {
-    fn merge_origins(mut lhs: Vec<ControlOrigin>, rhs: Vec<ControlOrigin>) -> Vec<ControlOrigin> {
-        for origin in rhs {
-            if !lhs.contains(&origin) {
-                lhs.push(origin);
-            }
-        }
-
-        lhs
-    }
+    Conditional(IndexSet<ControlOrigin>),
 }
 
 impl Not for ControlEvaluation {
@@ -183,19 +173,22 @@ impl BitAnd for ControlEvaluation {
 
     fn bitand(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
-            (Self::NotSatisfied(lhs), Self::NotSatisfied(rhs)) => {
-                Self::NotSatisfied(Self::merge_origins(lhs, rhs))
+            (Self::NotSatisfied(mut lhs), Self::NotSatisfied(rhs)) => {
+                lhs.extend(rhs);
+                Self::NotSatisfied(lhs)
             }
             (Self::NotSatisfied(origins), _) | (_, Self::NotSatisfied(origins)) => {
                 Self::NotSatisfied(origins)
             }
-            (Self::Conditional(lhs), Self::Conditional(rhs)) => {
-                Self::Conditional(Self::merge_origins(lhs, rhs))
+            (Self::Conditional(mut lhs), Self::Conditional(rhs)) => {
+                lhs.extend(rhs);
+                Self::Conditional(lhs)
             }
             (Self::Conditional(origins), Self::Satisfied(_))
             | (Self::Satisfied(_), Self::Conditional(origins)) => Self::Conditional(origins),
-            (Self::Satisfied(lhs), Self::Satisfied(rhs)) => {
-                Self::Satisfied(Self::merge_origins(lhs, rhs))
+            (Self::Satisfied(mut lhs), Self::Satisfied(rhs)) => {
+                lhs.extend(rhs);
+                Self::Satisfied(lhs)
             }
         }
     }
@@ -206,19 +199,22 @@ impl BitOr for ControlEvaluation {
 
     fn bitor(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
-            (Self::Satisfied(lhs), Self::Satisfied(rhs)) => {
-                Self::Satisfied(Self::merge_origins(lhs, rhs))
+            (Self::Satisfied(mut lhs), Self::Satisfied(rhs)) => {
+                lhs.extend(rhs);
+                Self::Satisfied(lhs)
             }
             (Self::Satisfied(origins), _) | (_, Self::Satisfied(origins)) => {
                 Self::Satisfied(origins)
             }
-            (Self::Conditional(lhs), Self::Conditional(rhs)) => {
-                Self::Conditional(Self::merge_origins(lhs, rhs))
+            (Self::Conditional(mut lhs), Self::Conditional(rhs)) => {
+                lhs.extend(rhs);
+                Self::Conditional(lhs)
             }
             (Self::Conditional(origins), Self::NotSatisfied(_))
             | (Self::NotSatisfied(_), Self::Conditional(origins)) => Self::Conditional(origins),
-            (Self::NotSatisfied(lhs), Self::NotSatisfied(rhs)) => {
-                Self::NotSatisfied(Self::merge_origins(lhs, rhs))
+            (Self::NotSatisfied(mut lhs), Self::NotSatisfied(rhs)) => {
+                lhs.extend(rhs);
+                Self::NotSatisfied(lhs)
             }
         }
     }
@@ -251,7 +247,7 @@ impl<'a> VersionBound<'a> {
 
         let Some(ref version) = version else {
             // No detectable version; treat as conditional.
-            return ControlEvaluation::Conditional(vec![ControlOrigin::UsesRef]);
+            return ControlEvaluation::Conditional(indexset! { ControlOrigin::UsesRef });
         };
 
         let satisfied = match self {
@@ -261,9 +257,9 @@ impl<'a> VersionBound<'a> {
         };
 
         if satisfied {
-            ControlEvaluation::Satisfied(vec![ControlOrigin::UsesRef])
+            ControlEvaluation::Satisfied(indexset! { ControlOrigin::UsesRef })
         } else {
-            ControlEvaluation::NotSatisfied(vec![ControlOrigin::UsesRef])
+            ControlEvaluation::NotSatisfied(indexset! { ControlOrigin::UsesRef })
         }
     }
 }
@@ -371,7 +367,7 @@ impl<'a> ControlExpr<'a> {
                         }
                     };
 
-                    let origins = vec![ControlOrigin::Input { field: field_name }];
+                    let origins = indexset! { ControlOrigin::Input { field: field_name } };
                     match (control_value, toggle) {
                         (None, _) => ControlEvaluation::Conditional(origins),
                         (Some(true), Toggle::OptIn) | (Some(false), Toggle::OptOut) => {
@@ -382,23 +378,29 @@ impl<'a> ControlExpr<'a> {
                         }
                     }
                 } else if *enabled_by_default {
-                    ControlEvaluation::Satisfied(vec![ControlOrigin::Default { field: field_name }])
+                    ControlEvaluation::Satisfied(indexset! {
+                        ControlOrigin::Default { field: field_name }
+                    })
                 } else {
-                    ControlEvaluation::NotSatisfied(vec![ControlOrigin::Default {
-                        field: field_name,
-                    }])
+                    ControlEvaluation::NotSatisfied(indexset! {
+                        ControlOrigin::Default { field: field_name }
+                    })
                 }
             }
             Self::All(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(ControlEvaluation::Satisfied(vec![]), |acc, expr| acc & expr),
+                .fold(
+                    ControlEvaluation::Satisfied(IndexSet::new()),
+                    |acc, expr| acc & expr,
+                ),
             Self::Any(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(ControlEvaluation::NotSatisfied(vec![]), |acc, expr| {
-                    acc | expr
-                }),
+                .fold(
+                    ControlEvaluation::NotSatisfied(IndexSet::new()),
+                    |acc, expr| acc | expr,
+                ),
             Self::Not(expr) => !expr.eval(uses, comments, with),
         }
     }
@@ -406,8 +408,8 @@ impl<'a> ControlExpr<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum Usage {
-    Enabled(Vec<ControlOrigin>),
-    Conditional(Vec<ControlOrigin>),
+    Enabled(IndexSet<ControlOrigin>),
+    Conditional(IndexSet<ControlOrigin>),
     Always,
 }
 
@@ -416,7 +418,7 @@ mod tests {
     use std::str::FromStr as _;
 
     use github_actions_models::common::{EnvValue, RepositoryUses};
-    use indexmap::IndexMap;
+    use indexmap::{IndexMap, indexset};
 
     use super::{
         ActionCoordinate, ControlEvaluation, ControlExpr, ControlFieldType, ControlOrigin, Toggle,
@@ -446,19 +448,27 @@ mod tests {
 
         assert_eq!(
             optin_control.eval(&uses, &[], &with_enabled),
-            ControlEvaluation::Satisfied(vec![ControlOrigin::Input { field: "set-me" }])
+            ControlEvaluation::Satisfied(indexset! {
+                ControlOrigin::Input { field: "set-me" }
+            })
         );
         assert_eq!(
             optin_control.eval(&uses, &[], &with_disabled),
-            ControlEvaluation::NotSatisfied(vec![ControlOrigin::Input { field: "set-me" }])
+            ControlEvaluation::NotSatisfied(indexset! {
+                ControlOrigin::Input { field: "set-me" }
+            })
         );
         assert_eq!(
             optout_control.eval(&uses, &[], &with_enabled),
-            ControlEvaluation::NotSatisfied(vec![ControlOrigin::Input { field: "set-me" }])
+            ControlEvaluation::NotSatisfied(indexset! {
+                ControlOrigin::Input { field: "set-me" }
+            })
         );
         assert_eq!(
             optout_control.eval(&uses, &[], &with_disabled),
-            ControlEvaluation::Satisfied(vec![ControlOrigin::Input { field: "set-me" }])
+            ControlEvaluation::Satisfied(indexset! {
+                ControlOrigin::Input { field: "set-me" }
+            })
         );
     }
 
@@ -475,15 +485,21 @@ mod tests {
         for (value, expected) in [
             (
                 EnvValue::String("yes".into()),
-                ControlEvaluation::Satisfied(vec![ControlOrigin::Input { field: "set-me" }]),
+                ControlEvaluation::Satisfied(indexset! {
+                    ControlOrigin::Input { field: "set-me" }
+                }),
             ),
             (
                 EnvValue::String("no".into()),
-                ControlEvaluation::NotSatisfied(vec![ControlOrigin::Input { field: "set-me" }]),
+                ControlEvaluation::NotSatisfied(indexset! {
+                    ControlOrigin::Input { field: "set-me" }
+                }),
             ),
             (
                 EnvValue::String("${{ expression }}".into()),
-                ControlEvaluation::Conditional(vec![ControlOrigin::Input { field: "set-me" }]),
+                ControlEvaluation::Conditional(indexset! {
+                    ControlOrigin::Input { field: "set-me" }
+                }),
             ),
         ] {
             let with = IndexMap::from([("set-me".into(), value)]);
@@ -514,31 +530,33 @@ mod tests {
         let v6 = RepositoryUses::parse("foo/bar@v6.5.0").unwrap();
         assert_eq!(
             control.eval(&v6, &[], &IndexMap::new()),
-            ControlEvaluation::Satisfied(vec![
+            ControlEvaluation::Satisfied(indexset! {
                 ControlOrigin::UsesRef,
                 ControlOrigin::Default {
                     field: "enable-cache"
                 },
-            ])
+            })
         );
 
         let explicit = IndexMap::from([("enable-cache".into(), EnvValue::Boolean(true))]);
         assert_eq!(
             control.eval(&v6, &[], &explicit),
-            ControlEvaluation::Satisfied(vec![
+            ControlEvaluation::Satisfied(indexset! {
                 ControlOrigin::Input {
                     field: "enable-cache"
                 },
                 ControlOrigin::UsesRef,
-            ])
+            })
         );
 
         let v10 = RepositoryUses::parse("foo/bar@v10.0.0").unwrap();
         assert_eq!(
             control.eval(&v10, &[], &explicit),
-            ControlEvaluation::Satisfied(vec![ControlOrigin::Input {
-                field: "enable-cache"
-            }])
+            ControlEvaluation::Satisfied(indexset! {
+                ControlOrigin::Input {
+                    field: "enable-cache"
+                }
+            })
         );
         assert!(matches!(
             control.eval(&v10, &[], &IndexMap::new()),
@@ -552,12 +570,12 @@ mod tests {
         ));
         assert_eq!(
             control.eval(&v6, &[], &automatic),
-            ControlEvaluation::Satisfied(vec![
+            ControlEvaluation::Satisfied(indexset! {
                 ControlOrigin::UsesRef,
                 ControlOrigin::Input {
                     field: "enable-cache"
                 },
-            ])
+            })
         );
 
         let disabled = IndexMap::from([("enable-cache".into(), EnvValue::Boolean(false))]);
@@ -570,7 +588,7 @@ mod tests {
             RepositoryUses::parse("foo/bar@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1").unwrap();
         assert_eq!(
             control.eval(&unknown, &[], &IndexMap::new()),
-            ControlEvaluation::Conditional(vec![ControlOrigin::UsesRef])
+            ControlEvaluation::Conditional(indexset! { ControlOrigin::UsesRef })
         );
     }
 
@@ -650,9 +668,9 @@ mod tests {
         let step = &steps[4];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::Enabled(vec![ControlOrigin::Input {
-                field: "set-me"
-            }]))
+            Some(Usage::Enabled(indexset! {
+                ControlOrigin::Input { field: "set-me" }
+            }))
         );
 
         // Coordinate `uses:` matches but is explicitly toggled off.
@@ -667,18 +685,18 @@ mod tests {
         let step = &steps[0];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::Enabled(vec![ControlOrigin::Default {
-                field: "set-me"
-            }]))
+            Some(Usage::Enabled(indexset! {
+                ControlOrigin::Default { field: "set-me" }
+            }))
         );
 
         // Coordinate `uses:` matches and is explicitly toggled on.
         let step = &steps[4];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::Enabled(vec![ControlOrigin::Input {
-                field: "set-me"
-            }]))
+            Some(Usage::Enabled(indexset! {
+                ControlOrigin::Input { field: "set-me" }
+            }))
         );
 
         // Coordinate `uses:` matches but is explicitly toggled off, despite default enablement.
@@ -707,16 +725,20 @@ mod tests {
         let step = &steps[7];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::Enabled(vec![ControlOrigin::Input {
-                field: "disable-cache"
-            }]))
+            Some(Usage::Enabled(indexset! {
+                ControlOrigin::Input {
+                    field: "disable-cache"
+                }
+            }))
         );
 
         // Coordinate `uses:` matches but `with:` is an expression.
         let step = &steps[8];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::Conditional(vec![ControlOrigin::WithExpression]))
+            Some(Usage::Conditional(indexset! {
+                ControlOrigin::WithExpression
+            }))
         );
     }
 }

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -162,7 +162,7 @@ impl BitAnd for ControlEvaluation {
             (Self::NotSatisfied, Self::Satisfied) => Self::NotSatisfied,
             (Self::NotSatisfied, Self::NotSatisfied) => Self::NotSatisfied,
             (Self::NotSatisfied, Self::Conditional) => Self::NotSatisfied,
-            (Self::Conditional, Self::DefaultSatisfied) => Self::Satisfied,
+            (Self::Conditional, Self::DefaultSatisfied) => Self::Conditional,
             (Self::Conditional, Self::Satisfied) => Self::Conditional,
             (Self::Conditional, Self::NotSatisfied) => Self::NotSatisfied,
             (Self::Conditional, Self::Conditional) => Self::Conditional,
@@ -231,21 +231,21 @@ impl<'a> VersionBound<'a> {
         match self {
             VersionBound::Exact(control) => {
                 if version == control {
-                    ControlEvaluation::Satisfied
+                    ControlEvaluation::DefaultSatisfied
                 } else {
                     ControlEvaluation::NotSatisfied
                 }
             }
             VersionBound::LessThan(control) => {
                 if version < control {
-                    ControlEvaluation::Satisfied
+                    ControlEvaluation::DefaultSatisfied
                 } else {
                     ControlEvaluation::NotSatisfied
                 }
             }
             VersionBound::GreaterThan(control) => {
                 if version > control {
-                    ControlEvaluation::Satisfied
+                    ControlEvaluation::DefaultSatisfied
                 } else {
                     ControlEvaluation::NotSatisfied
                 }
@@ -393,7 +393,7 @@ impl<'a> ControlExpr<'a> {
             Self::All(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(ControlEvaluation::Satisfied, |acc, expr| acc & expr),
+                .fold(ControlEvaluation::DefaultSatisfied, |acc, expr| acc & expr),
             Self::Any(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -79,17 +79,16 @@ impl ActionCoordinate {
                 control,
             } => {
                 let LoE::Literal(with) = with else {
-                    return Some(Usage::conditional([ControlOrigin::WithExpression]));
+                    return Some(Usage::Conditional(vec![ControlOrigin::WithExpression]));
                 };
-                let evaluation = control.eval(uses, &uses_location.concrete.comments, with);
-                match evaluation.state {
-                    ControlState::Satisfied => Some(Usage::enabled(evaluation.origins)),
-                    ControlState::NotSatisfied => None,
-                    ControlState::Conditional => Some(Usage::conditional(evaluation.origins)),
+                match control.eval(uses, &uses_location.concrete.comments, with) {
+                    ControlEvaluation::Satisfied(origins) => Some(Usage::Enabled(origins)),
+                    ControlEvaluation::NotSatisfied(_) => None,
+                    ControlEvaluation::Conditional(origins) => Some(Usage::Conditional(origins)),
                 }
             }
             // The mere presence of this `uses:` implies the expected usage semantics.
-            Self::NotConfigurable(_) => Some(Usage::always()),
+            Self::NotConfigurable(_) => Some(Usage::Always),
         }
     }
 }
@@ -117,18 +116,6 @@ pub(crate) enum ControlFieldType {
     Exact(&'static [&'static str]),
 }
 
-/// The logical result of evaluating a control expression.
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum ControlState {
-    /// The control expression is satisfied.
-    Satisfied,
-    /// The control expression is not satisfied.
-    NotSatisfied,
-    /// The result depends on an Actions expression or another value that can't
-    /// be determined statically.
-    Conditional,
-}
-
 /// The part of a step that determined a control expression's result.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum ControlOrigin {
@@ -153,62 +140,40 @@ pub(crate) enum ControlOrigin {
     WithExpression,
 }
 
-/// The result of evaluating a control expression, including the evidence that
-/// produced that result.
+/// The logical result of evaluating a control expression, together with the
+/// evidence that produced that result.
 #[derive(Clone, Debug, PartialEq)]
-struct ControlEvaluation {
-    state: ControlState,
-    origins: Vec<ControlOrigin>,
+enum ControlEvaluation {
+    /// The control expression is satisfied.
+    Satisfied(Vec<ControlOrigin>),
+    /// The control expression is not satisfied.
+    NotSatisfied(Vec<ControlOrigin>),
+    /// The result depends on an Actions expression or another value that can't
+    /// be determined statically.
+    Conditional(Vec<ControlOrigin>),
 }
 
 impl ControlEvaluation {
-    fn new(state: ControlState, origin: ControlOrigin) -> Self {
-        Self {
-            state,
-            origins: vec![origin],
-        }
-    }
-
-    fn without_origins(state: ControlState) -> Self {
-        Self {
-            state,
-            origins: vec![],
-        }
-    }
-
-    fn decisive_origins(
-        state: ControlState,
-        evaluations: impl IntoIterator<Item = Self>,
-    ) -> Vec<ControlOrigin> {
-        let mut origins = vec![];
-
-        for evaluation in evaluations {
-            if evaluation.state != state {
-                continue;
-            }
-
-            for origin in evaluation.origins {
-                if !origins.contains(&origin) {
-                    origins.push(origin);
-                }
+    fn merge_origins(mut lhs: Vec<ControlOrigin>, rhs: Vec<ControlOrigin>) -> Vec<ControlOrigin> {
+        for origin in rhs {
+            if !lhs.contains(&origin) {
+                lhs.push(origin);
             }
         }
 
-        origins
+        lhs
     }
 }
 
 impl Not for ControlEvaluation {
     type Output = Self;
 
-    fn not(mut self) -> Self::Output {
-        self.state = match self.state {
-            ControlState::Satisfied => ControlState::NotSatisfied,
-            ControlState::NotSatisfied => ControlState::Satisfied,
-            ControlState::Conditional => ControlState::Conditional,
-        };
-
-        self
+    fn not(self) -> Self::Output {
+        match self {
+            Self::Satisfied(origins) => Self::NotSatisfied(origins),
+            Self::NotSatisfied(origins) => Self::Satisfied(origins),
+            Self::Conditional(origins) => Self::Conditional(origins),
+        }
     }
 }
 
@@ -216,19 +181,21 @@ impl BitAnd for ControlEvaluation {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {
-        let state = match (self.state, rhs.state) {
-            (ControlState::NotSatisfied, _) | (_, ControlState::NotSatisfied) => {
-                ControlState::NotSatisfied
+        match (self, rhs) {
+            (Self::NotSatisfied(lhs), Self::NotSatisfied(rhs)) => {
+                Self::NotSatisfied(Self::merge_origins(lhs, rhs))
             }
-            (ControlState::Conditional, _) | (_, ControlState::Conditional) => {
-                ControlState::Conditional
+            (Self::NotSatisfied(origins), _) | (_, Self::NotSatisfied(origins)) => {
+                Self::NotSatisfied(origins)
             }
-            (ControlState::Satisfied, ControlState::Satisfied) => ControlState::Satisfied,
-        };
-
-        Self {
-            state,
-            origins: Self::decisive_origins(state, [self, rhs]),
+            (Self::Conditional(lhs), Self::Conditional(rhs)) => {
+                Self::Conditional(Self::merge_origins(lhs, rhs))
+            }
+            (Self::Conditional(origins), Self::Satisfied(_))
+            | (Self::Satisfied(_), Self::Conditional(origins)) => Self::Conditional(origins),
+            (Self::Satisfied(lhs), Self::Satisfied(rhs)) => {
+                Self::Satisfied(Self::merge_origins(lhs, rhs))
+            }
         }
     }
 }
@@ -237,17 +204,21 @@ impl BitOr for ControlEvaluation {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {
-        let state = match (self.state, rhs.state) {
-            (ControlState::Satisfied, _) | (_, ControlState::Satisfied) => ControlState::Satisfied,
-            (ControlState::Conditional, _) | (_, ControlState::Conditional) => {
-                ControlState::Conditional
+        match (self, rhs) {
+            (Self::Satisfied(lhs), Self::Satisfied(rhs)) => {
+                Self::Satisfied(Self::merge_origins(lhs, rhs))
             }
-            (ControlState::NotSatisfied, ControlState::NotSatisfied) => ControlState::NotSatisfied,
-        };
-
-        Self {
-            state,
-            origins: Self::decisive_origins(state, [self, rhs]),
+            (Self::Satisfied(origins), _) | (_, Self::Satisfied(origins)) => {
+                Self::Satisfied(origins)
+            }
+            (Self::Conditional(lhs), Self::Conditional(rhs)) => {
+                Self::Conditional(Self::merge_origins(lhs, rhs))
+            }
+            (Self::Conditional(origins), Self::NotSatisfied(_))
+            | (Self::NotSatisfied(_), Self::Conditional(origins)) => Self::Conditional(origins),
+            (Self::NotSatisfied(lhs), Self::NotSatisfied(rhs)) => {
+                Self::NotSatisfied(Self::merge_origins(lhs, rhs))
+            }
         }
     }
 }
@@ -279,34 +250,20 @@ impl<'a> VersionBound<'a> {
 
         let Some(ref version) = version else {
             // No detectable version; treat as conditional.
-            return ControlEvaluation::new(ControlState::Conditional, ControlOrigin::UsesRef);
+            return ControlEvaluation::Conditional(vec![ControlOrigin::UsesRef]);
         };
 
-        let state = match self {
-            VersionBound::Exact(control) => {
-                if version == control {
-                    ControlState::Satisfied
-                } else {
-                    ControlState::NotSatisfied
-                }
-            }
-            VersionBound::LessThan(control) => {
-                if version < control {
-                    ControlState::Satisfied
-                } else {
-                    ControlState::NotSatisfied
-                }
-            }
-            VersionBound::GreaterThan(control) => {
-                if version > control {
-                    ControlState::Satisfied
-                } else {
-                    ControlState::NotSatisfied
-                }
-            }
+        let satisfied = match self {
+            VersionBound::Exact(control) => version == control,
+            VersionBound::LessThan(control) => version < control,
+            VersionBound::GreaterThan(control) => version > control,
         };
 
-        ControlEvaluation::new(state, ControlOrigin::UsesRef)
+        if satisfied {
+            ControlEvaluation::Satisfied(vec![ControlOrigin::UsesRef])
+        } else {
+            ControlEvaluation::NotSatisfied(vec![ControlOrigin::UsesRef])
+        }
     }
 }
 
@@ -381,140 +338,69 @@ impl<'a> ControlExpr<'a> {
                 satisfied_by_default: enabled_by_default,
             } => {
                 // If the controlling field is not present, the default dictates the semantics.
-                let (state, origin) = if let Some(field_value) = with.get(*field_name) {
-                    let state = match field_type {
+                if let Some(field_value) = with.get(*field_name) {
+                    let control_value = match field_type {
                         // We expect a boolean control.
                         ControlFieldType::Boolean => match field_value.to_string().as_str() {
-                            "true" => match toggle {
-                                Toggle::OptIn => ControlState::Satisfied,
-                                Toggle::OptOut => ControlState::NotSatisfied,
-                            },
-                            "false" => match toggle {
-                                Toggle::OptIn => ControlState::NotSatisfied,
-                                Toggle::OptOut => ControlState::Satisfied,
-                            },
+                            "true" => Some(true),
+                            "false" => Some(false),
                             other => match ExtractedExpr::from_fenced(other) {
                                 // We have something like `foo: ${{ expr }}`,
                                 // which could evaluate either way.
-                                Some(_) => ControlState::Conditional,
+                                Some(_) => None,
                                 // We have something like `foo: bar`, but we
                                 // were expecting a boolean. Assume pessimistically
                                 // that the action coerces any non-`false` value to `true`.
-                                None => match toggle {
-                                    Toggle::OptIn => ControlState::Satisfied,
-                                    Toggle::OptOut => ControlState::NotSatisfied,
-                                },
+                                None => Some(true),
                             },
                         },
                         // We expect a "free" string control, i.e. any value.
                         // Evaluate just the toggle.
-                        ControlFieldType::FreeString => match field_value.is_empty() {
-                            true => match toggle {
-                                Toggle::OptIn => ControlState::NotSatisfied,
-                                Toggle::OptOut => ControlState::Satisfied,
-                            },
-                            false => match toggle {
-                                Toggle::OptIn => ControlState::Satisfied,
-                                Toggle::OptOut => ControlState::NotSatisfied,
-                            },
-                        },
+                        ControlFieldType::FreeString => Some(!field_value.is_empty()),
                         // We expect a "fixed" string control, i.e. one of a set of values.
                         ControlFieldType::Exact(items) => {
-                            if items.contains(&field_value.to_string().as_str()) {
-                                match toggle {
-                                    Toggle::OptIn => ControlState::Satisfied,
-                                    Toggle::OptOut => ControlState::NotSatisfied,
-                                }
-                            } else {
-                                match toggle {
-                                    Toggle::OptIn => ControlState::NotSatisfied,
-                                    Toggle::OptOut => ControlState::Satisfied,
-                                }
-                            }
+                            Some(items.contains(&field_value.to_string().as_str()))
                         }
                     };
 
-                    (state, ControlOrigin::Input { field: field_name })
+                    let origins = vec![ControlOrigin::Input { field: field_name }];
+                    match (control_value, toggle) {
+                        (None, _) => ControlEvaluation::Conditional(origins),
+                        (Some(true), Toggle::OptIn) | (Some(false), Toggle::OptOut) => {
+                            ControlEvaluation::Satisfied(origins)
+                        }
+                        (Some(false), Toggle::OptIn) | (Some(true), Toggle::OptOut) => {
+                            ControlEvaluation::NotSatisfied(origins)
+                        }
+                    }
                 } else if *enabled_by_default {
-                    (
-                        ControlState::Satisfied,
-                        ControlOrigin::Default { field: field_name },
-                    )
+                    ControlEvaluation::Satisfied(vec![ControlOrigin::Default { field: field_name }])
                 } else {
-                    (
-                        ControlState::NotSatisfied,
-                        ControlOrigin::Default { field: field_name },
-                    )
-                };
-
-                ControlEvaluation::new(state, origin)
+                    ControlEvaluation::NotSatisfied(vec![ControlOrigin::Default {
+                        field: field_name,
+                    }])
+                }
             }
             Self::All(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(
-                    ControlEvaluation::without_origins(ControlState::Satisfied),
-                    |acc, expr| acc & expr,
-                ),
+                .fold(ControlEvaluation::Satisfied(vec![]), |acc, expr| acc & expr),
             Self::Any(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(
-                    ControlEvaluation::without_origins(ControlState::NotSatisfied),
-                    |acc, expr| acc | expr,
-                ),
+                .fold(ControlEvaluation::NotSatisfied(vec![]), |acc, expr| {
+                    acc | expr
+                }),
             Self::Not(expr) => !expr.eval(uses, comments, with),
         }
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub(crate) enum UsageState {
-    Enabled,
-    Conditional,
-    Always,
-}
-
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct Usage {
-    state: UsageState,
-    origins: Vec<ControlOrigin>,
-}
-
-impl Usage {
-    fn enabled(origins: impl IntoIterator<Item = ControlOrigin>) -> Self {
-        Self {
-            state: UsageState::Enabled,
-            origins: origins.into_iter().collect(),
-        }
-    }
-
-    fn conditional(origins: impl IntoIterator<Item = ControlOrigin>) -> Self {
-        Self {
-            state: UsageState::Conditional,
-            origins: origins.into_iter().collect(),
-        }
-    }
-
-    fn always() -> Self {
-        Self {
-            state: UsageState::Always,
-            origins: vec![ControlOrigin::UsesRef],
-        }
-    }
-
-    pub(crate) fn state(&self) -> UsageState {
-        self.state
-    }
-
-    pub(crate) fn origins(&self) -> &[ControlOrigin] {
-        &self.origins
-    }
-
-    pub(crate) fn into_enabled(mut self) -> Self {
-        self.state = UsageState::Enabled;
-        self
-    }
+pub(crate) enum Usage {
+    Enabled(Vec<ControlOrigin>),
+    Conditional(Vec<ControlOrigin>),
+    Always,
 }
 
 #[cfg(test)]
@@ -525,8 +411,8 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::{
-        ActionCoordinate, ControlEvaluation, ControlExpr, ControlFieldType, ControlOrigin,
-        ControlState, Toggle, Usage, VersionBound,
+        ActionCoordinate, ControlEvaluation, ControlExpr, ControlFieldType, ControlOrigin, Toggle,
+        Usage, VersionBound,
     };
     use crate::{
         models::{
@@ -552,31 +438,19 @@ mod tests {
 
         assert_eq!(
             optin_control.eval(&uses, &[], &with_enabled),
-            ControlEvaluation::new(
-                ControlState::Satisfied,
-                ControlOrigin::Input { field: "set-me" }
-            )
+            ControlEvaluation::Satisfied(vec![ControlOrigin::Input { field: "set-me" }])
         );
         assert_eq!(
             optin_control.eval(&uses, &[], &with_disabled),
-            ControlEvaluation::new(
-                ControlState::NotSatisfied,
-                ControlOrigin::Input { field: "set-me" }
-            )
+            ControlEvaluation::NotSatisfied(vec![ControlOrigin::Input { field: "set-me" }])
         );
         assert_eq!(
             optout_control.eval(&uses, &[], &with_enabled),
-            ControlEvaluation::new(
-                ControlState::NotSatisfied,
-                ControlOrigin::Input { field: "set-me" }
-            )
+            ControlEvaluation::NotSatisfied(vec![ControlOrigin::Input { field: "set-me" }])
         );
         assert_eq!(
             optout_control.eval(&uses, &[], &with_disabled),
-            ControlEvaluation::new(
-                ControlState::Satisfied,
-                ControlOrigin::Input { field: "set-me" }
-            )
+            ControlEvaluation::Satisfied(vec![ControlOrigin::Input { field: "set-me" }])
         );
     }
 
@@ -595,36 +469,30 @@ mod tests {
         let v6 = RepositoryUses::parse("foo/bar@v6.5.0").unwrap();
         assert_eq!(
             control.eval(&v6, &[], &IndexMap::new()),
-            ControlEvaluation {
-                state: ControlState::Satisfied,
-                origins: vec![
-                    ControlOrigin::UsesRef,
-                    ControlOrigin::Default {
-                        field: "enable-cache"
-                    },
-                ],
-            }
+            ControlEvaluation::Satisfied(vec![
+                ControlOrigin::UsesRef,
+                ControlOrigin::Default {
+                    field: "enable-cache"
+                },
+            ])
         );
 
         let explicit = IndexMap::from([("enable-cache".into(), EnvValue::Boolean(true))]);
         assert_eq!(
             control.eval(&v6, &[], &explicit),
-            ControlEvaluation {
-                state: ControlState::Satisfied,
-                origins: vec![
-                    ControlOrigin::UsesRef,
-                    ControlOrigin::Input {
-                        field: "enable-cache"
-                    },
-                ],
-            }
+            ControlEvaluation::Satisfied(vec![
+                ControlOrigin::UsesRef,
+                ControlOrigin::Input {
+                    field: "enable-cache"
+                },
+            ])
         );
 
         let unknown =
             RepositoryUses::parse("foo/bar@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1").unwrap();
         assert_eq!(
             control.eval(&unknown, &[], &IndexMap::new()),
-            ControlEvaluation::new(ControlState::Conditional, ControlOrigin::UsesRef)
+            ControlEvaluation::Conditional(vec![ControlOrigin::UsesRef])
         );
     }
 
@@ -688,7 +556,7 @@ mod tests {
 
         // Trivial cases: coordinate is not configurable and matches the `uses:`.
         for step in &[&steps[0], &steps[1]] {
-            assert_eq!(coord.usage(*step), Some(Usage::always()));
+            assert_eq!(coord.usage(*step), Some(Usage::Always));
         }
 
         // Coordinate `uses:` matches but is not enabled by default and is
@@ -704,7 +572,9 @@ mod tests {
         let step = &steps[4];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::enabled([ControlOrigin::Input { field: "set-me" }]))
+            Some(Usage::Enabled(vec![ControlOrigin::Input {
+                field: "set-me"
+            }]))
         );
 
         // Coordinate `uses:` matches but is explicitly toggled off.
@@ -719,14 +589,18 @@ mod tests {
         let step = &steps[0];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::enabled([ControlOrigin::Default { field: "set-me" }]))
+            Some(Usage::Enabled(vec![ControlOrigin::Default {
+                field: "set-me"
+            }]))
         );
 
         // Coordinate `uses:` matches and is explicitly toggled on.
         let step = &steps[4];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::enabled([ControlOrigin::Input { field: "set-me" }]))
+            Some(Usage::Enabled(vec![ControlOrigin::Input {
+                field: "set-me"
+            }]))
         );
 
         // Coordinate `uses:` matches but is explicitly toggled off, despite default enablement.
@@ -755,7 +629,7 @@ mod tests {
         let step = &steps[7];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::enabled([ControlOrigin::Input {
+            Some(Usage::Enabled(vec![ControlOrigin::Input {
                 field: "disable-cache"
             }]))
         );
@@ -764,7 +638,7 @@ mod tests {
         let step = &steps[8];
         assert_eq!(
             coord.usage(step),
-            Some(Usage::conditional([ControlOrigin::WithExpression]))
+            Some(Usage::Conditional(vec![ControlOrigin::WithExpression]))
         );
     }
 }

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -18,7 +18,11 @@ use std::ops::{BitAnd, BitOr, Not};
 use github_actions_models::common::{EnvValue, RepositoryUses, Uses, expr::LoE};
 use indexmap::IndexMap;
 
-use crate::{finding::location::Comment, models::version::Version, utils::ExtractedExpr};
+use crate::{
+    finding::location::Comment,
+    models::{uses::RepositoryUsesExt, version::Version},
+    utils::ExtractedExpr,
+};
 
 use super::{StepBodyCommon, StepCommon, uses::RepositoryUsesPattern};
 
@@ -193,15 +197,60 @@ impl BitOr for ControlEvaluation {
 }
 
 pub(crate) enum VersionBound<'a> {
+    #[allow(dead_code)]
     Exact(Version<'a>),
     LessThan(Version<'a>),
+    #[allow(dead_code)]
     GreaterThan(Version<'a>),
     // TODO: Not(Version)?
 }
 
 impl<'a> VersionBound<'a> {
-    pub(crate) fn eval(&self, uses: &RepositoryUses) -> ControlEvaluation {
-        todo!()
+    /// Evaluate a `uses:` clause (and its comments) against a version bound.
+    ///
+    /// This is currently offline to keep it fast. As a result, some evaluations
+    /// yield [`ControlEvaluation::Conditional`], e.g. `uses: foo/bar@<commit>` with no version
+    /// comment. In the future we could make it online.
+    pub(crate) fn eval(&self, uses: &RepositoryUses, comments: &[Comment]) -> ControlEvaluation {
+        let version = if let Some(sym_ref) = uses.symbolic_ref() {
+            // We have a tag (or branch) reference, which we'll try and treat as a version.
+            Version::parse(sym_ref).ok()
+        } else {
+            // We have a commit reference, which means we need to try and discover the version
+            // in the comments.
+            comments
+                .iter()
+                .find_map(|comment| Version::from_comment(comment))
+        };
+
+        let Some(ref version) = version else {
+            // No detectable version; treat as conditional.
+            return ControlEvaluation::Conditional;
+        };
+
+        match self {
+            VersionBound::Exact(control) => {
+                if version == control {
+                    ControlEvaluation::Satisfied
+                } else {
+                    ControlEvaluation::NotSatisfied
+                }
+            }
+            VersionBound::LessThan(control) => {
+                if version < control {
+                    ControlEvaluation::Satisfied
+                } else {
+                    ControlEvaluation::NotSatisfied
+                }
+            }
+            VersionBound::GreaterThan(control) => {
+                if version > control {
+                    ControlEvaluation::Satisfied
+                } else {
+                    ControlEvaluation::NotSatisfied
+                }
+            }
+        }
     }
 }
 
@@ -214,7 +263,7 @@ impl<'a> VersionBound<'a> {
 /// four-valued: control fields can be default-satisfied, explicitly satisfied,
 /// not satisfied, or conditionally satisfied.
 pub(crate) enum ControlExpr<'a> {
-    /// A single bound on the action's version.
+    /// A bound on the action's version.
     VersionBound(VersionBound<'a>),
     /// A single control field.
     Field {
@@ -269,7 +318,7 @@ impl<'a> ControlExpr<'a> {
         with: &IndexMap<String, EnvValue>,
     ) -> ControlEvaluation {
         match self {
-            Self::VersionBound(vb) => todo!(),
+            Self::VersionBound(vb) => vb.eval(uses, comments),
             Self::Field {
                 toggle,
                 field_name,
@@ -388,7 +437,7 @@ mod tests {
         let optout_control =
             ControlExpr::field(Toggle::OptOut, "set-me", ControlFieldType::FreeString, true);
 
-        let uses = RepositoryUses::parse("foo/bar").unwrap();
+        let uses = RepositoryUses::parse("foo/bar@doesnotmatter").unwrap();
         let with_enabled = IndexMap::from([("set-me".into(), EnvValue::String("anything".into()))]);
         let with_disabled = IndexMap::from([("set-me".into(), EnvValue::String("".into()))]);
 

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -133,12 +133,23 @@ enum ControlState {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum ControlOrigin {
     /// A missing input whose action-defined default determined the result.
+    ///
+    /// For example, an action that has a default of `cache: true`, where usage
+    /// of the action does not override `cache`.
     Default { field: &'static str },
     /// An explicitly configured action input.
+    ///
+    /// For example, a user explicitly setting `cache: true`.
     Input { field: &'static str },
-    /// The action reference in `uses:`, such as its version.
+    /// The `uses:` clause itself.
+    ///
+    /// For example, if we know that `actions/foo@v4` and earlier enable caching
+    /// unconditionally, then we way that the `uses:` clause determines the overall
+    /// result.
     UsesRef,
     /// An expression that supplies the entire `with:` mapping.
+    ///
+    /// This happens if the entire `with:` clause is opaque, e.g. `with: ${{ expr }}`.
     WithExpression,
 }
 

--- a/crates/zizmor/src/models/coordinate.rs
+++ b/crates/zizmor/src/models/coordinate.rs
@@ -20,7 +20,7 @@ use indexmap::IndexMap;
 
 use crate::{
     finding::location::Comment,
-    models::{uses::RepositoryUsesExt, version::Version},
+    models::{uses::RepositoryUsesExt as _, version::Version},
     utils::ExtractedExpr,
 };
 
@@ -79,17 +79,17 @@ impl ActionCoordinate {
                 control,
             } => {
                 let LoE::Literal(with) = with else {
-                    return Some(Usage::ConditionalOptIn);
+                    return Some(Usage::conditional([ControlOrigin::WithExpression]));
                 };
-                match control.eval(uses, &uses_location.concrete.comments, with) {
-                    ControlEvaluation::DefaultSatisfied => Some(Usage::DefaultActionBehaviour),
-                    ControlEvaluation::Satisfied => Some(Usage::DirectOptIn),
-                    ControlEvaluation::NotSatisfied => None,
-                    ControlEvaluation::Conditional => Some(Usage::ConditionalOptIn),
+                let evaluation = control.eval(uses, &uses_location.concrete.comments, with);
+                match evaluation.state {
+                    ControlState::Satisfied => Some(Usage::enabled(evaluation.origins)),
+                    ControlState::NotSatisfied => None,
+                    ControlState::Conditional => Some(Usage::conditional(evaluation.origins)),
                 }
             }
             // The mere presence of this `uses:` implies the expected usage semantics.
-            Self::NotConfigurable(_) => Some(Usage::Always),
+            Self::NotConfigurable(_) => Some(Usage::always()),
         }
     }
 }
@@ -117,30 +117,87 @@ pub(crate) enum ControlFieldType {
     Exact(&'static [&'static str]),
 }
 
-/// The result of evaluating a control expression.
-#[derive(Copy, Clone, PartialEq)]
-pub(crate) enum ControlEvaluation {
-    /// The control expression is satisfied by default.
-    DefaultSatisfied,
+/// The logical result of evaluating a control expression.
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum ControlState {
     /// The control expression is satisfied.
     Satisfied,
     /// The control expression is not satisfied.
     NotSatisfied,
-    /// The control expression is conditionally satisfied,
-    /// i.e. depends on an actions expression or similar.
+    /// The result depends on an Actions expression or another value that can't
+    /// be determined statically.
     Conditional,
+}
+
+/// The part of a step that determined a control expression's result.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum ControlOrigin {
+    /// A missing input whose action-defined default determined the result.
+    Default { field: &'static str },
+    /// An explicitly configured action input.
+    Input { field: &'static str },
+    /// The action reference in `uses:`, such as its version.
+    UsesRef,
+    /// An expression that supplies the entire `with:` mapping.
+    WithExpression,
+}
+
+/// The result of evaluating a control expression, including the evidence that
+/// produced that result.
+#[derive(Clone, Debug, PartialEq)]
+struct ControlEvaluation {
+    state: ControlState,
+    origins: Vec<ControlOrigin>,
+}
+
+impl ControlEvaluation {
+    fn new(state: ControlState, origin: ControlOrigin) -> Self {
+        Self {
+            state,
+            origins: vec![origin],
+        }
+    }
+
+    fn without_origins(state: ControlState) -> Self {
+        Self {
+            state,
+            origins: vec![],
+        }
+    }
+
+    fn decisive_origins(
+        state: ControlState,
+        evaluations: impl IntoIterator<Item = Self>,
+    ) -> Vec<ControlOrigin> {
+        let mut origins = vec![];
+
+        for evaluation in evaluations {
+            if evaluation.state != state {
+                continue;
+            }
+
+            for origin in evaluation.origins {
+                if !origins.contains(&origin) {
+                    origins.push(origin);
+                }
+            }
+        }
+
+        origins
+    }
 }
 
 impl Not for ControlEvaluation {
     type Output = Self;
 
-    fn not(self) -> Self::Output {
-        match self {
-            Self::DefaultSatisfied => Self::NotSatisfied,
-            Self::Satisfied => Self::NotSatisfied,
-            Self::NotSatisfied => Self::Satisfied,
-            Self::Conditional => Self::Conditional,
-        }
+    fn not(mut self) -> Self::Output {
+        self.state = match self.state {
+            ControlState::Satisfied => ControlState::NotSatisfied,
+            ControlState::NotSatisfied => ControlState::Satisfied,
+            ControlState::Conditional => ControlState::Conditional,
+        };
+
+        self
     }
 }
 
@@ -148,24 +205,19 @@ impl BitAnd for ControlEvaluation {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {
-        // NOTE: This could be done less literally, but I find it easier to read.
-        match (self, rhs) {
-            (Self::DefaultSatisfied, Self::DefaultSatisfied) => Self::DefaultSatisfied,
-            (Self::DefaultSatisfied, Self::Satisfied) => Self::Satisfied,
-            (Self::DefaultSatisfied, Self::NotSatisfied) => Self::NotSatisfied,
-            (Self::DefaultSatisfied, Self::Conditional) => Self::Conditional,
-            (Self::Satisfied, Self::DefaultSatisfied) => Self::Satisfied,
-            (Self::Satisfied, Self::Satisfied) => Self::Satisfied,
-            (Self::Satisfied, Self::NotSatisfied) => Self::NotSatisfied,
-            (Self::Satisfied, Self::Conditional) => Self::Conditional,
-            (Self::NotSatisfied, Self::DefaultSatisfied) => Self::NotSatisfied,
-            (Self::NotSatisfied, Self::Satisfied) => Self::NotSatisfied,
-            (Self::NotSatisfied, Self::NotSatisfied) => Self::NotSatisfied,
-            (Self::NotSatisfied, Self::Conditional) => Self::NotSatisfied,
-            (Self::Conditional, Self::DefaultSatisfied) => Self::Conditional,
-            (Self::Conditional, Self::Satisfied) => Self::Conditional,
-            (Self::Conditional, Self::NotSatisfied) => Self::NotSatisfied,
-            (Self::Conditional, Self::Conditional) => Self::Conditional,
+        let state = match (self.state, rhs.state) {
+            (ControlState::NotSatisfied, _) | (_, ControlState::NotSatisfied) => {
+                ControlState::NotSatisfied
+            }
+            (ControlState::Conditional, _) | (_, ControlState::Conditional) => {
+                ControlState::Conditional
+            }
+            (ControlState::Satisfied, ControlState::Satisfied) => ControlState::Satisfied,
+        };
+
+        Self {
+            state,
+            origins: Self::decisive_origins(state, [self, rhs]),
         }
     }
 }
@@ -174,24 +226,17 @@ impl BitOr for ControlEvaluation {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {
-        // TODO: Does this mapping make sense?
-        match (self, rhs) {
-            (Self::DefaultSatisfied, Self::DefaultSatisfied) => Self::DefaultSatisfied,
-            (Self::DefaultSatisfied, Self::Satisfied) => Self::Satisfied,
-            (Self::DefaultSatisfied, Self::NotSatisfied) => Self::DefaultSatisfied,
-            (Self::DefaultSatisfied, Self::Conditional) => Self::DefaultSatisfied,
-            (Self::Satisfied, Self::DefaultSatisfied) => Self::Satisfied,
-            (Self::Satisfied, Self::Satisfied) => Self::Satisfied,
-            (Self::Satisfied, Self::NotSatisfied) => Self::Satisfied,
-            (Self::Satisfied, Self::Conditional) => Self::Satisfied,
-            (Self::NotSatisfied, Self::DefaultSatisfied) => Self::DefaultSatisfied,
-            (Self::NotSatisfied, Self::Satisfied) => Self::Satisfied,
-            (Self::NotSatisfied, Self::NotSatisfied) => Self::NotSatisfied,
-            (Self::NotSatisfied, Self::Conditional) => Self::Conditional,
-            (Self::Conditional, Self::DefaultSatisfied) => Self::DefaultSatisfied,
-            (Self::Conditional, Self::Satisfied) => Self::Satisfied,
-            (Self::Conditional, Self::NotSatisfied) => Self::Conditional,
-            (Self::Conditional, Self::Conditional) => Self::Conditional,
+        let state = match (self.state, rhs.state) {
+            (ControlState::Satisfied, _) | (_, ControlState::Satisfied) => ControlState::Satisfied,
+            (ControlState::Conditional, _) | (_, ControlState::Conditional) => {
+                ControlState::Conditional
+            }
+            (ControlState::NotSatisfied, ControlState::NotSatisfied) => ControlState::NotSatisfied,
+        };
+
+        Self {
+            state,
+            origins: Self::decisive_origins(state, [self, rhs]),
         }
     }
 }
@@ -209,48 +254,48 @@ impl<'a> VersionBound<'a> {
     /// Evaluate a `uses:` clause (and its comments) against a version bound.
     ///
     /// This is currently offline to keep it fast. As a result, some evaluations
-    /// yield [`ControlEvaluation::Conditional`], e.g. `uses: foo/bar@<commit>` with no version
-    /// comment. In the future we could make it online.
-    pub(crate) fn eval(&self, uses: &RepositoryUses, comments: &[Comment]) -> ControlEvaluation {
+    /// are conditional, e.g. `uses: foo/bar@<commit>` with no version comment.
+    /// In the future we could make it online.
+    fn eval(&self, uses: &RepositoryUses, comments: &[Comment]) -> ControlEvaluation {
         let version = if let Some(sym_ref) = uses.symbolic_ref() {
             // We have a tag (or branch) reference, which we'll try and treat as a version.
             Version::parse(sym_ref).ok()
         } else {
             // We have a commit reference, which means we need to try and discover the version
             // in the comments.
-            comments
-                .iter()
-                .find_map(|comment| Version::from_comment(comment))
+            comments.iter().find_map(Version::from_comment)
         };
 
         let Some(ref version) = version else {
             // No detectable version; treat as conditional.
-            return ControlEvaluation::Conditional;
+            return ControlEvaluation::new(ControlState::Conditional, ControlOrigin::UsesRef);
         };
 
-        match self {
+        let state = match self {
             VersionBound::Exact(control) => {
                 if version == control {
-                    ControlEvaluation::DefaultSatisfied
+                    ControlState::Satisfied
                 } else {
-                    ControlEvaluation::NotSatisfied
+                    ControlState::NotSatisfied
                 }
             }
             VersionBound::LessThan(control) => {
                 if version < control {
-                    ControlEvaluation::DefaultSatisfied
+                    ControlState::Satisfied
                 } else {
-                    ControlEvaluation::NotSatisfied
+                    ControlState::NotSatisfied
                 }
             }
             VersionBound::GreaterThan(control) => {
                 if version > control {
-                    ControlEvaluation::DefaultSatisfied
+                    ControlState::Satisfied
                 } else {
-                    ControlEvaluation::NotSatisfied
+                    ControlState::NotSatisfied
                 }
             }
-        }
+        };
+
+        ControlEvaluation::new(state, ControlOrigin::UsesRef)
     }
 }
 
@@ -259,9 +304,8 @@ impl<'a> VersionBound<'a> {
 /// This allows us to express basic quantified logic, such as
 /// "all/any of these fields must be satisfied".
 ///
-/// This is made slightly more complicated by the fact that our logic is
-/// four-valued: control fields can be default-satisfied, explicitly satisfied,
-/// not satisfied, or conditionally satisfied.
+/// Evaluations also retain the origins that determined their logical result,
+/// allowing consumers to distinguish inputs, defaults, and `uses:` constraints.
 pub(crate) enum ControlExpr<'a> {
     /// A bound on the action's version.
     VersionBound(VersionBound<'a>),
@@ -311,7 +355,7 @@ impl<'a> ControlExpr<'a> {
         Self::Not(Box::new(expr))
     }
 
-    pub(crate) fn eval(
+    fn eval(
         &self,
         uses: &RepositoryUses,
         comments: &[Comment],
@@ -326,89 +370,140 @@ impl<'a> ControlExpr<'a> {
                 satisfied_by_default: enabled_by_default,
             } => {
                 // If the controlling field is not present, the default dictates the semantics.
-                if let Some(field_value) = with.get(*field_name) {
-                    match field_type {
+                let (state, origin) = if let Some(field_value) = with.get(*field_name) {
+                    let state = match field_type {
                         // We expect a boolean control.
                         ControlFieldType::Boolean => match field_value.to_string().as_str() {
                             "true" => match toggle {
-                                Toggle::OptIn => ControlEvaluation::Satisfied,
-                                Toggle::OptOut => ControlEvaluation::NotSatisfied,
+                                Toggle::OptIn => ControlState::Satisfied,
+                                Toggle::OptOut => ControlState::NotSatisfied,
                             },
                             "false" => match toggle {
-                                Toggle::OptIn => ControlEvaluation::NotSatisfied,
-                                Toggle::OptOut => ControlEvaluation::Satisfied,
+                                Toggle::OptIn => ControlState::NotSatisfied,
+                                Toggle::OptOut => ControlState::Satisfied,
                             },
                             other => match ExtractedExpr::from_fenced(other) {
                                 // We have something like `foo: ${{ expr }}`,
                                 // which could evaluate either way.
-                                Some(_) => ControlEvaluation::Conditional,
+                                Some(_) => ControlState::Conditional,
                                 // We have something like `foo: bar`, but we
                                 // were expecting a boolean. Assume pessimistically
                                 // that the action coerces any non-`false` value to `true`.
                                 None => match toggle {
-                                    Toggle::OptIn => ControlEvaluation::Satisfied,
-                                    Toggle::OptOut => ControlEvaluation::NotSatisfied,
+                                    Toggle::OptIn => ControlState::Satisfied,
+                                    Toggle::OptOut => ControlState::NotSatisfied,
                                 },
                             },
                         },
                         // We expect a "free" string control, i.e. any value.
                         // Evaluate just the toggle.
-                        ControlFieldType::FreeString => {
-                            match field_value.is_empty() {
-                                true => match toggle {
-                                    Toggle::OptIn => ControlEvaluation::NotSatisfied,
-                                    Toggle::OptOut => ControlEvaluation::Satisfied,
-                                },
-                                false => match toggle {
-                                    Toggle::OptIn => ControlEvaluation::Satisfied,
-                                    Toggle::OptOut => ControlEvaluation::NotSatisfied,
-                                },
-                            }
-                            // match toggle {
-                            //     Toggle::OptIn => ControlEvaluation::Satisfied,
-                            //     Toggle::OptOut => ControlEvaluation::NotSatisfied,
-                            // }
-                        }
+                        ControlFieldType::FreeString => match field_value.is_empty() {
+                            true => match toggle {
+                                Toggle::OptIn => ControlState::NotSatisfied,
+                                Toggle::OptOut => ControlState::Satisfied,
+                            },
+                            false => match toggle {
+                                Toggle::OptIn => ControlState::Satisfied,
+                                Toggle::OptOut => ControlState::NotSatisfied,
+                            },
+                        },
                         // We expect a "fixed" string control, i.e. one of a set of values.
                         ControlFieldType::Exact(items) => {
                             if items.contains(&field_value.to_string().as_str()) {
                                 match toggle {
-                                    Toggle::OptIn => ControlEvaluation::Satisfied,
-                                    Toggle::OptOut => ControlEvaluation::NotSatisfied,
+                                    Toggle::OptIn => ControlState::Satisfied,
+                                    Toggle::OptOut => ControlState::NotSatisfied,
                                 }
                             } else {
                                 match toggle {
-                                    Toggle::OptIn => ControlEvaluation::NotSatisfied,
-                                    Toggle::OptOut => ControlEvaluation::Satisfied,
+                                    Toggle::OptIn => ControlState::NotSatisfied,
+                                    Toggle::OptOut => ControlState::Satisfied,
                                 }
                             }
                         }
-                    }
+                    };
+
+                    (state, ControlOrigin::Input { field: field_name })
                 } else if *enabled_by_default {
-                    ControlEvaluation::DefaultSatisfied
+                    (
+                        ControlState::Satisfied,
+                        ControlOrigin::Default { field: field_name },
+                    )
                 } else {
-                    ControlEvaluation::NotSatisfied
-                }
+                    (
+                        ControlState::NotSatisfied,
+                        ControlOrigin::Default { field: field_name },
+                    )
+                };
+
+                ControlEvaluation::new(state, origin)
             }
             Self::All(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(ControlEvaluation::DefaultSatisfied, |acc, expr| acc & expr),
+                .fold(
+                    ControlEvaluation::without_origins(ControlState::Satisfied),
+                    |acc, expr| acc & expr,
+                ),
             Self::Any(exprs) => exprs
                 .iter()
                 .map(|expr| expr.eval(uses, comments, with))
-                .fold(ControlEvaluation::NotSatisfied, |acc, expr| acc | expr),
+                .fold(
+                    ControlEvaluation::without_origins(ControlState::NotSatisfied),
+                    |acc, expr| acc | expr,
+                ),
             Self::Not(expr) => !expr.eval(uses, comments, with),
         }
     }
 }
 
-#[derive(PartialEq, Debug)]
-pub(crate) enum Usage {
-    ConditionalOptIn,
-    DirectOptIn,
-    DefaultActionBehaviour,
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum UsageState {
+    Enabled,
+    Conditional,
     Always,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Usage {
+    state: UsageState,
+    origins: Vec<ControlOrigin>,
+}
+
+impl Usage {
+    fn enabled(origins: impl IntoIterator<Item = ControlOrigin>) -> Self {
+        Self {
+            state: UsageState::Enabled,
+            origins: origins.into_iter().collect(),
+        }
+    }
+
+    fn conditional(origins: impl IntoIterator<Item = ControlOrigin>) -> Self {
+        Self {
+            state: UsageState::Conditional,
+            origins: origins.into_iter().collect(),
+        }
+    }
+
+    fn always() -> Self {
+        Self {
+            state: UsageState::Always,
+            origins: vec![ControlOrigin::UsesRef],
+        }
+    }
+
+    pub(crate) fn state(&self) -> UsageState {
+        self.state
+    }
+
+    pub(crate) fn origins(&self) -> &[ControlOrigin] {
+        &self.origins
+    }
+
+    pub(crate) fn into_enabled(mut self) -> Self {
+        self.state = UsageState::Enabled;
+        self
+    }
 }
 
 #[cfg(test)]
@@ -418,11 +513,14 @@ mod tests {
     use github_actions_models::common::{EnvValue, RepositoryUses};
     use indexmap::IndexMap;
 
-    use super::ActionCoordinate;
+    use super::{
+        ActionCoordinate, ControlEvaluation, ControlExpr, ControlFieldType, ControlOrigin,
+        ControlState, Toggle, Usage, VersionBound,
+    };
     use crate::{
         models::{
-            coordinate::{ControlEvaluation, ControlExpr, ControlFieldType, Toggle, Usage},
             uses::RepositoryUsesPattern,
+            version::Version,
             workflow::{Job, Workflow},
         },
         registry::input::InputKey,
@@ -441,22 +539,82 @@ mod tests {
         let with_enabled = IndexMap::from([("set-me".into(), EnvValue::String("anything".into()))]);
         let with_disabled = IndexMap::from([("set-me".into(), EnvValue::String("".into()))]);
 
-        assert!(matches!(
+        assert_eq!(
             optin_control.eval(&uses, &[], &with_enabled),
-            ControlEvaluation::Satisfied
-        ));
-        assert!(matches!(
+            ControlEvaluation::new(
+                ControlState::Satisfied,
+                ControlOrigin::Input { field: "set-me" }
+            )
+        );
+        assert_eq!(
             optin_control.eval(&uses, &[], &with_disabled),
-            ControlEvaluation::NotSatisfied
-        ));
-        assert!(matches!(
+            ControlEvaluation::new(
+                ControlState::NotSatisfied,
+                ControlOrigin::Input { field: "set-me" }
+            )
+        );
+        assert_eq!(
             optout_control.eval(&uses, &[], &with_enabled),
-            ControlEvaluation::NotSatisfied
-        ));
-        assert!(matches!(
+            ControlEvaluation::new(
+                ControlState::NotSatisfied,
+                ControlOrigin::Input { field: "set-me" }
+            )
+        );
+        assert_eq!(
             optout_control.eval(&uses, &[], &with_disabled),
-            ControlEvaluation::Satisfied
-        ));
+            ControlEvaluation::new(
+                ControlState::Satisfied,
+                ControlOrigin::Input { field: "set-me" }
+            )
+        );
+    }
+
+    #[test]
+    fn test_version_bound_provenance() {
+        let control = ControlExpr::all([
+            ControlExpr::VersionBound(VersionBound::LessThan(Version::parse("v10").unwrap())),
+            ControlExpr::field(
+                Toggle::OptIn,
+                "enable-cache",
+                ControlFieldType::Boolean,
+                true,
+            ),
+        ]);
+
+        let v6 = RepositoryUses::parse("foo/bar@v6.5.0").unwrap();
+        assert_eq!(
+            control.eval(&v6, &[], &IndexMap::new()),
+            ControlEvaluation {
+                state: ControlState::Satisfied,
+                origins: vec![
+                    ControlOrigin::UsesRef,
+                    ControlOrigin::Default {
+                        field: "enable-cache"
+                    },
+                ],
+            }
+        );
+
+        let explicit = IndexMap::from([("enable-cache".into(), EnvValue::Boolean(true))]);
+        assert_eq!(
+            control.eval(&v6, &[], &explicit),
+            ControlEvaluation {
+                state: ControlState::Satisfied,
+                origins: vec![
+                    ControlOrigin::UsesRef,
+                    ControlOrigin::Input {
+                        field: "enable-cache"
+                    },
+                ],
+            }
+        );
+
+        let unknown =
+            RepositoryUses::parse("foo/bar@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1").unwrap();
+        assert_eq!(
+            control.eval(&unknown, &[], &IndexMap::new()),
+            ControlEvaluation::new(ControlState::Conditional, ControlOrigin::UsesRef)
+        );
     }
 
     #[test]
@@ -519,7 +677,7 @@ mod tests {
 
         // Trivial cases: coordinate is not configurable and matches the `uses:`.
         for step in &[&steps[0], &steps[1]] {
-            assert_eq!(coord.usage(*step), Some(Usage::Always));
+            assert_eq!(coord.usage(*step), Some(Usage::always()));
         }
 
         // Coordinate `uses:` matches but is not enabled by default and is
@@ -533,7 +691,10 @@ mod tests {
 
         // Coordinate `uses:` matches and is explicitly toggled on.
         let step = &steps[4];
-        assert_eq!(coord.usage(step), Some(Usage::DirectOptIn));
+        assert_eq!(
+            coord.usage(step),
+            Some(Usage::enabled([ControlOrigin::Input { field: "set-me" }]))
+        );
 
         // Coordinate `uses:` matches but is explicitly toggled off.
         let step = &steps[5];
@@ -545,11 +706,17 @@ mod tests {
             control: ControlExpr::field(Toggle::OptIn, "set-me", ControlFieldType::Boolean, true),
         };
         let step = &steps[0];
-        assert_eq!(coord.usage(step), Some(Usage::DefaultActionBehaviour));
+        assert_eq!(
+            coord.usage(step),
+            Some(Usage::enabled([ControlOrigin::Default { field: "set-me" }]))
+        );
 
         // Coordinate `uses:` matches and is explicitly toggled on.
         let step = &steps[4];
-        assert_eq!(coord.usage(step), Some(Usage::DirectOptIn));
+        assert_eq!(
+            coord.usage(step),
+            Some(Usage::enabled([ControlOrigin::Input { field: "set-me" }]))
+        );
 
         // Coordinate `uses:` matches but is explicitly toggled off, despite default enablement.
         let step = &steps[5];
@@ -575,10 +742,18 @@ mod tests {
 
         // Coordinate `uses:` matches and the opt-out inverts the match, clearing it.
         let step = &steps[7];
-        assert_eq!(coord.usage(step), Some(Usage::DirectOptIn));
+        assert_eq!(
+            coord.usage(step),
+            Some(Usage::enabled([ControlOrigin::Input {
+                field: "disable-cache"
+            }]))
+        );
 
         // Coordinate `uses:` matches but `with:` is an expression.
         let step = &steps[8];
-        assert_eq!(coord.usage(step), Some(Usage::ConditionalOptIn));
+        assert_eq!(
+            coord.usage(step),
+            Some(Usage::conditional([ControlOrigin::WithExpression]))
+        );
     }
 }

--- a/crates/zizmor/src/models/uses.rs
+++ b/crates/zizmor/src/models/uses.rs
@@ -250,6 +250,9 @@ pub(crate) trait RepositoryUsesExt {
 
     /// See [`RepoRef::commit_ref`].
     fn commit_ref(&self) -> Option<&str>;
+
+    /// See [`RepoRef::symbolic_ref`].
+    fn symbolic_ref(&self) -> Option<&str>;
 }
 
 impl RepositoryUsesExt for RepositoryUses {
@@ -263,6 +266,10 @@ impl RepositoryUsesExt for RepositoryUses {
 
     fn commit_ref(&self) -> Option<&str> {
         RepoRef::from(self).commit_ref()
+    }
+
+    fn symbolic_ref(&self) -> Option<&str> {
+        RepoRef::from(self).symbolic_ref()
     }
 }
 

--- a/crates/zizmor/src/models/version.rs
+++ b/crates/zizmor/src/models/version.rs
@@ -5,7 +5,62 @@
 //! [semantic versioning](https://semver.org/), as GitHub Actions
 //! has no structured versioning scheme.
 
-use crate::utils::once::static_regex;
+use crate::{finding::location::Comment, utils::once::static_regex};
+
+static_regex!(
+    VERSION_COMMENT_PATTERN,
+    r#"(?x)                             # verbose mode
+    ^                                   # start of string
+    \#                                  # start of comment
+    \s*                                 # optional whitespace
+    (?:                                 # start non-capturing group for version prefix
+      (?:tag|version|ver)\s*[:=]\s*     # version prefix + `:` or `=`
+    )?                                  # end optional non-capturing group
+    (                                   # start capturing group for version
+      \S+                               # one or more non-whitespace characters
+    )                                   # end capturing group for version
+    $                                   # end of string
+    "#
+);
+
+/// A "raw" version.
+///
+/// This represents an arbitrary string that we *think* is a version
+/// (for context-sensitive reasons, e.g. being in a comment that looks
+/// like a version), but that we haven't validated at all as actually being
+/// semver-shaped.
+pub(crate) struct RawVersion<'a> {
+    raw: &'a str,
+}
+
+impl<'a> From<&'a str> for RawVersion<'a> {
+    fn from(raw: &'a str) -> Self {
+        RawVersion { raw }
+    }
+}
+
+impl<'a> RawVersion<'a> {
+    pub(crate) fn from_comment(comment: &Comment<'a>) -> Option<Self> {
+        let comment = comment.as_raw();
+        if let Some(captures) = VERSION_COMMENT_PATTERN.captures(comment)
+            && let Some(version_match) = captures.get(1)
+        {
+            Some(version_match.as_str().into())
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn as_raw(&self) -> &'a str {
+        self.raw
+    }
+
+    pub(crate) fn as_version(&self) -> Option<Version<'a>> {
+        // TODO: Handle "versions" like `name/v1.2.3`.
+        // These are somewhat common in GitHub Actions.
+        Version::parse(self.raw).ok()
+    }
+}
 
 static_regex!(
     VERSION_PATTERN,

--- a/crates/zizmor/src/models/version.rs
+++ b/crates/zizmor/src/models/version.rs
@@ -135,6 +135,10 @@ impl<'a> Version<'a> {
             patch,
         })
     }
+
+    pub(crate) fn from_comment(comment: &Comment<'a>) -> Option<Self> {
+        RawVersion::from_comment(comment).and_then(|rc| rc.as_version())
+    }
 }
 
 impl Ord for Version<'_> {
@@ -157,7 +161,55 @@ impl PartialEq for Version<'_> {
 
 #[cfg(test)]
 mod tests {
+    use crate::models::version::VERSION_COMMENT_PATTERN;
+
     use super::Version;
+
+    #[test]
+    fn test_version_comment_pattern() {
+        let test_cases = vec![
+            ("# tag=v2.8.0", Some("v2.8.0")),
+            ("# tag=v6-beta", Some("v6-beta")),
+            ("# tag=v1.2.3-rc.1", Some("v1.2.3-rc.1")),
+            ("# tag=v1.2.3rc.1", Some("v1.2.3rc.1")),
+            ("# tag=v6-beta-2", Some("v6-beta-2")),
+            ("# tag=release-2024-01", Some("release-2024-01")),
+            ("# v2.8.0", Some("v2.8.0")),
+            ("# v6-beta", Some("v6-beta")),
+            ("# v1.2.3-rc.1", Some("v1.2.3-rc.1")),
+            ("# v1.2.3rc1", Some("v1.2.3rc1")),
+            ("# v6-beta-2", Some("v6-beta-2")),
+            ("# v1.0.0-rc-1", Some("v1.0.0-rc-1")),
+            ("# v2.0-preview-3", Some("v2.0-preview-3")),
+            ("# tag=2.8.0", Some("2.8.0")),
+            ("# version: 2.8.0", Some("2.8.0")),
+            ("# version: v1.2.3-rc.1", Some("v1.2.3-rc.1")),
+            ("# version: v1.2.3rc.1", Some("v1.2.3rc.1")),
+            ("# version: v6-beta-2", Some("v6-beta-2")),
+            ("# version: v1.0.0-rc-1", Some("v1.0.0-rc-1")),
+            ("# ver=1.0.0", Some("1.0.0")),
+            ("# visit the docs", None),
+            ("# some other comment", None),
+            ("# zizmor: ignore[ref-version-mismatch]", None),
+        ];
+
+        for (comment, expected) in test_cases {
+            // Test the pattern matching directly
+            match (VERSION_COMMENT_PATTERN.captures(comment), expected) {
+                (None, None) => (),
+                (None, Some(expected)) => {
+                    assert!(
+                        false,
+                        "Got no match in '{comment}', but expected {expected}"
+                    )
+                }
+                (Some(caps), None) => {
+                    assert!(false, "Got unexpected match: {caps:?}")
+                }
+                (Some(_), Some(_)) => (),
+            }
+        }
+    }
 
     #[test]
     fn parse_valid_versions() {

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -454,18 +454,7 @@ fn test_issue_1081() -> anyhow::Result<()> {
        |
        = note: audit confidence → Low
 
-    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
-      --> @@INPUT@@:23:9
-       |
-     5 | on: release
-       | ----------- generally used when publishing artifacts generated at runtime
-    ...
-    23 |       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action version may enable caching
-       |
-       = note: audit confidence → Low
-
-    4 findings (1 suppressed): 0 informational, 0 low, 0 medium, 3 high
+    3 findings (1 suppressed): 0 informational, 0 low, 0 medium, 2 high
     "
     );
 
@@ -638,6 +627,20 @@ fn test_issue_2320() -> anyhow::Result<()> {
         .run()?,
     @"
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:19:9
+       |
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
+    ...
+    19 |       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    20 |         with:
+    21 |           enable-cache: true
+       |           ------------------ enables caching explicitly here
+       |
+       = note: audit confidence → Low
+
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:24:9
        |
      5 | on: release
@@ -648,7 +651,7 @@ fn test_issue_2320() -> anyhow::Result<()> {
        |
        = note: audit confidence → Low
 
-    2 findings (1 ignored): 0 informational, 0 low, 0 medium, 1 high
+    3 findings (1 ignored): 0 informational, 0 low, 0 medium, 2 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -50,25 +50,24 @@ fn test_caching_opt_in_boolean_toggle() -> anyhow::Result<()> {
                 "cache-poisoning/caching-opt-in-boolean-toggle.yml"
             ))
             .run()?,
-        @r#"
+        @"
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:19:9
        |
-     1 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     1 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    19 |           uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    20 | /         with:
-    21 | |           dotnet-version: "5.0.x"
-    22 | |           cache: true
-       | |_____________________- enables caching explicitly here
+    19 |         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    ...
+    22 |           cache: true
+       |           ----------- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
 
     4 findings (1 ignored, 2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
-    "#,
+    ",
     );
 
     Ok(())
@@ -82,25 +81,23 @@ fn test_caching_opt_in_expression() -> anyhow::Result<()> {
                 "cache-poisoning/caching-opt-in-expression.yml"
             ))
             .run()?,
-        @r#"
+        @"
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:19:9
        |
-     1 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     1 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    19 |           uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    20 | /         with:
-    21 | |           python-version: "3.12"
-    22 | |           enable-cache: ${{ github.ref == 'refs/heads/main' }}
-       | |______________________________________________________________- may enable caching here
+    19 |         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action version may enable caching
+    ...
+    22 |           enable-cache: ${{ github.ref == 'refs/heads/main' }}
+       |           ---------------------------------------------------- may enable caching here
        |
        = note: audit confidence → Low
-       = note: this finding has an auto-fix
 
-    3 findings (1 ignored, 1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
-    "#,
+    3 findings (1 ignored, 1 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    ",
     );
 
     Ok(())
@@ -118,16 +115,14 @@ fn test_caching_opt_in_multi_value_toggle() -> anyhow::Result<()> {
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:18:9
        |
-     1 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     1 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    18 |           uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    19 | /         with:
-    20 | |           distribution: "zulu"
-    21 | |           cache: "gradle"
-    22 | |           java-version: "17"
-       | |____________________________- enables caching explicitly here
+    18 |         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    ...
+    21 |           cache: "gradle"
+       |           --------------- enables caching explicitly here
        |
        = note: audit confidence → Low
 
@@ -203,16 +198,14 @@ fn test_caching_opt_in_boolish_toggle() -> anyhow::Result<()> {
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:17:9
        |
-     4 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     4 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    17 |           uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    18 | /         with:
-    19 | |           target: ${{ matrix.platform.target }}
-    20 | |           args: --release --out dist
-    21 | |           sccache: "true"
-       | |__________________________- enables caching explicitly here
+    17 |         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    ...
+    21 |           sccache: "true"
+       |           --------------- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -286,12 +279,9 @@ fn test_issue_343() -> anyhow::Result<()> {
     ...
     34 |           uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    35 | /         with:
-    36 | |           go-version: stable
-    37 | |           cache: true
-    38 | |
-    39 | |       # Finding because setup enables cache explicitly
-       | |______________________________________________________- enables caching explicitly here
+    ...
+    37 |             cache: true
+       |             ----------- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -307,10 +297,9 @@ fn test_issue_343() -> anyhow::Result<()> {
     ...
     41 |           uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    42 | /         with:
-    43 | |           go-version: stable
-    44 | |           cache: "true"
-       | |________________________- enables caching explicitly here
+    ...
+    44 |             cache: "true"
+       |             ------------- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -410,15 +399,16 @@ fn test_issue_642() -> anyhow::Result<()> {
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:15:9
        |
-    15 |           uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    16 | /         with:
-    17 | |           cache-binary: true
-    18 | |           version: latest
-       | |_________________________- enables caching explicitly here
+    15 |         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    16 |         with:
+    17 |           cache-binary: true
+       |           ------------------ enables caching explicitly here
+    18 |           version: latest
+       |           --------------- enables caching explicitly here
     ...
-    21 |           uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
-       |           ----------------------------------------------------------------------- runtime artifacts usually published here
+    21 |         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+       |         ----------------------------------------------------------------------- runtime artifacts usually published here
        |
        = note: audit confidence → Low
 
@@ -449,24 +439,33 @@ fn test_issue_1081() -> anyhow::Result<()> {
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
        |
        = note: audit confidence → Low
-       = note: this finding has an auto-fix
 
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:18:9
        |
-     5 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    18 |         - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    19 | /         with:
-    20 | |           enable-cache: true
-       | |____________________________- enables caching explicitly here
+    18 |       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    19 |         with:
+    20 |           enable-cache: true
+       |           ------------------ enables caching explicitly here
        |
        = note: audit confidence → Low
-       = note: this finding has an auto-fix
 
-    3 findings (1 suppressed, 2 unsafe fixes): 0 informational, 0 low, 0 medium, 2 high
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:23:9
+       |
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
+    ...
+    23 |       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action version may enable caching
+       |
+       = note: audit confidence → Low
+
+    4 findings (1 suppressed): 0 informational, 0 low, 0 medium, 3 high
     "
     );
 
@@ -497,14 +496,14 @@ fn test_issue_1152() -> anyhow::Result<()> {
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:20:9
        |
-     5 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    20 |           uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    21 | /         with:
-    22 | |           package-manager-cache: true
-       | |_____________________________________- enables caching explicitly here
+    20 |         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    21 |         with:
+    22 |           package-manager-cache: true
+       |           --------------------------- enables caching explicitly here
        |
        = note: audit confidence → Low
 
@@ -565,15 +564,14 @@ fn test_ramsey_composer_install_action() -> anyhow::Result<()> {
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:15:9
        |
-     1 |   on: release
-       |   ----------- generally used when publishing artifacts generated at runtime
+     1 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
     ...
-    15 |         - uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    16 | /         with:
-    17 | |           # NOT OK: caching explicitly enabled
-    18 | |           ignore-cache: false
-       | |_____________________________- enables caching explicitly here
+    15 |       - uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    ...
+    18 |           ignore-cache: false
+       |           ------------------- enables caching explicitly here
        |
        = note: audit confidence → Low
 
@@ -649,12 +647,9 @@ fn test_trigger_heuristics_tag_only() -> anyhow::Result<()> {
     ...
     16 |         - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    17 | /         with:
-    18 | |           # this is the opposite of #1940: caching is explicitly enabled here,
-    19 | |           # but *only* for tag events, which we consider unsafe becaue we assume that
-    20 | |           # tag events correspond to releases.
-    21 | |           sccache: ${{ startsWith(github.ref, 'refs/tags/') }}
-       | |______________________________________________________________- enables caching explicitly here
+    ...
+    21 |             sccache: ${{ startsWith(github.ref, 'refs/tags/') }}
+       |             ---------------------------------------------------- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -672,12 +667,9 @@ fn test_trigger_heuristics_tag_only() -> anyhow::Result<()> {
     ...
     22 |         - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    23 | /         with:
-    24 | |           # this is the opposite of #2050: caching is explicitly enabled here for
-    25 | |           # pushes to tag refs, which we consider unsafe because we assume that tag
-    26 | |           # pushes correspond to releases.
-    27 | |           sccache: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-       | |__________________________________________________________________________________- enables caching explicitly here
+    ...
+    27 |             sccache: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+       |             ----------------------------------------------------------------------- enables caching explicitly here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -726,12 +718,9 @@ fn test_trigger_heuristics_tag_and_branch() -> anyhow::Result<()> {
     ...
     17 |         - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    18 | /         with:
-    19 | |           # we would consider this safe *if* there was only a tag and/or release trigger
-    20 | |           # for this workflow, but since there's also a branch trigger that looks like
-    21 | |           # a release we can't assert that all release events will also be tag events.
-    22 | |           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-       | |_______________________________________________________________- may enable caching here
+    ...
+    22 |             sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+       |             ----------------------------------------------------- may enable caching here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -750,11 +739,9 @@ fn test_trigger_heuristics_tag_and_branch() -> anyhow::Result<()> {
     ...
     23 |         - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-    24 | /         with:
-    25 | |           # same as above: we would consider this safe if there wasn't also a branch
-    26 | |           # trigger that looks like a release.
-    27 | |           sccache: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
-       | |_____________________________________________________________________________________- may enable caching here
+    ...
+    27 |             sccache: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
+       |             -------------------------------------------------------------------------- may enable caching here
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -454,7 +454,21 @@ fn test_issue_1081() -> anyhow::Result<()> {
        |
        = note: audit confidence → Low
 
-    3 findings (1 suppressed): 0 informational, 0 low, 0 medium, 2 high
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:23:9
+       |
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
+    ...
+    23 |       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    24 |         with:
+    25 |           enable-cache: auto
+       |           ------------------ enables caching explicitly here
+       |
+       = note: audit confidence → Low
+
+    4 findings (1 suppressed): 0 informational, 0 low, 0 medium, 3 high
     "
     );
 
@@ -646,12 +660,26 @@ fn test_issue_2320() -> anyhow::Result<()> {
      5 | on: release
        | ----------- generally used when publishing artifacts generated at runtime
     ...
-    24 |       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d
+    24 |       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+    25 |         with:
+    26 |           enable-cache: ${{ matrix.os == 'ubuntu-latest' }}
+       |           ------------------------------------------------- may enable caching here
+       |
+       = note: audit confidence → Low
+
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:29:9
+       |
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
+    ...
+    29 |       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action version may enable caching
        |
        = note: audit confidence → Low
 
-    3 findings (1 ignored): 0 informational, 0 low, 0 medium, 2 high
+    4 findings (1 ignored): 0 informational, 0 low, 0 medium, 3 high
     "
     );
 

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -30,7 +30,7 @@ fn test_caching_enabled_by_default() -> anyhow::Result<()> {
        | ----------- generally used when publishing artifacts generated at runtime
     ...
     21 |         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `lookup-only` enables caching
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -174,7 +174,7 @@ fn test_workflow_tag_trigger() -> anyhow::Result<()> {
        | |____________- generally used when publishing artifacts generated at runtime
     ...
     23 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `lookup-only` enables caching
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -228,7 +228,7 @@ fn test_publisher_step() -> anyhow::Result<()> {
       --> @@INPUT@@:23:9
        |
     23 |         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `lookup-only` enables caching
     ...
     30 |         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # zizmor: ignore[superfluous-actions]
        |         -------------------------------------------------------------------------- runtime artifacts usually published here
@@ -263,7 +263,7 @@ fn test_issue_343() -> anyhow::Result<()> {
        | |________________- generally used when publishing artifacts generated at runtime
     ...
     28 |           uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `cache` enables caching
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -360,7 +360,7 @@ fn test_workflow_release_branch_trigger() -> anyhow::Result<()> {
        | |________________________- generally used when publishing artifacts generated at runtime
     ...
     22 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `lookup-only` enables caching
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix
@@ -436,7 +436,7 @@ fn test_issue_1081() -> anyhow::Result<()> {
        | ----------- generally used when publishing artifacts generated at runtime
     ...
     15 |       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `enable-cache` enables caching for this action version
        |
        = note: audit confidence → Low
 
@@ -492,7 +492,7 @@ fn test_issue_1152() -> anyhow::Result<()> {
        | ----------- generally used when publishing artifacts generated at runtime
     ...
     16 |         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `package-manager-cache` enables caching
        |
        = note: audit confidence → Low
 
@@ -517,7 +517,7 @@ fn test_issue_1152() -> anyhow::Result<()> {
        | ----------- generally used when publishing artifacts generated at runtime
     ...
     42 |       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `package-manager-cache` enables caching
        |
        = note: audit confidence → Low
 
@@ -560,7 +560,7 @@ fn test_ramsey_composer_install_action() -> anyhow::Result<()> {
        | ----------- generally used when publishing artifacts generated at runtime
     ...
     13 |       - uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `ignore-cache` enables caching
        |
        = note: audit confidence → Low
 
@@ -607,7 +607,7 @@ fn test_workflow_release_trigger_object() -> anyhow::Result<()> {
        | |__________- generally used when publishing artifacts generated at runtime
     ...
     23 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `lookup-only` enables caching
        |
        = note: audit confidence → Low
        = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -627,6 +627,34 @@ fn test_issue_1940() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Bug #2320: setup-uv disables caching intelligently in v10+.
+//
+// See: <https://github.com/zizmorcore/zizmor/issues/2320>
+#[test]
+fn test_issue_2320() -> anyhow::Result<()> {
+    insta::assert_snapshot!(
+    zizmor()
+        .input(input_under_test("cache-poisoning/issue-2320-repro.yml"))
+        .run()?,
+    @"
+    error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+      --> @@INPUT@@:24:9
+       |
+     5 | on: release
+       | ----------- generally used when publishing artifacts generated at runtime
+    ...
+    24 |       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action version may enable caching
+       |
+       = note: audit confidence → Low
+
+    2 findings (1 ignored): 0 informational, 0 low, 0 medium, 1 high
+    "
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_trigger_heuristics_tag_only() -> anyhow::Result<()> {
     insta::assert_snapshot!(

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -316,16 +316,14 @@ info[use-trusted-publishing]: prefer trusted publishing for authentication
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> .github/workflows/cache-poisoning.yml:35:9
    |
-22 |   on: release
-   |   ----------- generally used when publishing artifacts generated at runtime
+22 | on: release
+   | ----------- generally used when publishing artifacts generated at runtime
 ...
-35 |           uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
-36 | /         with:
-37 | |           distribution: "zulu"
-38 | |           cache: "gradle"
-39 | |           java-version: "17"
-   | |____________________________- enables caching explicitly here
+35 |         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
+...
+38 |           cache: "gradle"
+   |           --------------- enables caching explicitly here
    |
    = note: audit confidence → Low
 

--- a/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/crates/zizmor/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -334,7 +334,7 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    | ----------- generally used when publishing artifacts generated at runtime
 ...
 55 |         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `lookup-only` enables caching
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-1081-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-1081-repro.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           enable-cache: true
 
+      # TRUE POSITIVE: enable-cache explicitly set to auto, and version is <10
+      - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+        with:
+          enable-cache: auto
+
   issue-1081-true-negative:
     name: issue-1081-true-negative
     runs-on: ubuntu-latest

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-1081-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-1081-repro.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           enable-cache: true
 
-      # TRUE POSITIVE: action version is unknown
-      - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1
-
   issue-1081-true-negative:
     name: issue-1081-true-negative
     runs-on: ubuntu-latest

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-1081-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-1081-repro.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           enable-cache: true
 
+      # TRUE POSITIVE: action version is unknown
+      - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1
+
   issue-1081-true-negative:
     name: issue-1081-true-negative
     runs-on: ubuntu-latest

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-2320-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-2320-repro.yml
@@ -1,0 +1,34 @@
+# repro case for https://github.com/zizmorcore/zizmor/issues/2320
+
+name: issue-2320
+
+on: release
+
+permissions: {}
+
+concurrency:
+  group: issue-2320
+  cancel-in-progress: true
+
+jobs:
+  issue-2320-true-positive:
+    name: issue-2320-true-positive
+    runs-on: ubuntu-latest
+    steps:
+      # TRUE POSITIVE: caching explicitly enabled
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      # TRUE POSITIVE: no version comment, so we assume < v10
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d
+
+  issue-2320-true-negative:
+    name: issue-2320-true-negative
+    runs-on: ubuntu-latest
+    steps:
+      # TRUE NEGATIVE: cache disabled by default on release for v10+
+      - uses: astral-sh/setup-uv@v10.0.0 # zizmor: ignore[unpinned-uses]
+
+      # TRUE NEGATIVE: like above, but with a version comment
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-2320-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-2320-repro.yml
@@ -32,3 +32,13 @@ jobs:
 
       # TRUE NEGATIVE: like above, but with a version comment
       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+
+      # TRUE NEGATIVE: like above, but with a version comment and explicitly disabled
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: false
+
+      # # TRUE NEGATIVE: like above, but with a version comment and automatically disabled
+      # - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+      #   with:
+      #     enable-cache: auto

--- a/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-2320-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/cache-poisoning/issue-2320-repro.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           enable-cache: true
 
+        # TRUE POSITIVE: caching conditionally (opaquely) enabled
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: ${{ matrix.os == 'ubuntu-latest' }}
+
       # TRUE POSITIVE: no version comment, so we assume < v10
       - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d
 
@@ -38,7 +43,7 @@ jobs:
         with:
           enable-cache: false
 
-      # # TRUE NEGATIVE: like above, but with a version comment and automatically disabled
-      # - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
-      #   with:
-      #     enable-cache: auto
+      # TRUE NEGATIVE: like above, but with a version comment and automatically disabled
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: auto

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,8 @@ of `zizmor`.
 
 * The [ref-confusion] audit now supports pre-commit config inputs (#2274)
 
+* The [cache-poisoning] audit now produces more detailed and more precise diagnostics (#2330)
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`
@@ -45,6 +47,9 @@ of `zizmor`.
   replace operations (#2295)
 
     Many thanks to @dmbuil for proposing and implementing this improvement!
+
+* Fixed a bug where the [cache-poisoning] audit would incorrectly flag
+  newer @astral-sh/setup-uv versions that disable caching behavior automatically (#2330)
 
 ## 1.29.0
 


### PR DESCRIPTION
This will fix #2320, but I need to think more through the implementation.

There are really two things here:

1. The coordinate API is now aware of "version bounds," i.e. it can express a constraint like "match this `uses:` clause but only for certain versions."
2. Doing (1) revealed that we were conflating "coordinate is satisfied" (i.e. not default satisfied) with "the `uses:` clause has a sibling `with:` clause," which is not actually guaranteed to be true now that we're treating version bounds as potentially satisfying on their own.

The solution to (2) is a pretty fundamental refactor to how coordinate matching is implemented: the `usage` API now returns a `Usage` that splits the satisfaction state (Enabled/Conditional/Always) from one or more "control origins," which encode the "why" of the satisfaction state. The `cache-poisoning` audit then consumes those origins to produce its locations. A nice consequence of that is that our other diagnostics from this audit become cleaner, which can be seen in the snapshots.

Doing this has regressed the fix generation for `cache-poisoning`, since we can no longer easily "invert" an `ActionCoordinate` to produce its fixes. 