### PR TITLE
Generalize fixes for cache-poisoning

### DIFF
--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -555,83 +555,58 @@ impl CachePoisoning {
         action: &CacheAwareAction,
         step: &Step<'doc>,
     ) -> Option<Fix<'doc>> {
-        match action.fix_strategy.as_ref()? {
+        let (field_name, field_value) = match action.fix_strategy.as_ref()? {
             CacheFixStrategy::Infer => match &action.coordinate {
-                ActionCoordinate::NotConfigurable(_pattern) => {
+                ActionCoordinate::NotConfigurable(_) => {
                     // For non-configurable actions, we can't provide automatic fixes
-                    None
+                    return None;
                 }
-                ActionCoordinate::Configurable { control, .. } => {
-                    self.create_configurable_action_fix(control, step)
-                }
+                ActionCoordinate::Configurable { control, .. } => match control {
+                    ControlExpr::Field {
+                        toggle,
+                        field_name,
+                        field_type,
+                        ..
+                    } => match (toggle, field_type) {
+                        (Toggle::OptOut, ControlFieldType::Boolean) => (*field_name, true),
+                        (Toggle::OptIn, ControlFieldType::Boolean) => (*field_name, false),
+                        // String control fields are action-specific and we can't reliably know
+                        // what value disables caching (e.g., setup-node expects '' not 'false')
+                        (Toggle::OptIn, _) | (Toggle::OptOut, _) => {
+                            return None;
+                        }
+                    },
+                    // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
+                    ControlExpr::VersionBound(_)
+                    | ControlExpr::All(_)
+                    | ControlExpr::Any(_)
+                    | ControlExpr::Not(_) => return None,
+                },
             },
             CacheFixStrategy::SetBooleanInput {
                 field_name,
                 field_value,
-            } => Some(Self::create_input_fix(
-                step,
-                field_name,
-                yaml_serde::Value::Bool(*field_value),
-                format!("Set {field_name}: {field_value} to disable caching"),
-            )),
-        }
+            } => (*field_name, *field_value),
+        };
+
+        Some(Self::create_input_fix(step, field_name, field_value))
     }
 
-    fn create_input_fix<'doc>(
-        step: &Step<'doc>,
-        field_name: &str,
-        field_value: yaml_serde::Value,
-        title: String,
-    ) -> Fix<'doc> {
+    fn create_input_fix<'doc>(step: &Step<'doc>, field_name: &str, field_value: bool) -> Fix<'doc> {
         Fix {
-            title,
+            title: format!("Set {field_name}: {field_value} to disable caching"),
             key: step.location().key,
             disposition: FixDisposition::default(),
             patches: vec![Patch {
                 route: step.route(),
                 operation: Op::MergeInto {
                     key: "with".to_string(),
-                    updates: IndexMap::from([(field_name.to_string(), field_value)]),
+                    updates: IndexMap::from([(
+                        field_name.to_string(),
+                        yaml_serde::Value::Bool(field_value),
+                    )]),
                 },
             }],
-        }
-    }
-
-    fn create_configurable_action_fix<'doc>(
-        &self,
-        control: &ControlExpr,
-        step: &Step<'doc>,
-    ) -> Option<Fix<'doc>> {
-        match control {
-            ControlExpr::Field {
-                toggle,
-                field_name,
-                field_type,
-                ..
-            } => {
-                let (field_value, title) = match (toggle, field_type) {
-                    (Toggle::OptOut, ControlFieldType::Boolean) => (
-                        yaml_serde::Value::Bool(true),
-                        format!("Set {field_name}: true to disable caching"),
-                    ),
-                    (Toggle::OptIn, ControlFieldType::Boolean) => (
-                        yaml_serde::Value::Bool(false),
-                        format!("Set {field_name}: false to disable caching"),
-                    ),
-                    // String control fields are action-specific and we can't reliably know
-                    // what value disables caching (e.g., setup-node expects '' not 'false')
-                    (Toggle::OptIn, _) | (Toggle::OptOut, _) => {
-                        return None;
-                    }
-                };
-
-                Some(Self::create_input_fix(step, field_name, field_value, title))
-            }
-            // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
-            ControlExpr::VersionBound(_)
-            | ControlExpr::All(_)
-            | ControlExpr::Any(_)
-            | ControlExpr::Not(_) => None,
         }
     }
 

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -561,10 +561,9 @@ impl CachePoisoning {
                     // For non-configurable actions, we can't provide automatic fixes
                     None
                 }
