### PR TITLE
Handle .git URLs correctly

### DIFF
--- a/crates/zizmor/src/models/repo_ref.rs
+++ b/crates/zizmor/src/models/repo_ref.rs
@@ -86,7 +86,14 @@ impl<'doc> RepoRef<'doc> {
         let slug = if url.host_str() == Some("github.com") {
             // We expect `https://github.com/owner/repo`, but
             // the user can naturally feed us nonsense.
-            let path = url.path();
+            //
+            // Bug #2358: a Git URL can have a `.git` suffix,
+            // e.g. `https://github.com/pre-commit/pre-commit-hooks.git`.
+            // We need to strip that from the path (which also removes
+            // it from the repo component of the slug).
+            //
+            // See: <https://github.com/zizmorcore/zizmor/issues/2358>
+            let path = url.path().strip_suffix(".git").unwrap_or(url.path());
             let mut parts = path.split('/');
 
             // We expect an empty component first, since `path()`
@@ -253,6 +260,36 @@ mod tests {
                     owner: "foo",
                     repo: "bar",
                     slug: "foo/bar",
+                },
+            ),
+            git_ref: "v1",
+        }
+        "#);
+
+        // GitHub URL with `.git` suffix also works correctly with slug detection.
+        let url = Url::parse("https://github.com/pre-commit/pre-commit-hooks.git").unwrap();
+        insta::assert_debug_snapshot!(RepoRef::from_url(&url, "v1"), @r#"
+        Url {
+            _url: Url {
+                scheme: "https",
+                cannot_be_a_base: false,
+                username: "",
+                password: None,
+                host: Some(
+                    Domain(
+                        "github.com",
+                    ),
+                ),
+                port: None,
+                path: "/pre-commit/pre-commit-hooks.git",
+                query: None,
+                fragment: None,
+            },
+            slug: Some(
+                Slug {
+                    owner: "pre-commit",
+                    repo: "pre-commit-hooks",
+                    slug: "pre-commit/pre-commit-hooks",
                 },
             ),
             git_ref: "v1",

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where `zizmor` would crash on pre-commit inputs that reference
+  a GitHub URL with an explicit `.git` suffix (#2363)
+
 ## 1.30.0
 
 ### New Features 🌈


### PR DESCRIPTION
This was an oversight in the original "extract a slug from a GitHub URL" logic -- we should strip a `.git` prefix from the "slug" part of the part, since it's just a way to explicitly signal that the URL is for a Git repository.

Failing to do this meant that we'd end up passing `foo/bar.git` rather than `foo/bar` into various GitHub APIs, which of course would then fail.

Fixes #2358.