### PR TITLE
docs: Add instructions for Sublime Text

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -270,6 +270,28 @@ vim.lsp.enable('zizmor')
 
 For more information about LSP configuration in neovim, see `:h lspconfig-all`.
 
+### Sublime Text
+
+Support for `zizmor` in Sublime Text is provided via the
+[LSP](https://lsp.sublimetext.io/) package. As with Visual
+Studio Code, you must install `zizmor` [separately](./installation.md) for the
+LSP server to work. 
+
+Install [LSP](https://packages.sublimetext.com/packages/LSP)
+and [YamlPipelines](https://packages.sublimetext.com/packages/YamlPipelines)
+packages using Package Control. Then, enable `zizmor` LSP by adding the following
+configuration in `Preferences > Package Settings > LSP > Server Configurations`:
+
+```json
+{
+    "zizmor": {
+        "enabled": true,
+        "command": ["zizmor", "--lsp"],
+        "selector": "source.yaml.pipeline.github-actions"
+    }
+}
+```
+
 ### Generic LSP integration
 
 `zizmor` can be integrated with any editor or IDE that supports LSP.


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first). — ehh, kinda #986?

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

This adds instructions to the documentation on how to enable `zizmor` support (via LSP) in Sublime Text. Here's what it looks like:

<img width="542" height="130" alt="image" src="https://github.com/user-attachments/assets/dbdb7837-e4c4-4866-8ecc-782be8f8866b" />

### Manual test

1. Install Sublime Text (free trial works)
2. [Install Package Control](https://packages.sublimetext.com/installation)
3. Install packages [LSP](https://packages.sublimetext.com/packages/LSP) and [YamlPipelines](https://packages.sublimetext.com/packages/YamlPipelines)
4. Open Server Configurations settings via "Preferences > Package Settings > LSP > Server Configurations" from the menu or with the Preferences: LSP Server Configurations entry from the Command Palette.
5. Paste the snippet from the docs


<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