-                ActionCoordinate::Configurable {
-                    uses_pattern,
-                    control,
-                } => self.create_configurable_action_fix(uses_pattern, control, step),
+                ActionCoordinate::Configurable { control, .. } => {
+                    self.create_configurable_action_fix(control, step)
+                }
             },
             CacheFixStrategy::SetBooleanInput {
                 field_name,
@@ -600,7 +599,6 @@ impl CachePoisoning {
 
     fn create_configurable_action_fix<'doc>(
         &self,
-        _uses_pattern: &crate::models::uses::RepositoryUsesPattern,
         control: &ControlExpr,
         step: &Step<'doc>,
     ) -> Option<Fix<'doc>> {
@@ -611,20 +609,14 @@ impl CachePoisoning {
                 field_type,
                 ..
             } => {
-                let (field_value, title, _description) = match (toggle, field_type) {
+                let (field_value, title) = match (toggle, field_type) {
                     (Toggle::OptOut, ControlFieldType::Boolean) => (
                         yaml_serde::Value::Bool(true),
                         format!("Set {field_name}: true to disable caching"),
-                        format!(
-                            "Set '{field_name}' to 'true' to disable cache writes in this publishing workflow."
-                        ),
                     ),
                     (Toggle::OptIn, ControlFieldType::Boolean) => (
                         yaml_serde::Value::Bool(false),
                         format!("Set {field_name}: false to disable caching"),
-                        format!(
-                            "Set '{field_name}' to 'false' to disable caching in this publishing workflow."
-                        ),
                     ),
                     // String control fields are action-specific and we can't reliably know
                     // what value disables caching (e.g., setup-node expects '' not 'false')

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -37,7 +37,8 @@ static REF_TYPE_TAG_PUSH_GUARD: LazyLock<Expr> = LazyLock::new(|| {
 });
 
 enum CacheFixStrategy {
-    /// Infer a fix from a simple top-level control field.
+    /// Infer a fix. At the moment, the only inferrable fixes are for [`ActionCoordinate`]s
+    /// that only have a single top-level control field.
     Infer,
     /// Disable caching by setting a boolean action input explicitly.
     SetBooleanInput {
@@ -54,6 +55,8 @@ struct CacheAwareAction {
 impl From<ActionCoordinate> for CacheAwareAction {
     fn from(coordinate: ActionCoordinate) -> Self {
         let fix_strategy = if matches!(&coordinate, ActionCoordinate::Configurable { .. }) {
+            // For now, we only consider a fix inferrable if the coordinate has a single
+            // top-level control field, i.e. is not logically qualified at all.
             Some(CacheFixStrategy::Infer)
         } else {
             // No automatic fix is available for this action.

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -50,13 +50,8 @@ struct CacheAwareAction {
 impl From<ActionCoordinate> for CacheAwareAction {
     fn from(coordinate: ActionCoordinate) -> Self {
         let fix = match &coordinate {
-            ActionCoordinate::NotConfigurable(_) => {
-                // For non-configurable actions, we can't provide automatic fixes
-                // No automatic fix is available for this action.
-                None
-            }
             // Infer a fix. At the moment, the only inferrable fixes are for [`ActionCoordinate`]s
-            // that only have a single top-level control field.
+            // that only have a single top-level boolean control field.
             ActionCoordinate::Configurable {
                 control:
                     ControlExpr::Field {
@@ -66,24 +61,19 @@ impl From<ActionCoordinate> for CacheAwareAction {
                         ..
                     },
                 ..
-            } => {
-                // For now, we only consider a fix inferrable if the coordinate has a single
-                // top-level control field, i.e. is not logically qualified at all.
-                Some(CacheFix {
-                    field_name,
-                    field_value: matches!(toggle, Toggle::OptOut),
-                })
-            }
-            ActionCoordinate::Configurable {
-                control: ControlExpr::Field { .. },
-                ..
-            } => {
-                // String control fields are action-specific and we can't reliably know
-                // what value disables caching (e.g., setup-node expects '' not 'false')
+            } => Some(CacheFix {
+                field_name,
+                field_value: matches!(toggle, Toggle::OptOut),
+            }),
+            _ => {
+                // We can't infer fixes for other coordinates at the moment.
+                //
+                // TODO: We may be able to infer fixes for string control fields.
+                //
+                // Version bounds and compelx control expressions (All/Any/Not)
+                // are probably not easy for us to infer in the future.
                 None
             }
-            // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
-            ActionCoordinate::Configurable { .. } => None,
         };
 
         Self { coordinate, fix }

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -36,11 +36,42 @@ static REF_TYPE_TAG_PUSH_GUARD: LazyLock<Expr> = LazyLock::new(|| {
         .inner
 });
 
+enum CacheFixStrategy {
+    /// Infer a fix from a simple top-level control field.
+    Infer,
+    /// Disable caching by setting a boolean action input explicitly.
+    SetBooleanInput {
+        field_name: &'static str,
+        field_value: bool,
+    },
+}
+
+struct CacheAwareAction {
+    coordinate: ActionCoordinate,
+    fix_strategy: Option<CacheFixStrategy>,
+}
+
+impl From<ActionCoordinate> for CacheAwareAction {
+    fn from(coordinate: ActionCoordinate) -> Self {
+        let fix_strategy = if matches!(&coordinate, ActionCoordinate::Configurable { .. }) {
+            Some(CacheFixStrategy::Infer)
+        } else {
+            // No automatic fix is available for this action.
+            None
+        };
+
+        Self {
+            coordinate,
+            fix_strategy,
+        }
+    }
+}
+
 /// The list of known cache-aware actions
 /// In the future we can easily retrieve this list from the static API,
 /// since it should be easily serializable
 #[allow(clippy::unwrap_used)]
-static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::new(|| {
+static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<CacheAwareAction>> = LazyLock::new(|| {
     vec![
         // https://github.com/actions/cache/blob/main/action.yml
         ActionCoordinate::Configurable {
@@ -51,7 +82,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 true,
             ),
-        },
+        }
+        .into(),
         // https://github.com/actions/setup-java/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-java".parse().unwrap(),
@@ -61,12 +93,14 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::FreeString,
                 false,
             ),
-        },
+        }
+        .into(),
         // https://github.com/actions/setup-go/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-go".parse().unwrap(),
             control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
-        },
+        }
+        .into(),
         // https://github.com/actions/setup-node/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-node".parse().unwrap(),
@@ -86,7 +120,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                     true,
                 ),
             ]),
-        },
+        }
+        .into(),
         // https://github.com/actions/setup-python/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-python".parse().unwrap(),
@@ -96,41 +131,49 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::FreeString,
                 false,
             ),
-        },
+        }
+        .into(),
         // https://github.com/actions/setup-dotnet/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions/setup-dotnet".parse().unwrap(),
             control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, false),
-        },
+        }
+        .into(),
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
-        ActionCoordinate::Configurable {
-            uses_pattern: "astral-sh/setup-uv".parse().unwrap(),
-            control: ControlExpr::any([
-                // Regardless of the version, setting `enable-cache: true`
-                // always explicitly enables the cache.
-                ControlExpr::field(
-                    Toggle::OptIn,
-                    "enable-cache",
-                    ControlFieldType::Exact(&["true"]),
-                    false,
-                ),
-                // For setup-uv below v10, any boolishly true `enable-cache`
-                // (including `enable-cache: auto`) is considered to enable the cache.
-                // This is slightly imprecise since `auto` actually disables the cache
-                // on self-hosted runners, but we don't have a good static way to
-                // detect those at the moment.
-                ControlExpr::all([
-                    ControlExpr::VersionBound(VersionBound::LessThan(
-                        Version::parse("v10").unwrap(),
-                    )),
+        CacheAwareAction {
+            coordinate: ActionCoordinate::Configurable {
+                uses_pattern: "astral-sh/setup-uv".parse().unwrap(),
+                control: ControlExpr::any([
+                    // Regardless of the version, setting `enable-cache: true`
+                    // always explicitly enables the cache.
                     ControlExpr::field(
                         Toggle::OptIn,
                         "enable-cache",
-                        ControlFieldType::Boolean,
-                        true,
+                        ControlFieldType::Exact(&["true"]),
+                        false,
                     ),
+                    // For setup-uv below v10, any boolishly true `enable-cache`
+                    // (including `enable-cache: auto`) is considered to enable the cache.
+                    // This is slightly imprecise since `auto` actually disables the cache
+                    // on self-hosted runners, but we don't have a good static way to
+                    // detect those at the moment.
+                    ControlExpr::all([
+                        ControlExpr::VersionBound(VersionBound::LessThan(
+                            Version::parse("v10").unwrap(),
+                        )),
+                        ControlExpr::field(
+                            Toggle::OptIn,
+                            "enable-cache",
+                            ControlFieldType::Boolean,
+                            true,
+                        ),
+                    ]),
                 ]),
-            ]),
+            },
+            fix_strategy: Some(CacheFixStrategy::SetBooleanInput {
+                field_name: "enable-cache",
+                field_value: false,
+            }),
         },
         // https://github.com/Swatinem/rust-cache/blob/master/action.yml
         ActionCoordinate::Configurable {
@@ -141,7 +184,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 true,
             ),
-        },
+        }
+        .into(),
         // https://github.com/ruby/setup-ruby/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "ruby/setup-ruby".parse().unwrap(),
@@ -151,12 +195,14 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 false,
             ),
-        },
+        }
+        .into(),
         // https://github.com/PyO3/maturin-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "PyO3/maturin-action".parse().unwrap(),
             control: ControlExpr::field(Toggle::OptIn, "sccache", ControlFieldType::Boolean, false),
