### PR TITLE
ref-version-mismatch: support reusable workflows

### DIFF
--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use github_actions_models::common::Uses;
+use github_actions_models::common::{RepositoryUses, Uses};
 use subfeature::Subfeature;
 use yamlpatch::{Op, Patch};
 
@@ -8,12 +8,15 @@ use crate::{
     config::Config,
     finding::{
         Confidence, Finding, Fix, Persona, Severity,
-        location::{Comment, Feature, Location, Routable as _},
+        location::{Comment, Feature, Locatable, Location, Routable as _},
     },
     github,
     models::{
-        StepCommon, action::CompositeStep, uses::RepositoryUsesExt as _, version::RawVersion,
-        workflow::Step,
+        AsDocument, StepCommon,
+        action::CompositeStep,
+        uses::RepositoryUsesExt as _,
+        version::RawVersion,
+        workflow::{ReusableWorkflowCallJob, Step},
     },
 };
 
@@ -53,17 +56,16 @@ impl RefVersionMismatch {
     }
 
     /// Create a Fix for updating the version comment to match the pinned hash
-    fn update_version_comment_fix<'doc, S: StepCommon<'doc>>(
-        &self,
-        step: &S,
-        correct_tag: &str,
-    ) -> Fix<'doc> {
+    fn update_version_comment_fix<'a, 'doc, S>(&self, parent: &'a S, correct_tag: &str) -> Fix<'doc>
+    where
+        S: Locatable<'doc> + AsDocument<'a, 'doc>,
+    {
         Fix {
             title: format!("update version comment to match pinned hash: {correct_tag}"),
-            key: step.location().key,
+            key: parent.location().key,
             disposition: Default::default(),
             patches: vec![Patch {
-                route: step.route().with_key("uses"),
+                route: parent.route().with_key("uses"),
                 operation: Op::ReplaceComment {
                     new: format!("# {correct_tag}").into(),
                 },
@@ -72,13 +74,16 @@ impl RefVersionMismatch {
     }
 
     /// Create a Fix for adding a version comment where none exists
-    fn add_version_comment_fix<'doc, S: StepCommon<'doc>>(step: &S, tag: &str) -> Fix<'doc> {
+    fn add_version_comment_fix<'a, 'doc, S>(parent: &'a S, tag: &str) -> Fix<'doc>
+    where
+        S: Locatable<'doc> + AsDocument<'a, 'doc>,
+    {
         Fix {
             title: format!("add version comment: {tag}"),
-            key: step.location().key,
+            key: parent.location().key,
             disposition: Default::default(),
             patches: vec![Patch {
-                route: step.route().with_key("uses"),
+                route: parent.route().with_key("uses"),
                 operation: Op::EmplaceComment {
                     new: format!("# {tag}").into(),
                 },
@@ -86,25 +91,23 @@ impl RefVersionMismatch {
         }
     }
 
-    async fn audit_step_common<'doc, S: StepCommon<'doc>>(
+    async fn process_uses<'a, 'doc, S>(
         &self,
-        step: &S,
-    ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        let mut findings = vec![];
-
-        let Some(Uses::Repository(uses)) = step.uses() else {
-            return Ok(findings);
-        };
-
+        uses: &'doc RepositoryUses,
+        parent: &'a S,
+    ) -> Result<Option<Finding<'doc>>, AuditError>
+    where
+        S: Locatable<'doc> + AsDocument<'a, 'doc>,
+    {
         // Only check steps that have commit refs (not symbolic refs like v1.0.0)
         let Some(commit_sha) = uses.commit_ref() else {
-            return Ok(findings);
+            return Ok(None);
         };
 
-        let step_location = step.location();
-        let uses_location = step_location
+        let parent_location = parent.location();
+        let uses_location = parent_location
             .with_keys(["uses".into()])
-            .concretize(step.document())
+            .concretize(parent.as_document())
             .map_err(Self::err)?;
 
         let comment_version_state = Self::comment_version_state(&uses_location.concrete.comments);
@@ -119,7 +122,7 @@ impl RefVersionMismatch {
                     .await
                     .map_err(Self::err)?
                 else {
-                    return Ok(findings);
+                    return Ok(None);
                 };
 
                 let (annotation, tip) = match comment_version_state {
@@ -138,16 +141,16 @@ impl RefVersionMismatch {
                     .severity(Severity::Low)
                     .confidence(Confidence::High)
                     .persona(Persona::Pedantic)
-                    .add_location(step_location.hidden())
+                    .add_location(parent_location.hidden())
                     .add_location(uses_location.symbolic.primary().annotated(annotation))
                     .tip(tip);
 
                 if matches!(comment_version_state, CommentVersionState::Missing) {
-                    builder = builder.fix(Self::add_version_comment_fix(step, &tag.name));
+                    builder = builder.fix(Self::add_version_comment_fix(parent, &tag.name));
                 }
 
-                findings.push(builder.build(step).map_err(Self::err)?);
-                return Ok(findings);
+                // findings.push(builder.build(step).map_err(Self::err)?);
+                return Ok(Some(builder.build(parent).map_err(Self::err)?));
             }
         };
 
@@ -159,7 +162,7 @@ impl RefVersionMismatch {
 
         // If the ref matches, there's nothing to do.
         if git_ref.as_ref().map(|r| r.commit()) == Some(commit_sha) {
-            return Ok(findings);
+            return Ok(None);
         }
 
         let subfeature = Subfeature::new(
@@ -174,7 +177,7 @@ impl RefVersionMismatch {
                     kind = commit_for_ref.kind(),
                     short_commit = &commit_for_ref.commit()[..12]
                 )),
-                Feature::from_subfeature(&subfeature, step),
+                Feature::from_subfeature(&subfeature, parent),
             ),
             None => Location::new(
                 uses_location
@@ -182,7 +185,7 @@ impl RefVersionMismatch {
                     .clone()
                     .primary()
                     .annotated("points to unknown ref"),
-                Feature::from_subfeature(&subfeature, step),
+                Feature::from_subfeature(&subfeature, parent),
             ),
         };
 
@@ -197,17 +200,27 @@ impl RefVersionMismatch {
             .await
             .map_err(Self::err)?
         {
-            builder = builder.add_location(step_location.hidden()).add_location(
+            builder = builder.add_location(parent_location.hidden()).add_location(
                 uses_location
                     .symbolic
                     .annotated(format!("is pointed to by tag {tag}", tag = suggestion.name)),
             );
             // Add auto-fix to update the version comment to match the pinned hash
-            builder = builder.fix(self.update_version_comment_fix(step, &suggestion.name));
+            builder = builder.fix(self.update_version_comment_fix(parent, &suggestion.name));
         }
-        findings.push(builder.build(step).map_err(Self::err)?);
 
-        Ok(findings)
+        Ok(Some(builder.build(parent).map_err(Self::err)?))
+    }
+
+    async fn process_step<'doc, S: StepCommon<'doc>>(
+        &self,
+        step: &S,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let Some(Uses::Repository(uses)) = step.uses() else {
+            return Ok(vec![]);
+        };
+
+        Ok(self.process_uses(uses, step).await?.into_iter().collect())
     }
 }
 
@@ -232,7 +245,7 @@ impl Audit for RefVersionMismatch {
         step: &Step<'doc>,
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        self.audit_step_common(step).await
+        self.process_step(step).await
     }
 
     async fn audit_composite_step<'doc>(
@@ -240,16 +253,26 @@ impl Audit for RefVersionMismatch {
         step: &CompositeStep<'doc>,
         _config: &Config,
     ) -> Result<Vec<Finding<'doc>>, AuditError> {
-        self.audit_step_common(step).await
+        self.process_step(step).await
+    }
+
+    async fn audit_reusable_job<'doc>(
+        &self,
+        job: &ReusableWorkflowCallJob<'doc>,
+        _config: &Config,
+    ) -> Result<Vec<Finding<'doc>>, AuditError> {
+        let Uses::Repository(uses) = &job.uses else {
+            return Ok(vec![]);
+        };
+
+        Ok(self.process_uses(uses, job).await?.into_iter().collect())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        finding::location::Locatable as _, models::action::Action, registry::input::InputKey,
-    };
+    use crate::{models::action::Action, registry::input::InputKey};
 
     #[test]
     fn test_comment_version_state_with_unrelated_comment() {

--- a/crates/zizmor/src/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/src/audit/ref_version_mismatch.rs
@@ -142,7 +142,13 @@ impl RefVersionMismatch {
                     .confidence(Confidence::High)
                     .persona(Persona::Pedantic)
                     .add_location(parent_location.hidden())
-                    .add_location(uses_location.symbolic.primary().annotated(annotation))
+                    .add_location(
+                        uses_location
+                            .symbolic
+                            .primary()
+                            .subfeature(Subfeature::new(0, uses.raw()))
+                            .annotated(annotation),
+                    )
                     .tip(tip);
 
                 if matches!(comment_version_state, CommentVersionState::Missing) {
@@ -203,6 +209,7 @@ impl RefVersionMismatch {
             builder = builder.add_location(parent_location.hidden()).add_location(
                 uses_location
                     .symbolic
+                    .subfeature(Subfeature::new(0, uses.raw()))
                     .annotated(format!("is pointed to by tag {tag}", tag = suggestion.name)),
             );
             // Add auto-fix to update the version comment to match the pinned hash

--- a/crates/zizmor/tests/integration/audit/ref_version_mismatch.rs
+++ b/crates/zizmor/tests/integration/audit/ref_version_mismatch.rs
@@ -26,9 +26,9 @@ fn test_ref_version_mismatch() -> Result<()> {
       --> @@INPUT@@:25:77
        |
     25 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.1
-       |         -----------------------------------------------------------------   ^^^^^^ tag points to commit 5e21ff4d9bc1
-       |         |
-       |         is pointed to by tag v3.8.2
+       |               -----------------------------------------------------------   ^^^^^^ tag points to commit 5e21ff4d9bc1
+       |               |
+       |               is pointed to by tag v3.8.2
        |
        = note: audit confidence → High
        = note: this finding has an auto-fix
@@ -37,9 +37,9 @@ fn test_ref_version_mismatch() -> Result<()> {
       --> @@INPUT@@:28:77
        |
     28 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v300000.8.1
-       |         -----------------------------------------------------------------   ^^^^^^^^^^^ points to unknown ref
-       |         |
-       |         is pointed to by tag v3.8.2
+       |               -----------------------------------------------------------   ^^^^^^^^^^^ points to unknown ref
+       |               |
+       |               is pointed to by tag v3.8.2
        |
        = note: audit confidence → High
        = note: this finding has an auto-fix
@@ -72,20 +72,20 @@ fn test_missing_version_comment_pedantic() -> Result<()> {
        = note: this finding has an auto-fix
 
     help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-      --> @@INPUT@@:16:9
+      --> @@INPUT@@:16:15
        |
     16 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
        |
        = note: audit confidence → High
        = tip: add version comment '# v3.8.2'
        = note: this finding has an auto-fix
 
     help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-      --> @@INPUT@@:19:9
+      --> @@INPUT@@:19:15
        |
     19 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # some comment
-       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment does not contain a version
+       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment does not contain a version
        |
        = note: audit confidence → High
        = tip: rewrite comment to include '# v3.8.2'
@@ -94,9 +94,9 @@ fn test_missing_version_comment_pedantic() -> Result<()> {
       --> @@INPUT@@:25:77
        |
     25 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.1
-       |         -----------------------------------------------------------------   ^^^^^^ tag points to commit 5e21ff4d9bc1
-       |         |
-       |         is pointed to by tag v3.8.2
+       |               -----------------------------------------------------------   ^^^^^^ tag points to commit 5e21ff4d9bc1
+       |               |
+       |               is pointed to by tag v3.8.2
        |
        = note: audit confidence → High
        = note: this finding has an auto-fix
@@ -105,9 +105,9 @@ fn test_missing_version_comment_pedantic() -> Result<()> {
       --> @@INPUT@@:28:77
        |
     28 |       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v300000.8.1
-       |         -----------------------------------------------------------------   ^^^^^^^^^^^ points to unknown ref
-       |         |
-       |         is pointed to by tag v3.8.2
+       |               -----------------------------------------------------------   ^^^^^^^^^^^ points to unknown ref
+       |               |
+       |               is pointed to by tag v3.8.2
        |
        = note: audit confidence → High
        = note: this finding has an auto-fix
@@ -160,9 +160,9 @@ fn test_issue_1853() -> Result<()> {
       --> @@INPUT@@:14:75
        |
     14 |         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v9.9.9
-       |         ---------------------------------------------------------------   ^^^^^^ points to unknown ref
-       |         |
-       |         is pointed to by tag v6.4.0
+       |               ---------------------------------------------------------   ^^^^^^ points to unknown ref
+       |               |
+       |               is pointed to by tag v6.4.0
        |
        = note: audit confidence → High
        = note: this finding has an auto-fix
@@ -264,14 +264,44 @@ fn test_issue_2321() -> Result<()> {
       --> @@INPUT@@:14:87
        |
     14 |         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
-       |         ---------------------------------------------------------------------------   ^^ branch points to commit 4d27395796ac
-       |         |
-       |         is pointed to by tag v1
+       |               ---------------------------------------------------------------------   ^^ branch points to commit 4d27395796ac
+       |               |
+       |               is pointed to by tag v1
        |
        = note: audit confidence → High
        = note: this finding has an auto-fix
 
     2 findings (1 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
+    "
+    );
+
+    Ok(())
+}
+
+/// Bug #2324: ref-version-mismatch should support reusable workflow calls.
+///
+/// See: <https://github.com/zizmorcore/zizmor/issues/2324>
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
+fn test_issue_2324() -> Result<()> {
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(NetworkMode::AssertOnline)
+            .input(input_under_test("ref-version-mismatch/issue-2324-repro.yml"))
+            .run()?,
+        @"
+    warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
+      --> @@INPUT@@:11:104
+       |
+    11 |     uses: docker/github-builder/.github/workflows/build.yml@58cb9f5b71b1836d6f690c1e95effdeb9b98cb8a # v1.16.0
+       |           ------------------------------------------------------------------------------------------   ^^^^^^^ tag points to commit a492c6d04fd3
+       |           |
+       |           is pointed to by tag v1.17.0
+       |
+       = note: audit confidence → High
+       = note: this finding has an auto-fix
+
+    1 findings (1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
     "
     );
 
@@ -585,6 +615,47 @@ jobs:
            - name: Setup Go
     -        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v9.9.9
     +        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+    "
+    );
+
+    Ok(())
+}
+
+#[cfg(feature = "gh-token-tests")]
+#[test]
+fn test_fix_reusable_workflow() -> anyhow::Result<()> {
+    use crate::common::WorkspaceBuilder;
+
+    let workflow_content = r#"
+name: reusable
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  job1:
+    name: job1
+    uses: docker/github-builder/.github/workflows/build.yml@58cb9f5b71b1836d6f690c1e95effdeb9b98cb8a # v1.16.0
+"#;
+
+    let workspace = WorkspaceBuilder::new().is_git_repo(true).build()?;
+    workspace.add_file(".github/workflows/test.yml", &workflow_content);
+
+    insta::assert_snapshot!(
+        &workspace.diff(".github/workflows/test.yml", |workspace| {
+            zizmor()
+                .args(["--fix=all", "--persona=pedantic"])
+                .offline(NetworkMode::AssertOnline)
+                .input(workspace.path())
+                .run()
+        })?,
+        @"
+    @@ -11,2 +11,2 @@
+         name: job1
+    -    uses: docker/github-builder/.github/workflows/build.yml@58cb9f5b71b1836d6f690c1e95effdeb9b98cb8a # v1.16.0
+    +    uses: docker/github-builder/.github/workflows/build.yml@58cb9f5b71b1836d6f690c1e95effdeb9b98cb8a # v1.17.0
     "
     );
 

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__astral_sh_uv.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__astral_sh_uv.snap
@@ -112,20 +112,20 @@ help[template-injection]: code injection via template expansion
     = note: audit confidence → High
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/build-docker.yml:116:9
+   --> .github/workflows/build-docker.yml:116:15
     |
 116 |       - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v1.6.0'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/build-docker.yml:245:9
+   --> .github/workflows/build-docker.yml:245:15
     |
 245 |       - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v1.6.0'
@@ -763,10 +763,10 @@ info[anonymous-definition]: workflow or action definition without a name
    = tip: use 'name: ...' to give this job a name
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-  --> .github/workflows/publish-mirror.yml:24:9
+  --> .github/workflows/publish-mirror.yml:24:15
    |
 24 |         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
    |
    = note: audit confidence → High
    = tip: add version comment '# v4.3.0'
@@ -1044,100 +1044,100 @@ info[anonymous-definition]: workflow or action definition without a name
     = tip: use 'name: ...' to give this job a name
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-  --> .github/workflows/release.yml:62:9
+  --> .github/workflows/release.yml:62:15
    |
 62 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
    |
    = note: audit confidence → High
    = tip: add version comment '# v4.2.2'
    = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:127:9
+   --> .github/workflows/release.yml:127:15
     |
 127 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.2.2'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:132:9
+   --> .github/workflows/release.yml:132:15
     |
 132 |         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.3.0'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:139:9
+   --> .github/workflows/release.yml:139:15
     |
 139 |         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.3.0'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:178:9
+   --> .github/workflows/release.yml:178:15
     |
 178 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.2.2'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:183:9
+   --> .github/workflows/release.yml:183:15
     |
 183 |         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.3.0'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:190:9
+   --> .github/workflows/release.yml:190:15
     |
 190 |         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.3.0'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:257:9
+   --> .github/workflows/release.yml:257:15
     |
 257 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.2.2'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:263:9
+   --> .github/workflows/release.yml:263:15
     |
 263 |         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v4.3.0'
     = note: this finding has an auto-fix
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/release.yml:273:9
+   --> .github/workflows/release.yml:273:15
     |
 273 |         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v3.1.0'
@@ -1375,10 +1375,10 @@ help[anonymous-definition]: workflow or action definition without a name
      = tip: use 'name: ...' to give this workflow a name
 
 help[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
-   --> .github/workflows/test-integration.yml:852:9
+   --> .github/workflows/test-integration.yml:852:16
     |
 852 |         uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db"
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing version comment
     |
     = note: audit confidence → High
     = tip: add version comment '# v3.0.1'

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__curl.snap
@@ -75,9 +75,9 @@ warning[ref-version-mismatch]: action's hash pin has mismatched or missing versi
   --> .github/workflows/windows.yml:57:87
    |
 57 |       - uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # v6
-   |         ---------------------------------------------------------------------------   ^^ tag points to commit 3f0a3f9f988f
-   |         |
-   |         is pointed to by tag v6.0.0
+   |               ---------------------------------------------------------------------   ^^ tag points to commit 3f0a3f9f988f
+   |               |
+   |               is pointed to by tag v6.0.0
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__libssh2.snap
+++ b/crates/zizmor/tests/integration/e2e/snapshots/integration__e2e__crater__libssh2.snap
@@ -15,9 +15,9 @@ warning[ref-version-mismatch]: action's hash pin has mismatched or missing versi
    --> .github/workflows/ci.yml:658:87
     |
 658 |       - uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # v6
-    |         ---------------------------------------------------------------------------   ^^ tag points to commit 3f0a3f9f988f
-    |         |
-    |         is pointed to by tag v6.0.0
+    |               ---------------------------------------------------------------------   ^^ tag points to commit 3f0a3f9f988f
+    |               |
+    |               is pointed to by tag v6.0.0
     |
     = note: audit confidence → High
     = note: this finding has an auto-fix

--- a/crates/zizmor/tests/integration/test-data/ref-version-mismatch/issue-2324-repro.yml
+++ b/crates/zizmor/tests/integration/test-data/ref-version-mismatch/issue-2324-repro.yml
@@ -1,0 +1,11 @@
+name: ISSUE-2324-REPRO
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  job1:
+    name: job1
+    uses: docker/github-builder/.github/workflows/build.yml@58cb9f5b71b1836d6f690c1e95effdeb9b98cb8a # v1.16.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -38,13 +38,16 @@ of `zizmor`.
 
     Many thanks to @njgudman for proposing and implementing this enhancement!
 
-* The [unpinned-tools] audit now produced more detailed and more precise diagnostics (#2339)
+* The [unpinned-tools] audit now produces more detailed and more precise diagnostics (#2339)
 
 * The [unpinned-tools] audit now detects usages of @extractions/setup-just (#2339)
 
 * The [unpinned-tools] audit now detects usages of @extractions/setup-crate (#2340)
 
 * The [archived-uses] audit now detects several more archived repositories (#2340)
+
+* The [ref-version-mismatch] audit now supports `#!yaml uses:` that reference
+  reusable workflows (#2344)
 
 ### Bug Fixes 🐛
 


### PR DESCRIPTION
~~WIP.~~ 

This basically does the same trick as `unpinned-uses`.

Part of #2324.