-        },
+        }
+        .into(),
         // https://github.com/mlugg/setup-zig/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "mlugg/setup-zig".parse().unwrap(),
@@ -166,7 +212,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 true,
             ),
-        },
+        }
+        .into(),
         // https://github.com/oven-sh/setup-bun/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "oven-sh/setup-bun".parse().unwrap(),
@@ -176,7 +223,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 true,
             ),
-        },
+        }
+        .into(),
         // https://github.com/DeterminateSystems/magic-nix-cache-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "DeterminateSystems/magic-nix-cache-action".parse().unwrap(),
@@ -186,7 +234,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 true,
             ),
-        },
+        }
+        .into(),
         // https://github.com/graalvm/setup-graalvm/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "graalvm/setup-graalvm".parse().unwrap(),
@@ -196,7 +245,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::FreeString,
                 false,
             ),
-        },
+        }
+        .into(),
         // https://github.com/gradle/actions/blob/main/setup-gradle/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "gradle/actions/setup-gradle".parse().unwrap(),
@@ -206,7 +256,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 ControlFieldType::Boolean,
                 true,
             ),
-        },
+        }
+        .into(),
         // https://github.com/docker/setup-buildx-action/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "docker/setup-buildx-action".parse().unwrap(),
@@ -224,21 +275,24 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                     false,
                 ),
             ]),
-        },
+        }
+        .into(),
         // https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "actions-rust-lang/setup-rust-toolchain".parse().unwrap(),
             control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
-        },
+        }
+        .into(),
         // https://github.com/Mozilla-Actions/sccache-action/blob/main/action.yml
-        ActionCoordinate::NotConfigurable("Mozilla-Actions/sccache-action".parse().unwrap()),
+        ActionCoordinate::NotConfigurable("Mozilla-Actions/sccache-action".parse().unwrap()).into(),
         // https://github.com/nix-community/cache-nix-action/blob/main/action.yml
-        ActionCoordinate::NotConfigurable("nix-community/cache-nix-action".parse().unwrap()),
+        ActionCoordinate::NotConfigurable("nix-community/cache-nix-action".parse().unwrap()).into(),
         // https://github.com/jdx/mise-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "jdx/mise-action".parse().unwrap(),
             control: ControlExpr::field(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
-        },
+        }
+        .into(),
         // https://github.com/ramsey/composer-install/blob/v3/action.yml
         ActionCoordinate::Configurable {
             uses_pattern: "ramsey/composer-install".parse().unwrap(),
@@ -248,9 +302,11 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
                 field_type: ControlFieldType::Exact(&["yes", "true", "1"]),
                 satisfied_by_default: true,
             },
-        },
+        }
+        .into(),
         // https://github.com/awalsh128/cache-apt-pkgs-action/blob/master/action.yml
-        ActionCoordinate::NotConfigurable("awalsh128/cache-apt-pkgs-action".parse().unwrap()),
+        ActionCoordinate::NotConfigurable("awalsh128/cache-apt-pkgs-action".parse().unwrap())
+            .into(),
     ]
 });
 
@@ -488,26 +544,57 @@ impl CachePoisoning {
     fn evaluate_cache_usage<'doc>(
         &self,
         step: &impl StepCommon<'doc>,
-    ) -> Option<(&'static ActionCoordinate, Usage)> {
+    ) -> Option<(&'static CacheAwareAction, Usage)> {
         KNOWN_CACHE_AWARE_ACTIONS
             .iter()
-            .find_map(|coord| coord.usage(step).map(|usage| (coord, usage)))
+            .find_map(|action| action.coordinate.usage(step).map(|usage| (action, usage)))
     }
 
     fn create_cache_disable_fix<'doc>(
         &self,
-        coord: &ActionCoordinate,
+        action: &CacheAwareAction,
         step: &Step<'doc>,
     ) -> Option<Fix<'doc>> {
-        match coord {
-            ActionCoordinate::NotConfigurable(_pattern) => {
-                // For non-configurable actions, we can't provide automatic fixes
-                None
-            }
-            ActionCoordinate::Configurable {
-                uses_pattern,
-                control,
-            } => self.create_configurable_action_fix(uses_pattern, control, step),
+        match action.fix_strategy.as_ref()? {
+            CacheFixStrategy::Infer => match &action.coordinate {
+                ActionCoordinate::NotConfigurable(_pattern) => {
+                    // For non-configurable actions, we can't provide automatic fixes
+                    None
+                }
+                ActionCoordinate::Configurable {
+                    uses_pattern,
+                    control,
+                } => self.create_configurable_action_fix(uses_pattern, control, step),
+            },
+            CacheFixStrategy::SetBooleanInput {
+                field_name,
+                field_value,
+            } => Some(Self::create_input_fix(
+                step,
+                field_name,
+                yaml_serde::Value::Bool(*field_value),
+                format!("Set {field_name}: {field_value} to disable caching"),
+            )),
+        }
+    }
+
+    fn create_input_fix<'doc>(
+        step: &Step<'doc>,
+        field_name: &str,
+        field_value: yaml_serde::Value,
+        title: String,
+    ) -> Fix<'doc> {
+        Fix {
+            title,
+            key: step.location().key,
+            disposition: FixDisposition::default(),
+            patches: vec![Patch {
+                route: step.route(),
+                operation: Op::MergeInto {
+                    key: "with".to_string(),
+                    updates: IndexMap::from([(field_name.to_string(), field_value)]),
+                },
+            }],
         }
     }
 
@@ -546,18 +633,7 @@ impl CachePoisoning {
                     }
                 };
 
-                Some(Fix {
-                    title,
-                    key: step.location().key,
-                    disposition: FixDisposition::default(),
-                    patches: vec![Patch {
-                        route: step.route(),
-                        operation: Op::MergeInto {
-                            key: "with".to_string(),
-                            updates: IndexMap::from([(field_name.to_string(), field_value)]),
-                        },
-                    }],
-                })
+                Some(Self::create_input_fix(step, field_name, field_value, title))
             }
             // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
             ControlExpr::VersionBound(_)
@@ -618,9 +694,10 @@ impl CachePoisoning {
         step: &Step<'doc>,
         scenario: &PublishingScenario<'doc>,
     ) -> Result<Option<Finding<'doc>>, AuditError> {
-        let Some((coord, cache_usage)) = self.evaluate_cache_usage(step) else {
+        let Some((action, cache_usage)) = self.evaluate_cache_usage(step) else {
             return Ok(None);
         };
+        let coord = &action.coordinate;
 
         let cache_usage = if matches!(&cache_usage, Usage::Conditional(_)) {
             self.conditional_cache_usage_heuristics(coord, step, scenario, cache_usage)
@@ -752,7 +829,7 @@ impl CachePoisoning {
         finding_builder = finding_builder.add_location(step.location().hidden());
 
         // Add fix if available
-        if let Some(fix) = self.create_cache_disable_fix(coord, step) {
+        if let Some(fix) = self.create_cache_disable_fix(action, step) {
             finding_builder = finding_builder.fix(fix);
         }
 

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -589,11 +589,7 @@ impl CachePoisoning {
             } => (*field_name, *field_value),
         };
 
-        Some(Self::create_input_fix(step, field_name, field_value))
-    }
-
-    fn create_input_fix<'doc>(step: &Step<'doc>, field_name: &str, field_value: bool) -> Fix<'doc> {
-        Fix {
+        Some(Fix {
             title: format!("Set {field_name}: {field_value} to disable caching"),
             key: step.location().key,
             disposition: FixDisposition::default(),
@@ -607,7 +603,7 @@ impl CachePoisoning {
                     )]),
                 },
             }],
-        }
+        })
     }
 
     /// Apply heuristics to a [`Usage::Conditional`] to attempt to refine it into

--- a/crates/zizmor/src/audit/cache_poisoning.rs
+++ b/crates/zizmor/src/audit/cache_poisoning.rs
@@ -36,37 +36,57 @@ static REF_TYPE_TAG_PUSH_GUARD: LazyLock<Expr> = LazyLock::new(|| {
         .inner
 });
 
-enum CacheFixStrategy {
-    /// Infer a fix. At the moment, the only inferrable fixes are for [`ActionCoordinate`]s
-    /// that only have a single top-level control field.
-    Infer,
-    /// Disable caching by setting a boolean action input explicitly.
-    SetBooleanInput {
-        field_name: &'static str,
-        field_value: bool,
-    },
+/// Disable caching by setting a boolean action input explicitly.
+struct CacheFix {
+    field_name: &'static str,
+    field_value: bool,
 }
 
 struct CacheAwareAction {
     coordinate: ActionCoordinate,
-    fix_strategy: Option<CacheFixStrategy>,
+    fix: Option<CacheFix>,
 }
 
 impl From<ActionCoordinate> for CacheAwareAction {
     fn from(coordinate: ActionCoordinate) -> Self {
-        let fix_strategy = if matches!(&coordinate, ActionCoordinate::Configurable { .. }) {
-            // For now, we only consider a fix inferrable if the coordinate has a single
-            // top-level control field, i.e. is not logically qualified at all.
-            Some(CacheFixStrategy::Infer)
-        } else {
-            // No automatic fix is available for this action.
-            None
+        let fix = match &coordinate {
+            ActionCoordinate::NotConfigurable(_) => {
+                // For non-configurable actions, we can't provide automatic fixes
+                // No automatic fix is available for this action.
+                None
+            }
+            // Infer a fix. At the moment, the only inferrable fixes are for [`ActionCoordinate`]s
+            // that only have a single top-level control field.
+            ActionCoordinate::Configurable {
+                control:
+                    ControlExpr::Field {
+                        toggle,
+                        field_name,
+                        field_type: ControlFieldType::Boolean,
+                        ..
+                    },
+                ..
+            } => {
+                // For now, we only consider a fix inferrable if the coordinate has a single
+                // top-level control field, i.e. is not logically qualified at all.
+                Some(CacheFix {
+                    field_name,
+                    field_value: matches!(toggle, Toggle::OptOut),
+                })
+            }
+            ActionCoordinate::Configurable {
+                control: ControlExpr::Field { .. },
+                ..
+            } => {
+                // String control fields are action-specific and we can't reliably know
+                // what value disables caching (e.g., setup-node expects '' not 'false')
+                None
+            }
+            // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
+            ActionCoordinate::Configurable { .. } => None,
         };
 
-        Self {
-            coordinate,
-            fix_strategy,
-        }
+        Self { coordinate, fix }
     }
 }
 
@@ -173,7 +193,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<CacheAwareAction>> = LazyLock::ne
                     ]),
                 ]),
             },
-            fix_strategy: Some(CacheFixStrategy::SetBooleanInput {
+            fix: Some(CacheFix {
                 field_name: "enable-cache",
                 field_value: false,
             }),
@@ -558,39 +578,10 @@ impl CachePoisoning {
         action: &CacheAwareAction,
         step: &Step<'doc>,
     ) -> Option<Fix<'doc>> {
-        let (field_name, field_value) = match action.fix_strategy.as_ref()? {
-            CacheFixStrategy::Infer => match &action.coordinate {
-                ActionCoordinate::NotConfigurable(_) => {
-                    // For non-configurable actions, we can't provide automatic fixes
-                    return None;
-                }
-                ActionCoordinate::Configurable { control, .. } => match control {
-                    ControlExpr::Field {
-                        toggle,
-                        field_name,
-                        field_type,
-                        ..
-                    } => match (toggle, field_type) {
-                        (Toggle::OptOut, ControlFieldType::Boolean) => (*field_name, true),
-                        (Toggle::OptIn, ControlFieldType::Boolean) => (*field_name, false),
-                        // String control fields are action-specific and we can't reliably know
-                        // what value disables caching (e.g., setup-node expects '' not 'false')
-                        (Toggle::OptIn, _) | (Toggle::OptOut, _) => {
-                            return None;
-                        }
-                    },
-                    // For version bounds and complex control expressions (All/Any/Not), don't provide automatic fixes for now
-                    ControlExpr::VersionBound(_)
-                    | ControlExpr::All(_)
-                    | ControlExpr::Any(_)
-                    | ControlExpr::Not(_) => return None,
-                },
-            },
-            CacheFixStrategy::SetBooleanInput {
-                field_name,
-                field_value,
-            } => (*field_name, *field_value),
-        };
+        let CacheFix {
+            field_name,
+            field_value,
+        } = action.fix.as_ref()?;
 
         Some(Fix {
             title: format!("Set {field_name}: {field_value} to disable caching"),
@@ -602,7 +593,7 @@ impl CachePoisoning {
                     key: "with".to_string(),
                     updates: IndexMap::from([(
                         field_name.to_string(),
-                        yaml_serde::Value::Bool(field_value),
+                        yaml_serde::Value::Bool(*field_value),
                     )]),
                 },
             }],

--- a/crates/zizmor/tests/integration/audit/cache_poisoning.rs
+++ b/crates/zizmor/tests/integration/audit/cache_poisoning.rs
@@ -95,8 +95,9 @@ fn test_caching_opt_in_expression() -> anyhow::Result<()> {
        |           ---------------------------------------------------- may enable caching here
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
-    3 findings (1 ignored, 1 suppressed): 0 informational, 0 low, 0 medium, 1 high
+    3 findings (1 ignored, 1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
     ",
     );
 
@@ -439,6 +440,7 @@ fn test_issue_1081() -> anyhow::Result<()> {
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ omitting `enable-cache` enables caching for this action version
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:18:9
@@ -453,6 +455,7 @@ fn test_issue_1081() -> anyhow::Result<()> {
        |           ------------------ enables caching explicitly here
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:23:9
@@ -467,8 +470,9 @@ fn test_issue_1081() -> anyhow::Result<()> {
        |           ------------------ enables caching explicitly here
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
-    4 findings (1 suppressed): 0 informational, 0 low, 0 medium, 3 high
+    4 findings (1 suppressed, 3 unsafe fixes): 0 informational, 0 low, 0 medium, 3 high
     "
     );
 
@@ -653,6 +657,7 @@ fn test_issue_2320() -> anyhow::Result<()> {
        |           ------------------ enables caching explicitly here
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:24:9
@@ -667,6 +672,7 @@ fn test_issue_2320() -> anyhow::Result<()> {
        |           ------------------------------------------------- may enable caching here
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
     error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
       --> @@INPUT@@:29:9
@@ -678,8 +684,9 @@ fn test_issue_2320() -> anyhow::Result<()> {
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action version may enable caching
        |
        = note: audit confidence → Low
+       = note: this finding has an auto-fix
 
-    4 findings (1 ignored): 0 informational, 0 low, 0 medium, 3 high
+    4 findings (1 ignored, 3 unsafe fixes): 0 informational, 0 low, 0 medium, 3 high
     "
     );
 
@@ -885,6 +892,61 @@ jobs:
     -          cache: true
     +          cache: false
            - uses: softprops/action-gh-release@v1
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_fix_setup_uv_compound_control() -> anyhow::Result<()> {
+    let workflow_content = r#"
+name: Test Workflow
+on: release
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+      - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+        with:
+          enable-cache: true
+      - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+        with:
+          enable-cache: auto
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: ${{ github.ref == 'refs/heads/main' }}
+"#;
+
+    let workspace = WorkspaceBuilder::new().is_git_repo(true).build()?;
+    workspace.add_file(".github/workflows/cache-poisoning.yml", workflow_content);
+
+    insta::assert_snapshot!(
+        &workspace.diff(".github/workflows/cache-poisoning.yml", |workspace| {
+            zizmor()
+                .args(["--fix=all"])
+                .input(workspace.path())
+                .run()
+        })?,
+        @"
+    @@ -9,10 +9,12 @@
+           - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+    +        with:
+    +          enable-cache: false
+           - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+             with:
+    -          enable-cache: true
+    +          enable-cache: false
+           - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
+             with:
+    -          enable-cache: auto
+    +          enable-cache: false
+           - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+             with:
+    -          enable-cache: ${{ github.ref == 'refs/heads/main' }}
+    +          enable-cache: false
     "
     );
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,8 @@ of `zizmor`.
 
 * The [cache-poisoning] audit now produces more detailed and more precise diagnostics (#2330)
 
+* The [cache-poisoning] audit now handles and exposes auto-fixes in a more general manner (#2332)
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where `zizmor` would reject a `.pre-commit-config.yml`


### PR DESCRIPTION
This addresses the fix availability regression in #2330.

In principle this can be generalized even further, e.g. `CacheFix` could become an enum of different common fix 'stencils' and we could infer more than just boolean fixes. But this is fine for now.